### PR TITLE
Add wallet scaffolding with proofs and tab state models

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod node;
 pub mod reputation;
 pub mod storage;
 pub mod types;
+pub mod wallet;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1,0 +1,7 @@
+pub mod proofs;
+pub mod tabs;
+pub mod wallet;
+
+pub use proofs::{ProofGenerator, TxProof, UptimeProof};
+pub use tabs::{HistoryEntry, HistoryStatus, NodeTabMetrics, ReceiveTabAddress, SendPreview};
+pub use wallet::Wallet;

--- a/src/wallet/proofs.rs
+++ b/src/wallet/proofs.rs
@@ -1,0 +1,63 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use stwo::core::vcs::blake2_hash::Blake2sHasher;
+
+use crate::types::{Address, SignedTransaction};
+
+#[derive(Clone, Debug, Serialize)]
+pub struct TxProof {
+    pub wallet_address: Address,
+    pub tx_hash: String,
+    pub proof_commitment: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct UptimeProof {
+    pub wallet_address: Address,
+    pub window_start: u64,
+    pub window_end: u64,
+    pub proof_commitment: String,
+}
+
+#[derive(Clone)]
+pub struct ProofGenerator {
+    wallet_address: Address,
+}
+
+impl ProofGenerator {
+    pub fn new(wallet_address: Address) -> Self {
+        Self { wallet_address }
+    }
+
+    pub fn generate_tx_proof(&self, tx: &SignedTransaction) -> TxProof {
+        let mut data = Vec::new();
+        data.extend_from_slice(self.wallet_address.as_bytes());
+        data.extend_from_slice(&tx.hash());
+        let commitment: [u8; 32] = Blake2sHasher::hash(&data).into();
+        TxProof {
+            wallet_address: self.wallet_address.clone(),
+            tx_hash: hex::encode(tx.hash()),
+            proof_commitment: hex::encode(commitment),
+        }
+    }
+
+    pub fn generate_uptime_proof(&self) -> UptimeProof {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let window_start = now.saturating_sub(3600);
+        let mut data = Vec::new();
+        data.extend_from_slice(self.wallet_address.as_bytes());
+        data.extend_from_slice(&window_start.to_be_bytes());
+        data.extend_from_slice(&now.to_be_bytes());
+        let commitment: [u8; 32] = Blake2sHasher::hash(&data).into();
+        UptimeProof {
+            wallet_address: self.wallet_address.clone(),
+            window_start,
+            window_end: now,
+            proof_commitment: hex::encode(commitment),
+        }
+    }
+}

--- a/src/wallet/tabs/history.rs
+++ b/src/wallet/tabs/history.rs
@@ -1,0 +1,58 @@
+use serde::Serialize;
+
+use crate::types::SignedTransaction;
+
+#[derive(Clone, Debug, Serialize)]
+pub enum HistoryStatus {
+    Pending { submitted_at: u64 },
+    Confirmed { height: u64, timestamp: u64 },
+    Pruned { pruned_height: u64 },
+}
+
+impl HistoryStatus {
+    pub fn confirmation_height(&self) -> u64 {
+        match self {
+            HistoryStatus::Pending { .. } => u64::MAX,
+            HistoryStatus::Confirmed { height, .. } => *height,
+            HistoryStatus::Pruned { pruned_height } => *pruned_height,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HistoryEntry {
+    pub transaction: SignedTransaction,
+    pub status: HistoryStatus,
+    pub reputation_delta: i64,
+}
+
+impl HistoryEntry {
+    pub fn pending(transaction: SignedTransaction, submitted_at: u64) -> Self {
+        Self {
+            transaction,
+            status: HistoryStatus::Pending { submitted_at },
+            reputation_delta: 0,
+        }
+    }
+
+    pub fn confirmed(
+        transaction: SignedTransaction,
+        height: u64,
+        timestamp: u64,
+        reputation_delta: i64,
+    ) -> Self {
+        Self {
+            transaction,
+            status: HistoryStatus::Confirmed { height, timestamp },
+            reputation_delta,
+        }
+    }
+
+    pub fn pruned(transaction: SignedTransaction, pruned_height: u64) -> Self {
+        Self {
+            transaction,
+            status: HistoryStatus::Pruned { pruned_height },
+            reputation_delta: 0,
+        }
+    }
+}

--- a/src/wallet/tabs/mod.rs
+++ b/src/wallet/tabs/mod.rs
@@ -1,0 +1,9 @@
+mod history;
+mod node;
+mod receive;
+mod send;
+
+pub use history::{HistoryEntry, HistoryStatus};
+pub use node::NodeTabMetrics;
+pub use receive::ReceiveTabAddress;
+pub use send::SendPreview;

--- a/src/wallet/tabs/node.rs
+++ b/src/wallet/tabs/node.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+
+use crate::reputation::Tier;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct NodeTabMetrics {
+    pub reputation_score: f64,
+    pub tier: Tier,
+    pub uptime_hours: u64,
+    pub latest_block_height: u64,
+    pub latest_block_hash: Option<String>,
+    pub total_blocks: u64,
+}
+
+impl NodeTabMetrics {
+    pub fn consensus_health(&self) -> &'static str {
+        match self.tier {
+            Tier::Tl3 | Tier::Tl4 | Tier::Tl5 => "consensus-active",
+            Tier::Tl1 | Tier::Tl2 => "observer",
+            Tier::Tl0 => "wallet-only",
+        }
+    }
+}

--- a/src/wallet/tabs/receive.rs
+++ b/src/wallet/tabs/receive.rs
@@ -1,0 +1,15 @@
+use serde::Serialize;
+
+use crate::types::Address;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ReceiveTabAddress {
+    pub derivation_index: u32,
+    pub address: Address,
+}
+
+impl ReceiveTabAddress {
+    pub fn qr_uri(&self) -> String {
+        format!("rpp:{}?index={}", self.address, self.derivation_index)
+    }
+}

--- a/src/wallet/tabs/send.rs
+++ b/src/wallet/tabs/send.rs
@@ -1,0 +1,21 @@
+use serde::Serialize;
+
+use crate::types::Address;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SendPreview {
+    pub from: Address,
+    pub to: Address,
+    pub amount: u128,
+    pub fee: u64,
+    pub memo: Option<String>,
+    pub nonce: u64,
+    pub balance_before: u128,
+    pub balance_after: u128,
+}
+
+impl SendPreview {
+    pub fn total(&self) -> u128 {
+        self.amount + self.fee as u128
+    }
+}

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -1,0 +1,197 @@
+use std::sync::Arc;
+
+use ed25519_dalek::Keypair;
+use serde::Serialize;
+use stwo::core::vcs::blake2_hash::Blake2sHasher;
+
+use crate::crypto::{address_from_public_key, sign_message};
+use crate::errors::{ChainError, ChainResult};
+use crate::reputation::Tier;
+use crate::storage::Storage;
+use crate::types::{Address, SignedTransaction, Transaction};
+
+use super::proofs::{ProofGenerator, TxProof, UptimeProof};
+use super::tabs::{HistoryEntry, HistoryStatus, NodeTabMetrics, ReceiveTabAddress, SendPreview};
+
+#[derive(Clone)]
+pub struct Wallet {
+    storage: Storage,
+    keypair: Arc<Keypair>,
+    address: Address,
+    proof_generator: ProofGenerator,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct WalletAccountSummary {
+    pub address: Address,
+    pub balance: u128,
+    pub nonce: u64,
+    pub reputation_score: f64,
+    pub tier: Tier,
+    pub uptime_hours: u64,
+}
+
+impl Wallet {
+    pub fn new(storage: Storage, keypair: Keypair) -> Self {
+        let address = address_from_public_key(&keypair.public);
+        let proof_generator = ProofGenerator::new(address.clone());
+        Self {
+            storage,
+            keypair: Arc::new(keypair),
+            address,
+            proof_generator,
+        }
+    }
+
+    pub fn address(&self) -> &Address {
+        &self.address
+    }
+
+    pub fn account_summary(&self) -> ChainResult<WalletAccountSummary> {
+        let account = self
+            .storage
+            .read_account(&self.address)?
+            .ok_or_else(|| ChainError::Config("wallet account not found".into()))?;
+        Ok(WalletAccountSummary {
+            address: account.address.clone(),
+            balance: account.balance,
+            nonce: account.nonce,
+            reputation_score: account.reputation.score,
+            tier: account.reputation.tier.clone(),
+            uptime_hours: account.reputation.timetokes.hours_online,
+        })
+    }
+
+    pub fn build_transaction(
+        &self,
+        to: Address,
+        amount: u128,
+        fee: u64,
+        memo: Option<String>,
+    ) -> ChainResult<Transaction> {
+        let account = self
+            .storage
+            .read_account(&self.address)?
+            .ok_or_else(|| ChainError::Transaction("wallet account not found".into()))?;
+        let total = amount
+            .checked_add(fee as u128)
+            .ok_or_else(|| ChainError::Transaction("amount overflow".into()))?;
+        if account.balance < total {
+            return Err(ChainError::Transaction("insufficient balance".into()));
+        }
+        let nonce = account.nonce + 1;
+        Ok(Transaction::new(
+            self.address.clone(),
+            to,
+            amount,
+            fee,
+            nonce,
+            memo,
+        ))
+    }
+
+    pub fn preview_send(
+        &self,
+        to: Address,
+        amount: u128,
+        fee: u64,
+        memo: Option<String>,
+    ) -> ChainResult<SendPreview> {
+        let account = self
+            .storage
+            .read_account(&self.address)?
+            .ok_or_else(|| ChainError::Transaction("wallet account not found".into()))?;
+        let total = amount
+            .checked_add(fee as u128)
+            .ok_or_else(|| ChainError::Transaction("amount overflow".into()))?;
+        let remaining_balance = account.balance.saturating_sub(total);
+        Ok(SendPreview {
+            from: self.address.clone(),
+            to,
+            amount,
+            fee,
+            memo,
+            nonce: account.nonce + 1,
+            balance_before: account.balance,
+            balance_after: remaining_balance,
+        })
+    }
+
+    pub fn sign_transaction(&self, tx: Transaction) -> SignedTransaction {
+        let signature = sign_message(&self.keypair, &tx.canonical_bytes());
+        SignedTransaction::new(tx, signature, &self.keypair.public)
+    }
+
+    pub fn prove_transaction(&self, tx: &SignedTransaction) -> TxProof {
+        self.proof_generator.generate_tx_proof(tx)
+    }
+
+    pub fn generate_uptime_proof(&self) -> UptimeProof {
+        self.proof_generator.generate_uptime_proof()
+    }
+
+    pub fn history(&self) -> ChainResult<Vec<HistoryEntry>> {
+        let blocks = self.storage.load_blockchain()?;
+        let mut history = Vec::new();
+        for block in blocks {
+            for tx in &block.transactions {
+                if tx.payload.from == self.address || tx.payload.to == self.address {
+                    let status = HistoryStatus::Confirmed {
+                        height: block.header.height,
+                        timestamp: block.header.timestamp,
+                    };
+                    history.push(HistoryEntry {
+                        transaction: tx.clone(),
+                        status,
+                        reputation_delta: self.estimate_reputation_delta(tx),
+                    });
+                }
+            }
+        }
+        history.sort_by_key(|entry| entry.status.confirmation_height());
+        Ok(history)
+    }
+
+    fn estimate_reputation_delta(&self, tx: &SignedTransaction) -> i64 {
+        if tx.payload.to == self.address {
+            1
+        } else if tx.payload.from == self.address {
+            -1
+        } else {
+            0
+        }
+    }
+
+    pub fn receive_addresses(&self, count: usize) -> Vec<ReceiveTabAddress> {
+        (0..count)
+            .map(|index| self.derive_address(index as u32))
+            .collect()
+    }
+
+    pub fn derive_address(&self, index: u32) -> ReceiveTabAddress {
+        let mut seed = Vec::new();
+        seed.extend_from_slice(self.address.as_bytes());
+        seed.extend_from_slice(&index.to_be_bytes());
+        let hash: [u8; 32] = Blake2sHasher::hash(&seed).into();
+        ReceiveTabAddress {
+            derivation_index: index,
+            address: hex::encode(hash),
+        }
+    }
+
+    pub fn node_metrics(&self) -> ChainResult<NodeTabMetrics> {
+        let tip = self.storage.tip()?;
+        let account = self
+            .storage
+            .read_account(&self.address)?
+            .ok_or_else(|| ChainError::Config("wallet account not found".into()))?;
+        Ok(NodeTabMetrics {
+            reputation_score: account.reputation.score,
+            tier: account.reputation.tier.clone(),
+            uptime_hours: account.reputation.timetokes.hours_online,
+            latest_block_height: tip.as_ref().map(|meta| meta.height).unwrap_or(0),
+            latest_block_hash: tip.as_ref().map(|meta| meta.hash.clone()),
+            total_blocks: self.storage.load_blockchain()?.len() as u64,
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- add a wallet module that can build, sign and summarize transactions while exposing history and node metrics
- introduce lightweight proof generators and Electrum-style tab models for history, send, receive and node views
- export the new wallet module from the crate root for downstream use

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cdc282122083268436f9fb1240c1f1