### PR TITLE
Implement recursive pruning proofs and reputation system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod crypto;
 pub mod errors;
 pub mod ledger;
 pub mod node;
+pub mod reputation;
 pub mod storage;
 pub mod types;

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -1,0 +1,211 @@
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use stwo::core::vcs::blake2_hash::Blake2sHasher;
+
+/// Configuration weights used to evaluate the reputation score. The values
+/// mirror the blueprint defaults but can be tuned through governance.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReputationWeights {
+    pub w_v: f64,
+    pub w_u: f64,
+    pub w_c: f64,
+    pub w_p: f64,
+    pub w_d: f64,
+}
+
+impl Default for ReputationWeights {
+    fn default() -> Self {
+        Self {
+            w_v: 0.4,
+            w_u: 0.2,
+            w_c: 0.2,
+            w_p: 0.15,
+            w_d: 0.05,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Tier {
+    Tl0,
+    Tl1,
+    Tl2,
+    Tl3,
+    Tl4,
+    Tl5,
+}
+
+impl Tier {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Tier::Tl0 => "New",
+            Tier::Tl1 => "Validated",
+            Tier::Tl2 => "Available",
+            Tier::Tl3 => "Committed",
+            Tier::Tl4 => "Reliable",
+            Tier::Tl5 => "Trusted",
+        }
+    }
+
+    pub fn requirements(&self) -> &'static str {
+        match self {
+            Tier::Tl0 => "ZSI noch nicht validiert",
+            Tier::Tl1 => "ZSI validiert",
+            Tier::Tl2 => "+24h Uptime",
+            Tier::Tl3 => "Konsens-Runden ohne Fehlverhalten",
+            Tier::Tl4 => "Langfristige Uptime + Konsens",
+            Tier::Tl5 => "Langzeit-Historie, hoher Score",
+        }
+    }
+}
+
+impl fmt::Display for Tier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl Default for Tier {
+    fn default() -> Self {
+        Tier::Tl0
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZsiIdentity {
+    pub public_key_commitment: String,
+    pub validated: bool,
+    pub reputation_proof: Option<String>,
+}
+
+impl ZsiIdentity {
+    pub fn new(public_key_hint: &str) -> Self {
+        let commitment = Blake2sHasher::hash(public_key_hint.as_bytes());
+        Self {
+            public_key_commitment: hex::encode::<[u8; 32]>(commitment.into()),
+            validated: false,
+            reputation_proof: None,
+        }
+    }
+
+    pub fn validate(&mut self, proof: &str) {
+        self.validated = true;
+        self.reputation_proof = Some(proof.to_string());
+    }
+
+    pub fn invalidate(&mut self) {
+        self.validated = false;
+        self.reputation_proof = None;
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct TimetokeBalance {
+    pub hours_online: u64,
+    pub last_proof_timestamp: u64,
+}
+
+impl TimetokeBalance {
+    pub fn record_proof(&mut self, timestamp: u64) {
+        if timestamp > self.last_proof_timestamp {
+            self.hours_online = self.hours_online.saturating_add(1);
+            self.last_proof_timestamp = timestamp;
+        }
+    }
+}
+
+pub fn current_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReputationProfile {
+    pub zsi: ZsiIdentity,
+    pub timetokes: TimetokeBalance,
+    pub consensus_success: u64,
+    pub peer_feedback: i64,
+    pub last_decay_timestamp: u64,
+    pub score: f64,
+    pub tier: Tier,
+}
+
+impl ReputationProfile {
+    pub fn new(identity_hint: &str) -> Self {
+        Self {
+            zsi: ZsiIdentity::new(identity_hint),
+            timetokes: TimetokeBalance::default(),
+            consensus_success: 0,
+            peer_feedback: 0,
+            last_decay_timestamp: current_timestamp(),
+            score: 0.0,
+            tier: Tier::default(),
+        }
+    }
+
+    pub fn record_online_proof(&mut self, timestamp: u64) {
+        self.timetokes.record_proof(timestamp);
+    }
+
+    pub fn record_consensus_success(&mut self) {
+        self.consensus_success = self.consensus_success.saturating_add(1);
+    }
+
+    pub fn apply_peer_feedback(&mut self, delta: i64) {
+        self.peer_feedback = self.peer_feedback.saturating_add(delta);
+    }
+
+    pub fn update_decay_reference(&mut self, timestamp: u64) {
+        self.last_decay_timestamp = timestamp;
+    }
+
+    fn saturating_curve(value: f64, scale: f64) -> f64 {
+        if scale <= 0.0 {
+            return 0.0;
+        }
+        1.0 - (-value / scale).exp()
+    }
+
+    fn decay_penalty(&self, now: u64) -> f64 {
+        let elapsed = now.saturating_sub(self.last_decay_timestamp);
+        Self::saturating_curve(elapsed as f64, 86_400.0 * 7.0)
+    }
+
+    pub fn recompute_score(&mut self, weights: &ReputationWeights, now: u64) {
+        let v = if self.zsi.validated { 1.0 } else { 0.0 };
+        let u = Self::saturating_curve(self.timetokes.hours_online as f64, 24.0);
+        let c = Self::saturating_curve(self.consensus_success as f64, 128.0);
+        let p = Self::saturating_curve(self.peer_feedback.max(0) as f64, 50.0);
+        let decay = self.decay_penalty(now);
+        self.score = weights.w_v * v + weights.w_u * u + weights.w_c * c + weights.w_p * p
+            - weights.w_d * decay;
+        self.score = self.score.clamp(0.0, 1.0);
+        self.update_tier();
+    }
+
+    fn update_tier(&mut self) {
+        self.tier = if !self.zsi.validated {
+            Tier::Tl0
+        } else if self.timetokes.hours_online < 24 {
+            Tier::Tl1
+        } else if self.consensus_success < 10 {
+            Tier::Tl2
+        } else if self.consensus_success < 100 {
+            Tier::Tl3
+        } else if self.score < 0.75 {
+            Tier::Tl4
+        } else {
+            Tier::Tl5
+        };
+    }
+}
+
+impl Default for ReputationProfile {
+    fn default() -> Self {
+        Self::new("default-reputation")
+    }
+}

--- a/src/types/account.rs
+++ b/src/types/account.rs
@@ -5,6 +5,8 @@ use std::str::FromStr;
 use malachite::Natural;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::reputation::ReputationProfile;
+
 use super::Address;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -97,15 +99,18 @@ pub struct Account {
     pub balance: u128,
     pub nonce: u64,
     pub stake: Stake,
+    pub reputation: ReputationProfile,
 }
 
 impl Account {
     pub fn new(address: Address, balance: u128, stake: Stake) -> Self {
+        let reputation = ReputationProfile::new(address.as_str());
         Self {
             address,
             balance,
             nonce: 0,
             stake,
+            reputation,
         }
     }
 

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -5,9 +5,13 @@ use serde::{Deserialize, Serialize};
 use stwo::core::vcs::blake2_hash::Blake2sHasher;
 
 use crate::crypto::{signature_from_hex, signature_to_hex, verify_signature};
-use crate::errors::ChainResult;
+use crate::errors::{ChainError, ChainResult};
+use crate::ledger::compute_merkle_root;
 
 use super::{Address, SignedTransaction};
+
+const PRUNING_WITNESS_DOMAIN: &[u8] = b"rpp-pruning-proof";
+const RECURSIVE_ANCHOR_SEED: &[u8] = b"rpp-recursive-anchor";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BlockHeader {
@@ -57,9 +61,266 @@ impl BlockHeader {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ProofSystem {
+    Stwo,
+    Plonky3,
+}
+
+impl Default for ProofSystem {
+    fn default() -> Self {
+        ProofSystem::Stwo
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PruningProof {
+    pub pruned_height: u64,
+    pub previous_block_hash: String,
+    pub previous_state_root: String,
+    pub pruned_tx_root: String,
+    pub resulting_state_root: String,
+    pub witness_commitment: String,
+}
+
+impl PruningProof {
+    fn witness(
+        pruned_height: u64,
+        previous_block_hash: &str,
+        previous_state_root: &str,
+        pruned_tx_root: &str,
+        resulting_state_root: &str,
+    ) -> String {
+        let mut data = Vec::new();
+        data.extend_from_slice(PRUNING_WITNESS_DOMAIN);
+        data.extend_from_slice(&pruned_height.to_be_bytes());
+        data.extend_from_slice(previous_block_hash.as_bytes());
+        data.extend_from_slice(previous_state_root.as_bytes());
+        data.extend_from_slice(pruned_tx_root.as_bytes());
+        data.extend_from_slice(resulting_state_root.as_bytes());
+        hex::encode::<[u8; 32]>(Blake2sHasher::hash(&data).into())
+    }
+
+    pub fn new(
+        pruned_height: u64,
+        previous_block_hash: String,
+        previous_state_root: String,
+        pruned_tx_root: String,
+        resulting_state_root: String,
+    ) -> Self {
+        let witness_commitment = Self::witness(
+            pruned_height,
+            &previous_block_hash,
+            &previous_state_root,
+            &pruned_tx_root,
+            &resulting_state_root,
+        );
+        Self {
+            pruned_height,
+            previous_block_hash,
+            previous_state_root,
+            pruned_tx_root,
+            resulting_state_root,
+            witness_commitment,
+        }
+    }
+
+    pub fn genesis(state_root: &str) -> Self {
+        Self::new(
+            0,
+            hex::encode([0u8; 32]),
+            state_root.to_string(),
+            hex::encode([0u8; 32]),
+            state_root.to_string(),
+        )
+    }
+
+    pub fn from_previous(previous: Option<&Block>, current_header: &BlockHeader) -> Self {
+        match previous {
+            Some(block) => Self::new(
+                block.header.height,
+                block.hash.clone(),
+                block.header.state_root.clone(),
+                block.header.tx_root.clone(),
+                current_header.state_root.clone(),
+            ),
+            None => Self::genesis(&current_header.state_root),
+        }
+    }
+
+    pub fn verify(
+        &self,
+        previous: Option<&Block>,
+        current_header: &BlockHeader,
+    ) -> ChainResult<()> {
+        if self.resulting_state_root != current_header.state_root {
+            return Err(ChainError::Crypto(
+                "pruning proof state root mismatch".into(),
+            ));
+        }
+        if current_header.height == 0 {
+            if self.pruned_height != 0 {
+                return Err(ChainError::Crypto(
+                    "genesis pruning proof references non-zero height".into(),
+                ));
+            }
+        } else if current_header.height != self.pruned_height.saturating_add(1) {
+            return Err(ChainError::Crypto("pruning proof height mismatch".into()));
+        }
+        if self.previous_block_hash != current_header.previous_hash {
+            return Err(ChainError::Crypto(
+                "pruning proof previous hash does not match header".into(),
+            ));
+        }
+        if self.witness_commitment
+            != Self::witness(
+                self.pruned_height,
+                &self.previous_block_hash,
+                &self.previous_state_root,
+                &self.pruned_tx_root,
+                &self.resulting_state_root,
+            )
+        {
+            return Err(ChainError::Crypto(
+                "pruning proof commitment invalid".into(),
+            ));
+        }
+        if let Some(previous_block) = previous {
+            if previous_block.header.height != self.pruned_height {
+                return Err(ChainError::Crypto(
+                    "pruning proof references incorrect block height".into(),
+                ));
+            }
+            if previous_block.hash != self.previous_block_hash {
+                return Err(ChainError::Crypto(
+                    "pruning proof references incorrect block hash".into(),
+                ));
+            }
+            if previous_block.header.state_root != self.previous_state_root {
+                return Err(ChainError::Crypto(
+                    "pruning proof previous state root mismatch".into(),
+                ));
+            }
+            if previous_block.header.tx_root != self.pruned_tx_root {
+                return Err(ChainError::Crypto(
+                    "pruning proof transaction commitment mismatch".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecursiveProof {
+    pub system: ProofSystem,
+    pub proof_commitment: String,
+    pub previous_proof_commitment: String,
+    pub previous_chain_commitment: String,
+    pub chain_commitment: String,
+}
+
+impl RecursiveProof {
+    pub fn anchor() -> String {
+        hex::encode::<[u8; 32]>(Blake2sHasher::hash(RECURSIVE_ANCHOR_SEED).into())
+    }
+
+    fn fold_chain(previous_chain: &str, header: &BlockHeader, pruning: &PruningProof) -> String {
+        let mut data = Vec::new();
+        data.extend_from_slice(previous_chain.as_bytes());
+        data.extend_from_slice(&header.hash());
+        data.extend_from_slice(pruning.witness_commitment.as_bytes());
+        data.extend_from_slice(header.state_root.as_bytes());
+        hex::encode::<[u8; 32]>(Blake2sHasher::hash(&data).into())
+    }
+
+    fn fold_proof(chain_commitment: &str, previous_proof: &str) -> String {
+        let mut data = Vec::new();
+        data.extend_from_slice(chain_commitment.as_bytes());
+        data.extend_from_slice(previous_proof.as_bytes());
+        hex::encode::<[u8; 32]>(Blake2sHasher::hash(&data).into())
+    }
+
+    pub fn genesis(header: &BlockHeader, pruning: &PruningProof) -> Self {
+        let anchor = Self::anchor();
+        let chain_commitment = Self::fold_chain(&anchor, header, pruning);
+        let proof_commitment = Self::fold_proof(&chain_commitment, &anchor);
+        Self {
+            system: ProofSystem::default(),
+            proof_commitment,
+            previous_proof_commitment: anchor.clone(),
+            previous_chain_commitment: anchor,
+            chain_commitment,
+        }
+    }
+
+    pub fn extend(previous: &RecursiveProof, header: &BlockHeader, pruning: &PruningProof) -> Self {
+        let chain_commitment = Self::fold_chain(&previous.chain_commitment, header, pruning);
+        let proof_commitment = Self::fold_proof(&chain_commitment, &previous.proof_commitment);
+        Self {
+            system: previous.system.clone(),
+            proof_commitment,
+            previous_proof_commitment: previous.proof_commitment.clone(),
+            previous_chain_commitment: previous.chain_commitment.clone(),
+            chain_commitment,
+        }
+    }
+
+    pub fn verify(
+        &self,
+        header: &BlockHeader,
+        pruning: &PruningProof,
+        previous: Option<&RecursiveProof>,
+    ) -> ChainResult<()> {
+        if header.height == 0 {
+            let anchor = Self::anchor();
+            if self.previous_chain_commitment != anchor || self.previous_proof_commitment != anchor
+            {
+                return Err(ChainError::Crypto("recursive proof anchor mismatch".into()));
+            }
+        }
+
+        if let Some(previous_proof) = previous {
+            if self.previous_chain_commitment != previous_proof.chain_commitment {
+                return Err(ChainError::Crypto(
+                    "recursive proof does not link to previous chain commitment".into(),
+                ));
+            }
+            if self.previous_proof_commitment != previous_proof.proof_commitment {
+                return Err(ChainError::Crypto(
+                    "recursive proof does not link to previous proof commitment".into(),
+                ));
+            }
+        }
+
+        let base_chain = previous
+            .map(|proof| proof.chain_commitment.as_str())
+            .unwrap_or(&self.previous_chain_commitment);
+        let expected_chain = Self::fold_chain(base_chain, header, pruning);
+        if expected_chain != self.chain_commitment {
+            return Err(ChainError::Crypto(
+                "recursive proof chain commitment mismatch".into(),
+            ));
+        }
+
+        let proof_seed = previous
+            .map(|proof| proof.proof_commitment.as_str())
+            .unwrap_or(&self.previous_proof_commitment);
+        let expected_proof = Self::fold_proof(&self.chain_commitment, proof_seed);
+        if expected_proof != self.proof_commitment {
+            return Err(ChainError::Crypto(
+                "recursive proof commitment mismatch".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Block {
     pub header: BlockHeader,
     pub transactions: Vec<SignedTransaction>,
+    pub pruning_proof: PruningProof,
+    pub recursive_proof: RecursiveProof,
     pub signature: String,
     pub hash: String,
 }
@@ -68,12 +329,16 @@ impl Block {
     pub fn new(
         header: BlockHeader,
         transactions: Vec<SignedTransaction>,
+        pruning_proof: PruningProof,
+        recursive_proof: RecursiveProof,
         signature: Signature,
     ) -> Self {
         let hash = header.hash();
         Self {
             header,
             transactions,
+            pruning_proof,
+            recursive_proof,
             signature: signature_to_hex(&signature),
             hash: hex::encode(hash),
         }
@@ -86,6 +351,35 @@ impl Block {
 
     pub fn block_hash(&self) -> [u8; 32] {
         self.header.hash()
+    }
+
+    pub fn verify(&self, previous: Option<&Block>) -> ChainResult<()> {
+        let mut tx_hashes = Vec::with_capacity(self.transactions.len());
+        for tx in &self.transactions {
+            tx.verify()?;
+            tx_hashes.push(tx.hash());
+        }
+        let computed_root = compute_merkle_root(&mut tx_hashes);
+        if hex::encode(computed_root) != self.header.tx_root {
+            return Err(ChainError::Crypto("transaction root mismatch".into()));
+        }
+
+        if let Some(prev_block) = previous {
+            if self.header.height != prev_block.header.height + 1 {
+                return Err(ChainError::Crypto(
+                    "invalid block height progression".into(),
+                ));
+            }
+            if self.header.previous_hash != prev_block.hash {
+                return Err(ChainError::Crypto("invalid previous block hash".into()));
+            }
+        }
+
+        self.pruning_proof.verify(previous, &self.header)?;
+        let previous_proof = previous.map(|block| &block.recursive_proof);
+        self.recursive_proof
+            .verify(&self.header, &self.pruning_proof, previous_proof)?;
+        Ok(())
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,7 @@ mod block;
 mod transaction;
 
 pub use account::{Account, Stake};
-pub use block::{Block, BlockHeader, BlockMetadata};
+pub use block::{Block, BlockHeader, BlockMetadata, ProofSystem, PruningProof, RecursiveProof};
 pub use transaction::{SignedTransaction, Transaction, TransactionEnvelope};
 
 pub type Address = String;


### PR DESCRIPTION
## Summary
- add pruning and recursive proof types to blocks and enforce verification when producing or bootstrapping
- implement a reputation module with ZSI identity, timetokes, scoring, and expose it through accounts
- update ledger logic to maintain reputation state and rewards while keeping node bootstrap lightweight

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cdb24803fc8326b503666d8b1976f3