### PR TITLE
Add STWO parameter and aggregator regression tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1460,10 +1461,13 @@ dependencies = [
  "anyhow",
  "axum",
  "bincode",
+ "blake2",
  "clap",
  "ed25519-dalek",
  "hex",
  "malachite",
+ "num-bigint",
+ "num-traits",
  "parking_lot",
  "rand 0.7.3",
  "rocksdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
+num-bigint = { version = "0.4", features = ["serde"] }
+num-traits = "0.2"
+blake2 = "0.10"

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use crate::errors::{ChainError, ChainResult};
 use crate::node::NodeHandle;
-use crate::types::{Account, Block, SignedTransaction};
+use crate::types::{Account, Block, TransactionProofBundle};
 
 #[derive(Clone)]
 struct AppState {
@@ -59,11 +59,11 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
 
 async fn submit_transaction(
     State(state): State<AppState>,
-    Json(tx): Json<SignedTransaction>,
+    Json(bundle): Json<TransactionProofBundle>,
 ) -> Result<Json<SubmitResponse>, (StatusCode, Json<ErrorResponse>)> {
     state
         .node
-        .submit_transaction(tx)
+        .submit_transaction(bundle)
         .map(|hash| Json(SubmitResponse { hash }))
         .map_err(to_http_error)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,6 @@ pub mod ledger;
 pub mod node;
 pub mod reputation;
 pub mod storage;
+pub mod stwo;
 pub mod types;
 pub mod wallet;

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -70,6 +71,31 @@ impl fmt::Display for Tier {
 impl Default for Tier {
     fn default() -> Self {
         Tier::Tl0
+    }
+}
+
+impl Ord for Tier {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.rank().cmp(&other.rank())
+    }
+}
+
+impl PartialOrd for Tier {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Tier {
+    fn rank(&self) -> u8 {
+        match self {
+            Tier::Tl0 => 0,
+            Tier::Tl1 => 1,
+            Tier::Tl2 => 2,
+            Tier::Tl3 => 3,
+            Tier::Tl4 => 4,
+            Tier::Tl5 => 5,
+        }
     }
 }
 

--- a/src/stwo/air/mod.rs
+++ b/src/stwo/air/mod.rs
@@ -1,0 +1,437 @@
+//! Algebraic Intermediate Representation (AIR) definitions and utilities
+//! supporting the STWO blueprint. The scaffolding below allows circuits to
+//! register constraint expressions over execution traces and deterministically
+//! compress their evaluations so that provers and verifiers can agree on the
+//! enforced algebra without implementing a full STARK backend yet.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::stwo::circuit::ExecutionTrace;
+use crate::stwo::params::{FieldElement, FieldError, StarkParameters};
+
+/// Errors that can be raised while manipulating AIR artifacts.
+#[derive(Debug, thiserror::Error)]
+pub enum AirError {
+    #[error("trace segment '{0}' not found")]
+    MissingSegment(String),
+
+    #[error("column '{column}' not found in segment '{segment}'")]
+    MissingColumn { segment: String, column: String },
+
+    #[error(
+        "row {row} with offset {offset} out of bounds for column '{column}' in segment '{segment}'"
+    )]
+    RowOutOfBounds {
+        segment: String,
+        column: String,
+        row: usize,
+        offset: isize,
+    },
+
+    #[error("field arithmetic error: {0}")]
+    Field(#[from] FieldError),
+
+    #[error("constraint evaluation count mismatch: expected {expected}, found {actual}")]
+    EvaluationCount { expected: usize, actual: usize },
+}
+
+/// Identifier referencing a column inside a named trace segment.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AirColumn {
+    segment: String,
+    column: String,
+}
+
+impl AirColumn {
+    pub fn new(segment: impl Into<String>, column: impl Into<String>) -> Self {
+        Self {
+            segment: segment.into(),
+            column: column.into(),
+        }
+    }
+
+    /// Returns the name of the trace segment backing the column.
+    pub fn segment(&self) -> &str {
+        &self.segment
+    }
+
+    /// Returns the column label within the trace segment.
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    /// Build an AIR expression referencing the column at the current row.
+    pub fn expr(&self) -> AirExpression {
+        AirExpression::Column(ColumnReference {
+            column: self.clone(),
+            offset: 0,
+        })
+    }
+
+    /// Build an AIR expression referencing the column shifted by `offset`
+    /// relative to the current row.
+    pub fn shifted(&self, offset: isize) -> AirExpression {
+        AirExpression::Column(ColumnReference {
+            column: self.clone(),
+            offset,
+        })
+    }
+}
+
+/// Reference to a column plus the relative row offset to read.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnReference {
+    column: AirColumn,
+    offset: isize,
+}
+
+/// Expression tree describing algebraic constraints over the execution trace.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AirExpression {
+    Constant(FieldElement),
+    Column(ColumnReference),
+    Add(Vec<AirExpression>),
+    Sub(Box<AirExpression>, Box<AirExpression>),
+    Mul(Vec<AirExpression>),
+}
+
+impl AirExpression {
+    /// Create a constant expression from a field element.
+    pub fn constant(value: FieldElement) -> Self {
+        Self::Constant(value)
+    }
+
+    /// Build the sum of multiple expressions.
+    pub fn sum(terms: Vec<AirExpression>) -> Self {
+        Self::Add(terms)
+    }
+
+    /// Build the product of multiple expressions.
+    pub fn product(terms: Vec<AirExpression>) -> Self {
+        Self::Mul(terms)
+    }
+
+    /// Build the difference of two expressions.
+    pub fn difference(lhs: AirExpression, rhs: AirExpression) -> Self {
+        Self::Sub(Box::new(lhs), Box::new(rhs))
+    }
+
+    fn evaluate(
+        &self,
+        view: &TraceView<'_>,
+        row: usize,
+        parameters: &StarkParameters,
+    ) -> Result<FieldElement, AirError> {
+        match self {
+            AirExpression::Constant(value) => Ok(value.clone()),
+            AirExpression::Column(reference) => {
+                view.value(&reference.column, row, reference.offset)
+            }
+            AirExpression::Add(terms) => {
+                let mut acc = FieldElement::zero(parameters.modulus());
+                for term in terms {
+                    let value = term.evaluate(view, row, parameters)?;
+                    acc = acc.add(&value)?;
+                }
+                Ok(acc)
+            }
+            AirExpression::Sub(lhs, rhs) => {
+                let left = lhs.evaluate(view, row, parameters)?;
+                let right = rhs.evaluate(view, row, parameters)?;
+                Ok(left.sub(&right)?)
+            }
+            AirExpression::Mul(terms) => {
+                if terms.is_empty() {
+                    return Ok(FieldElement::one(parameters.modulus()));
+                }
+                let mut acc = FieldElement::one(parameters.modulus());
+                for term in terms {
+                    let value = term.evaluate(view, row, parameters)?;
+                    acc = acc.mul(&value)?;
+                }
+                Ok(acc)
+            }
+        }
+    }
+}
+
+impl From<AirColumn> for AirExpression {
+    fn from(column: AirColumn) -> Self {
+        column.expr()
+    }
+}
+
+/// Domain selector describing which rows of a trace segment a constraint
+/// should be evaluated on.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ConstraintDomain {
+    AllRows,
+    FirstRow,
+    LastRow,
+    Range { start: usize, end: Option<usize> },
+}
+
+impl ConstraintDomain {
+    fn rows(&self, length: usize) -> Vec<usize> {
+        match self {
+            ConstraintDomain::AllRows => (0..length).collect(),
+            ConstraintDomain::FirstRow => {
+                if length > 0 {
+                    vec![0]
+                } else {
+                    Vec::new()
+                }
+            }
+            ConstraintDomain::LastRow => {
+                if length > 0 {
+                    vec![length - 1]
+                } else {
+                    Vec::new()
+                }
+            }
+            ConstraintDomain::Range { start, end } => {
+                if *start >= length {
+                    Vec::new()
+                } else {
+                    let end_index = end.map(|idx| idx.min(length)).unwrap_or(length);
+                    (*start..end_index).collect()
+                }
+            }
+        }
+    }
+}
+
+/// Algebraic constraint evaluated over a subset of rows inside a segment.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AirConstraint {
+    pub name: String,
+    pub segment: String,
+    pub domain: ConstraintDomain,
+    pub expression: AirExpression,
+}
+
+impl AirConstraint {
+    pub fn new(
+        name: impl Into<String>,
+        segment: impl Into<String>,
+        domain: ConstraintDomain,
+        expression: AirExpression,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            segment: segment.into(),
+            domain,
+            expression,
+        }
+    }
+}
+
+/// Bundle of constraints describing the AIR for a circuit.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AirDefinition {
+    constraints: Vec<AirConstraint>,
+}
+
+impl AirDefinition {
+    pub fn new(constraints: Vec<AirConstraint>) -> Self {
+        Self { constraints }
+    }
+
+    pub fn constraints(&self) -> &[AirConstraint] {
+        &self.constraints
+    }
+
+    /// Evaluate all constraints over the provided execution trace.
+    pub fn evaluate(
+        &self,
+        trace: &ExecutionTrace,
+        parameters: &StarkParameters,
+    ) -> Result<Vec<ConstraintEvaluation>, AirError> {
+        let view = TraceView::new(trace);
+        let mut evaluations = Vec::with_capacity(self.constraints.len());
+        for constraint in &self.constraints {
+            let segment = view
+                .segment(constraint.segment.as_str())
+                .ok_or_else(|| AirError::MissingSegment(constraint.segment.clone()))?;
+            let rows = constraint.domain.rows(segment.row_count());
+            let mut results = Vec::new();
+            for row in rows {
+                let value = constraint.expression.evaluate(&view, row, parameters)?;
+                if !value.is_zero() {
+                    results.push((row, value));
+                }
+            }
+            evaluations.push(ConstraintEvaluation {
+                name: constraint.name.clone(),
+                rows: results,
+            });
+        }
+        Ok(evaluations)
+    }
+}
+
+/// Evaluation results for a single AIR constraint.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConstraintEvaluation {
+    pub name: String,
+    pub rows: Vec<(usize, FieldElement)>,
+}
+
+impl ConstraintEvaluation {
+    pub fn is_satisfied(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn first_violation(&self) -> Option<(usize, FieldElement)> {
+        self.rows.first().cloned()
+    }
+}
+
+/// Result of compressing multiple constraint evaluations into a linear
+/// combination using random-looking challenges.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConstraintCompressionResult {
+    pub aggregated: Vec<(usize, FieldElement)>,
+}
+
+impl ConstraintCompressionResult {
+    pub fn is_zero(&self) -> bool {
+        self.aggregated.iter().all(|(_, value)| value.is_zero())
+    }
+
+    pub fn first_violation(&self) -> Option<(usize, FieldElement)> {
+        self.aggregated
+            .iter()
+            .find(|(_, value)| !value.is_zero())
+            .cloned()
+    }
+}
+
+/// Deterministically derived randomizers used to combine constraint
+/// evaluations. In a production prover these would be sampled via a Fiat–
+/// Shamir transcript.
+#[derive(Debug)]
+pub struct ConstraintCompressor {
+    challenges: Vec<FieldElement>,
+}
+
+impl ConstraintCompressor {
+    pub fn new(parameters: &StarkParameters, air: &AirDefinition) -> Self {
+        let hasher = parameters.poseidon_hasher();
+        let challenges = air
+            .constraints()
+            .iter()
+            .enumerate()
+            .map(|(index, constraint)| {
+                hasher.hash_bytes(&vec![
+                    constraint.name.as_bytes().to_vec(),
+                    (index as u64).to_be_bytes().to_vec(),
+                ])
+            })
+            .collect();
+        Self { challenges }
+    }
+
+    pub fn compress(
+        &self,
+        evaluations: &[ConstraintEvaluation],
+    ) -> Result<ConstraintCompressionResult, AirError> {
+        if evaluations.len() != self.challenges.len() {
+            return Err(AirError::EvaluationCount {
+                expected: self.challenges.len(),
+                actual: evaluations.len(),
+            });
+        }
+        let mut aggregated: BTreeMap<usize, FieldElement> = BTreeMap::new();
+        for (evaluation, challenge) in evaluations.iter().zip(self.challenges.iter()) {
+            for (row, value) in &evaluation.rows {
+                let scaled = value.mul(challenge)?;
+                if let Some(existing) = aggregated.get_mut(row) {
+                    *existing = existing.add(&scaled)?;
+                } else {
+                    aggregated.insert(*row, scaled.clone());
+                }
+            }
+        }
+        Ok(ConstraintCompressionResult {
+            aggregated: aggregated.into_iter().collect(),
+        })
+    }
+}
+
+struct SegmentView<'a> {
+    name: &'a str,
+    column_index: HashMap<&'a str, usize>,
+    rows: &'a [Vec<FieldElement>],
+}
+
+impl<'a> SegmentView<'a> {
+    fn new(segment: &'a crate::stwo::circuit::TraceSegment) -> Self {
+        let mut column_index = HashMap::new();
+        for (idx, column) in segment.columns.iter().enumerate() {
+            column_index.insert(column.as_str(), idx);
+        }
+        Self {
+            name: segment.name.as_str(),
+            column_index,
+            rows: &segment.rows,
+        }
+    }
+
+    fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn value(&self, column: &str, row: usize, offset: isize) -> Result<FieldElement, AirError> {
+        let index = self
+            .column_index
+            .get(column)
+            .ok_or_else(|| AirError::MissingColumn {
+                segment: self.name.to_string(),
+                column: column.to_string(),
+            })?;
+        let target = row as isize + offset;
+        if target < 0 || target as usize >= self.rows.len() {
+            return Err(AirError::RowOutOfBounds {
+                segment: self.name.to_string(),
+                column: column.to_string(),
+                row,
+                offset,
+            });
+        }
+        Ok(self.rows[target as usize][*index].clone())
+    }
+}
+
+struct TraceView<'a> {
+    segments: HashMap<&'a str, SegmentView<'a>>,
+}
+
+impl<'a> TraceView<'a> {
+    fn new(trace: &'a ExecutionTrace) -> Self {
+        let segments = trace
+            .segments
+            .iter()
+            .map(|segment| (segment.name.as_str(), SegmentView::new(segment)))
+            .collect();
+        Self { segments }
+    }
+
+    fn segment(&self, name: &str) -> Option<&SegmentView<'a>> {
+        self.segments.get(name)
+    }
+
+    fn value(
+        &self,
+        column: &AirColumn,
+        row: usize,
+        offset: isize,
+    ) -> Result<FieldElement, AirError> {
+        let segment = self
+            .segment(column.segment.as_str())
+            .ok_or_else(|| AirError::MissingSegment(column.segment.clone()))?;
+        segment.value(column.column.as_str(), row, offset)
+    }
+}

--- a/src/stwo/circuit/mod.rs
+++ b/src/stwo/circuit/mod.rs
@@ -1,0 +1,153 @@
+//! Definitions for STARK constraint systems used across the stack.
+
+use serde::{Deserialize, Serialize};
+
+use crate::stwo::air::{AirDefinition, ConstraintCompressor};
+use crate::stwo::params::{FieldElement, StarkParameters};
+
+pub mod pruning;
+pub mod recursive;
+pub mod state;
+pub mod transaction;
+
+pub use pruning::PruningWitness;
+pub use recursive::RecursiveWitness;
+pub use state::StateWitness;
+pub use transaction::TransactionWitness;
+
+/// Execution trace segment captured while evaluating a circuit.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TraceSegment {
+    pub name: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<Vec<FieldElement>>,
+}
+
+impl TraceSegment {
+    pub fn new(
+        name: impl Into<String>,
+        columns: Vec<String>,
+        rows: Vec<Vec<FieldElement>>,
+    ) -> Result<Self, CircuitError> {
+        if columns.is_empty() {
+            return Err(CircuitError::InvalidWitness(
+                "trace segment requires at least one column".into(),
+            ));
+        }
+        let name = name.into();
+        let width = columns.len();
+        for (index, row) in rows.iter().enumerate() {
+            if row.len() != width {
+                return Err(CircuitError::InvalidWitness(format!(
+                    "trace segment '{}' row {} width mismatch: expected {}, found {}",
+                    name,
+                    index,
+                    width,
+                    row.len()
+                )));
+            }
+        }
+        Ok(Self {
+            name,
+            columns,
+            rows,
+        })
+    }
+}
+
+/// Execution trace emitted by a circuit. Consists of one or more named segments.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecutionTrace {
+    pub segments: Vec<TraceSegment>,
+}
+
+impl ExecutionTrace {
+    pub fn from_segments(segments: Vec<TraceSegment>) -> Result<Self, CircuitError> {
+        if segments.is_empty() {
+            return Err(CircuitError::InvalidWitness(
+                "execution trace must contain at least one segment".into(),
+            ));
+        }
+        Ok(Self { segments })
+    }
+
+    pub fn single(segment: TraceSegment) -> Result<Self, CircuitError> {
+        Self::from_segments(vec![segment])
+    }
+}
+
+/// Convert arbitrary string encodings into field elements. Hex inputs are
+/// decoded preferentially, falling back to ASCII encoding when decoding fails.
+pub fn string_to_field(parameters: &StarkParameters, value: &str) -> FieldElement {
+    let bytes = hex::decode(value).unwrap_or_else(|_| value.as_bytes().to_vec());
+    parameters.element_from_bytes(&bytes)
+}
+
+/// Generic trait implemented by all STARK-compatible circuits in the system.
+pub trait StarkCircuit {
+    /// Structured name of the circuit. Used for logging, metrics and serialization headers.
+    fn name(&self) -> &'static str;
+
+    /// Compute all constraints over the execution trace and permutation arguments.
+    fn evaluate_constraints(&self) -> Result<(), CircuitError>;
+
+    /// Materialize the execution trace associated with the witness and circuit.
+    fn generate_trace(&self, parameters: &StarkParameters) -> Result<ExecutionTrace, CircuitError>;
+
+    /// Describe the AIR constraints associated with the generated execution trace.
+    fn define_air(
+        &self,
+        parameters: &StarkParameters,
+        trace: &ExecutionTrace,
+    ) -> Result<AirDefinition, CircuitError>;
+
+    /// Evaluate and compress the AIR constraints over the execution trace.
+    fn verify_air(
+        &self,
+        parameters: &StarkParameters,
+        trace: &ExecutionTrace,
+    ) -> Result<(), CircuitError> {
+        let air = self.define_air(parameters, trace)?;
+        let evaluations = air
+            .evaluate(trace, parameters)
+            .map_err(|err| CircuitError::InvalidWitness(err.to_string()))?;
+        for evaluation in &evaluations {
+            if let Some((row, value)) = evaluation.first_violation() {
+                return Err(CircuitError::ConstraintViolation(format!(
+                    "AIR constraint '{}' failed at row {} with value {}",
+                    evaluation.name,
+                    row,
+                    value.to_hex()
+                )));
+            }
+        }
+        let compressor = ConstraintCompressor::new(parameters, &air);
+        let compressed = compressor
+            .compress(&evaluations)
+            .map_err(|err| CircuitError::InvalidWitness(err.to_string()))?;
+        if let Some((row, value)) = compressed.first_violation() {
+            return Err(CircuitError::ConstraintViolation(format!(
+                "compressed AIR evaluation failed at row {} with value {}",
+                row,
+                value.to_hex()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Errors that can be raised while evaluating STARK constraints.
+#[derive(Debug, thiserror::Error)]
+pub enum CircuitError {
+    /// Raised when an execution trace fails a constraint.
+    #[error("constraint violation: {0}")]
+    ConstraintViolation(String),
+
+    /// Raised when witness data is malformed or inconsistent.
+    #[error("invalid witness data: {0}")]
+    InvalidWitness(String),
+
+    /// Raised for unsupported features or configuration mismatches.
+    #[error("unsupported operation: {0}")]
+    Unsupported(&'static str),
+}

--- a/src/stwo/circuit/pruning.rs
+++ b/src/stwo/circuit/pruning.rs
@@ -1,0 +1,211 @@
+//! Pruning proof STARK constraints blueprint implementation.
+
+use std::collections::HashSet;
+
+use crate::ledger::compute_merkle_root;
+use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, ConstraintDomain};
+use crate::stwo::params::StarkParameters;
+
+use super::{CircuitError, ExecutionTrace, StarkCircuit, TraceSegment, string_to_field};
+
+/// Witness for the pruning circuit describing the set of removed transactions.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct PruningWitness {
+    pub previous_tx_root: String,
+    pub pruned_tx_root: String,
+    pub original_transactions: Vec<String>,
+    pub removed_transactions: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct PruningCircuit {
+    pub witness: PruningWitness,
+}
+
+impl PruningCircuit {
+    pub fn new(witness: PruningWitness) -> Self {
+        Self { witness }
+    }
+
+    fn decode_hash(hex: &str) -> Result<[u8; 32], CircuitError> {
+        let bytes = hex::decode(hex)
+            .map_err(|_| CircuitError::ConstraintViolation("invalid hex encoding".into()))?;
+        if bytes.len() != 32 {
+            return Err(CircuitError::ConstraintViolation(
+                "transaction hash must be 32 bytes".into(),
+            ));
+        }
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes);
+        Ok(array)
+    }
+
+    fn compute_root(hashes: &[String]) -> Result<String, CircuitError> {
+        let mut leaves = hashes
+            .iter()
+            .map(|hash| Self::decode_hash(hash))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(hex::encode(compute_merkle_root(&mut leaves)))
+    }
+
+    fn verify_membership(&self) -> Result<(), CircuitError> {
+        let root = Self::compute_root(&self.witness.original_transactions)?;
+        if root != self.witness.previous_tx_root {
+            return Err(CircuitError::ConstraintViolation(
+                "original transaction set does not match previous root".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify_pruned_root(&self) -> Result<(), CircuitError> {
+        let removed: HashSet<_> = self.witness.removed_transactions.iter().cloned().collect();
+        let mut remaining = Vec::new();
+        for hash in &self.witness.original_transactions {
+            if !removed.contains(hash) {
+                remaining.push(hash.clone());
+            }
+        }
+        for hash in &self.witness.removed_transactions {
+            if !self.witness.original_transactions.contains(hash) {
+                return Err(CircuitError::ConstraintViolation(
+                    "pruning removed transaction not present in original set".into(),
+                ));
+            }
+        }
+        let pruned_root = Self::compute_root(&remaining)?;
+        if pruned_root != self.witness.pruned_tx_root {
+            return Err(CircuitError::ConstraintViolation(
+                "pruned transaction root mismatch".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl StarkCircuit for PruningCircuit {
+    fn name(&self) -> &'static str {
+        "pruning"
+    }
+
+    fn evaluate_constraints(&self) -> Result<(), CircuitError> {
+        self.verify_membership()?;
+        self.verify_pruned_root()?;
+        Ok(())
+    }
+
+    fn generate_trace(&self, parameters: &StarkParameters) -> Result<ExecutionTrace, CircuitError> {
+        let removed: HashSet<_> = self.witness.removed_transactions.iter().cloned().collect();
+        let mut remaining = Vec::new();
+        let mut original_rows = Vec::new();
+        for hash in &self.witness.original_transactions {
+            let is_removed = removed.contains(hash);
+            if !is_removed {
+                remaining.push(hash.clone());
+            }
+            let row = vec![
+                string_to_field(parameters, hash),
+                parameters.element_from_u64(if is_removed { 1 } else { 0 }),
+            ];
+            original_rows.push(row);
+        }
+
+        for hash in &self.witness.removed_transactions {
+            if !self.witness.original_transactions.contains(hash) {
+                return Err(CircuitError::ConstraintViolation(
+                    "pruning removed transaction not present in original set".into(),
+                ));
+            }
+        }
+
+        let membership_segment = TraceSegment::new(
+            "membership",
+            vec!["tx_hash".to_string(), "removed_flag".to_string()],
+            original_rows,
+        )?;
+
+        let previous_root_computed = Self::compute_root(&self.witness.original_transactions)?;
+        let pruned_root_computed = Self::compute_root(&remaining)?;
+        let summary_row = vec![
+            string_to_field(parameters, &self.witness.previous_tx_root),
+            string_to_field(parameters, &previous_root_computed),
+            string_to_field(parameters, &self.witness.pruned_tx_root),
+            string_to_field(parameters, &pruned_root_computed),
+            parameters.element_from_u64(self.witness.removed_transactions.len() as u64),
+        ];
+        let summary_segment = TraceSegment::new(
+            "roots",
+            vec![
+                "previous_root_witness".to_string(),
+                "previous_root_computed".to_string(),
+                "pruned_root_witness".to_string(),
+                "pruned_root_computed".to_string(),
+                "removed_count".to_string(),
+            ],
+            vec![summary_row],
+        )?;
+
+        ExecutionTrace::from_segments(vec![membership_segment, summary_segment])
+    }
+
+    fn define_air(
+        &self,
+        parameters: &StarkParameters,
+        _trace: &ExecutionTrace,
+    ) -> Result<AirDefinition, CircuitError> {
+        let membership_segment = "membership";
+        let removed_flag = AirColumn::new(membership_segment, "removed_flag");
+
+        let roots_segment = "roots";
+        let previous_root_witness = AirColumn::new(roots_segment, "previous_root_witness");
+        let previous_root_computed = AirColumn::new(roots_segment, "previous_root_computed");
+        let pruned_root_witness = AirColumn::new(roots_segment, "pruned_root_witness");
+        let pruned_root_computed = AirColumn::new(roots_segment, "pruned_root_computed");
+        let removed_count = AirColumn::new(roots_segment, "removed_count");
+
+        let one = parameters.element_from_u64(1);
+        let removed_len =
+            parameters.element_from_u64(self.witness.removed_transactions.len() as u64);
+
+        let constraints = vec![
+            AirConstraint::new(
+                "membership_flag_boolean",
+                membership_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::product(vec![
+                    removed_flag.expr(),
+                    AirExpression::difference(
+                        removed_flag.expr(),
+                        AirExpression::constant(one.clone()),
+                    ),
+                ]),
+            ),
+            AirConstraint::new(
+                "previous_root_matches",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    previous_root_witness.expr(),
+                    previous_root_computed.expr(),
+                ),
+            ),
+            AirConstraint::new(
+                "pruned_root_matches",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(pruned_root_witness.expr(), pruned_root_computed.expr()),
+            ),
+            AirConstraint::new(
+                "removed_count_matches",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    removed_count.expr(),
+                    AirExpression::constant(removed_len),
+                ),
+            ),
+        ];
+
+        Ok(AirDefinition::new(constraints))
+    }
+}

--- a/src/stwo/circuit/recursive.rs
+++ b/src/stwo/circuit/recursive.rs
@@ -1,0 +1,209 @@
+//! Recursive proof aggregation circuit blueprint implementation.
+
+use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, ConstraintDomain};
+use crate::stwo::params::{FieldElement, PoseidonHasher, StarkParameters};
+
+use super::{CircuitError, ExecutionTrace, StarkCircuit, TraceSegment, string_to_field};
+
+/// Witness connecting previous proof commitments with the latest aggregation.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RecursiveWitness {
+    pub previous_commitment: Option<String>,
+    pub aggregated_commitment: String,
+    pub tx_commitments: Vec<String>,
+    pub state_commitment: String,
+    pub pruning_commitment: String,
+    pub block_height: u64,
+}
+
+#[derive(Debug)]
+pub struct RecursiveCircuit {
+    pub witness: RecursiveWitness,
+}
+
+impl RecursiveCircuit {
+    pub fn new(witness: RecursiveWitness) -> Self {
+        Self { witness }
+    }
+
+    fn decode_field(params: &StarkParameters, value: &str) -> Result<FieldElement, CircuitError> {
+        Ok(string_to_field(params, value))
+    }
+
+    fn fold_commitments(
+        hasher: &PoseidonHasher,
+        params: &StarkParameters,
+        commitments: &[String],
+    ) -> Result<FieldElement, CircuitError> {
+        let mut acc = FieldElement::zero(params.modulus());
+        for commitment in commitments {
+            let element = Self::decode_field(params, commitment)?;
+            let inputs = vec![acc.clone(), element, FieldElement::zero(params.modulus())];
+            acc = hasher.hash(&inputs);
+        }
+        Ok(acc)
+    }
+
+    fn aggregate_with_params(
+        &self,
+        params: &StarkParameters,
+    ) -> Result<FieldElement, CircuitError> {
+        let hasher = params.poseidon_hasher();
+        let previous = match &self.witness.previous_commitment {
+            Some(value) => Self::decode_field(params, value)?,
+            None => FieldElement::zero(params.modulus()),
+        };
+        let state_element = Self::decode_field(params, &self.witness.state_commitment)?;
+        let pruning_element = Self::decode_field(params, &self.witness.pruning_commitment)?;
+        let state_pruning_digest = hasher.hash(&[
+            state_element,
+            pruning_element,
+            params.element_from_u64(self.witness.block_height),
+        ]);
+        let tx_digest = Self::fold_commitments(&hasher, params, &self.witness.tx_commitments)?;
+        let final_inputs = vec![previous, state_pruning_digest, tx_digest];
+        Ok(hasher.hash(&final_inputs))
+    }
+}
+
+impl StarkCircuit for RecursiveCircuit {
+    fn name(&self) -> &'static str {
+        "recursive"
+    }
+
+    fn evaluate_constraints(&self) -> Result<(), CircuitError> {
+        if self.witness.tx_commitments.is_empty() {
+            return Err(CircuitError::ConstraintViolation(
+                "recursive witness missing transaction commitments".into(),
+            ));
+        }
+        let params = StarkParameters::blueprint_default();
+        let aggregated = self.aggregate_with_params(&params)?;
+        let expected = Self::decode_field(&params, &self.witness.aggregated_commitment)?;
+        if aggregated != expected {
+            return Err(CircuitError::ConstraintViolation(
+                "aggregated commitment mismatch".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn generate_trace(&self, parameters: &StarkParameters) -> Result<ExecutionTrace, CircuitError> {
+        let hasher = parameters.poseidon_hasher();
+        let zero = FieldElement::zero(parameters.modulus());
+        let mut accumulator = zero.clone();
+        let mut fold_rows = Vec::new();
+        for commitment in &self.witness.tx_commitments {
+            let commitment_element = Self::decode_field(parameters, commitment)?;
+            let next = hasher.hash(&[
+                accumulator.clone(),
+                commitment_element.clone(),
+                zero.clone(),
+            ]);
+            fold_rows.push(vec![accumulator.clone(), commitment_element, next.clone()]);
+            accumulator = next;
+        }
+        let fold_segment = TraceSegment::new(
+            "tx_fold",
+            vec![
+                "accumulator_in".to_string(),
+                "commitment".to_string(),
+                "accumulator_out".to_string(),
+            ],
+            fold_rows,
+        )?;
+
+        let previous = match &self.witness.previous_commitment {
+            Some(value) => Self::decode_field(parameters, value)?,
+            None => FieldElement::zero(parameters.modulus()),
+        };
+        let state_element = Self::decode_field(parameters, &self.witness.state_commitment)?;
+        let pruning_element = Self::decode_field(parameters, &self.witness.pruning_commitment)?;
+        let state_pruning_digest = hasher.hash(&[
+            state_element,
+            pruning_element,
+            parameters.element_from_u64(self.witness.block_height),
+        ]);
+        let aggregate = hasher.hash(&[
+            previous.clone(),
+            state_pruning_digest.clone(),
+            accumulator.clone(),
+        ]);
+        let witness_commitment =
+            Self::decode_field(parameters, &self.witness.aggregated_commitment)?;
+        let summary_segment = TraceSegment::new(
+            "aggregation",
+            vec![
+                "previous".to_string(),
+                "state_pruning_digest".to_string(),
+                "tx_digest".to_string(),
+                "aggregate_computed".to_string(),
+                "aggregate_witness".to_string(),
+            ],
+            vec![vec![
+                previous,
+                state_pruning_digest,
+                accumulator,
+                aggregate.clone(),
+                witness_commitment,
+            ]],
+        )?;
+
+        ExecutionTrace::from_segments(vec![fold_segment, summary_segment])
+    }
+
+    fn define_air(
+        &self,
+        parameters: &StarkParameters,
+        trace: &ExecutionTrace,
+    ) -> Result<AirDefinition, CircuitError> {
+        let fold_segment = "tx_fold";
+        let accumulator_in = AirColumn::new(fold_segment, "accumulator_in");
+        let accumulator_out = AirColumn::new(fold_segment, "accumulator_out");
+
+        let aggregation_segment = "aggregation";
+        let aggregate_computed = AirColumn::new(aggregation_segment, "aggregate_computed");
+        let aggregate_witness = AirColumn::new(aggregation_segment, "aggregate_witness");
+
+        let zero = FieldElement::zero(parameters.modulus());
+
+        let mut constraints = vec![
+            AirConstraint::new(
+                "fold_initial_accumulator",
+                fold_segment,
+                ConstraintDomain::FirstRow,
+                AirExpression::difference(
+                    accumulator_in.expr(),
+                    AirExpression::constant(zero.clone()),
+                ),
+            ),
+            AirConstraint::new(
+                "fold_links_rows",
+                fold_segment,
+                ConstraintDomain::Range {
+                    start: 1,
+                    end: None,
+                },
+                AirExpression::difference(accumulator_in.expr(), accumulator_out.shifted(-1)),
+            ),
+            AirConstraint::new(
+                "aggregate_matches_witness",
+                aggregation_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(aggregate_computed.expr(), aggregate_witness.expr()),
+            ),
+        ];
+
+        if trace
+            .segments
+            .iter()
+            .find(|segment| segment.name == fold_segment)
+            .map(|segment| segment.rows.is_empty())
+            .unwrap_or(false)
+        {
+            constraints.retain(|constraint| constraint.segment != fold_segment);
+        }
+
+        Ok(AirDefinition::new(constraints))
+    }
+}

--- a/src/stwo/circuit/state.rs
+++ b/src/stwo/circuit/state.rs
@@ -1,0 +1,360 @@
+//! State transition STARK constraints blueprint implementation.
+
+use std::collections::HashMap;
+
+use crate::ledger::compute_merkle_root;
+use crate::reputation::{ReputationWeights, Tier, current_timestamp};
+use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, ConstraintDomain};
+use crate::stwo::params::StarkParameters;
+use crate::types::{Account, SignedTransaction, Stake};
+use serde_json::to_vec;
+
+use super::{
+    CircuitError, ExecutionTrace, StarkCircuit, TraceSegment, string_to_field,
+    transaction::TransactionCircuit, transaction::TransactionWitness,
+};
+
+/// Witness for the state transition circuit.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct StateWitness {
+    pub prev_state_root: String,
+    pub new_state_root: String,
+    pub transactions: Vec<SignedTransaction>,
+    pub accounts_before: Vec<Account>,
+    pub accounts_after: Vec<Account>,
+    pub required_tier: Tier,
+    pub reputation_weights: ReputationWeights,
+}
+
+/// Circuit verifying batched state transitions.
+#[derive(Debug)]
+pub struct StateCircuit {
+    pub witness: StateWitness,
+}
+
+impl StateCircuit {
+    pub fn new(witness: StateWitness) -> Self {
+        Self { witness }
+    }
+
+    fn sort_accounts(accounts: &mut Vec<Account>) {
+        accounts.sort_by(|a, b| a.address.cmp(&b.address));
+    }
+
+    fn compute_root(accounts: &mut Vec<Account>) -> String {
+        Self::sort_accounts(accounts);
+        let mut leaves = accounts
+            .iter()
+            .map(|account| {
+                let bytes = serde_json::to_vec(account).expect("serialize account");
+                <[u8; 32]>::from(stwo::core::vcs::blake2_hash::Blake2sHasher::hash(
+                    bytes.as_slice(),
+                ))
+            })
+            .collect::<Vec<_>>();
+        hex::encode(compute_merkle_root(&mut leaves))
+    }
+
+    fn check_roots(&self) -> Result<(), CircuitError> {
+        let mut before = self.witness.accounts_before.clone();
+        let mut after = self.witness.accounts_after.clone();
+        let prev_root = Self::compute_root(&mut before);
+        if prev_root != self.witness.prev_state_root {
+            return Err(CircuitError::ConstraintViolation(
+                "previous state root mismatch".into(),
+            ));
+        }
+        let new_root = Self::compute_root(&mut after);
+        if new_root != self.witness.new_state_root {
+            return Err(CircuitError::ConstraintViolation(
+                "new state root mismatch".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn replay_transactions(&self) -> Result<Vec<Account>, CircuitError> {
+        let mut state: HashMap<_, _> = self
+            .witness
+            .accounts_before
+            .iter()
+            .cloned()
+            .map(|account| (account.address.clone(), account))
+            .collect();
+
+        for tx in &self.witness.transactions {
+            let sender = state.get(&tx.payload.from).cloned().ok_or_else(|| {
+                CircuitError::ConstraintViolation("sender account missing".into())
+            })?;
+            let receiver = state.get(&tx.payload.to).cloned();
+            let witness = TransactionWitness {
+                signed_tx: tx.clone(),
+                sender_account: sender.clone(),
+                receiver_account: receiver.clone(),
+                required_tier: self.witness.required_tier.clone(),
+                reputation_weights: self.witness.reputation_weights.clone(),
+            };
+            TransactionCircuit::new(witness).evaluate_constraints()?;
+
+            let total = tx
+                .payload
+                .amount
+                .checked_add(tx.payload.fee as u128)
+                .ok_or_else(|| CircuitError::ConstraintViolation("amount overflow".into()))?;
+            let sender_mut = state
+                .get_mut(&tx.payload.from)
+                .ok_or_else(|| CircuitError::ConstraintViolation("sender missing".into()))?;
+            if sender_mut.balance < total {
+                return Err(CircuitError::ConstraintViolation(
+                    "insufficient balance during state replay".into(),
+                ));
+            }
+            sender_mut.balance -= total;
+            sender_mut.nonce += 1;
+
+            let recipient = state
+                .entry(tx.payload.to.clone())
+                .or_insert_with(|| Account::new(tx.payload.to.clone(), 0, Stake::default()));
+            recipient.balance = recipient.balance.saturating_add(tx.payload.amount);
+            recipient
+                .reputation
+                .recompute_score(&self.witness.reputation_weights, current_timestamp());
+        }
+
+        let mut accounts: Vec<Account> = state.into_values().collect();
+        Self::sort_accounts(&mut accounts);
+        Ok(accounts)
+    }
+
+    fn check_resulting_accounts(&self) -> Result<(), CircuitError> {
+        let expected = self.replay_transactions()?;
+        let mut provided = self.witness.accounts_after.clone();
+        Self::sort_accounts(&mut provided);
+        let expected_serialized = expected
+            .iter()
+            .map(|account| {
+                to_vec(account).map_err(|err| {
+                    CircuitError::InvalidWitness(format!(
+                        "failed to serialize expected account: {err}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let provided_serialized = provided
+            .iter()
+            .map(|account| {
+                to_vec(account).map_err(|err| {
+                    CircuitError::InvalidWitness(format!(
+                        "failed to serialize provided account: {err}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if expected_serialized != provided_serialized {
+            return Err(CircuitError::ConstraintViolation(
+                "resulting account set does not match provided witness".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl StarkCircuit for StateCircuit {
+    fn name(&self) -> &'static str {
+        "state"
+    }
+
+    fn evaluate_constraints(&self) -> Result<(), CircuitError> {
+        self.check_roots()?;
+        self.check_resulting_accounts()?;
+        Ok(())
+    }
+
+    fn generate_trace(&self, parameters: &StarkParameters) -> Result<ExecutionTrace, CircuitError> {
+        let mut state: HashMap<_, _> = self
+            .witness
+            .accounts_before
+            .iter()
+            .cloned()
+            .map(|account| (account.address.clone(), account))
+            .collect();
+
+        let mut transition_rows = Vec::new();
+        for tx in &self.witness.transactions {
+            let sender = state.get(&tx.payload.from).cloned().ok_or_else(|| {
+                CircuitError::ConstraintViolation("sender account missing".into())
+            })?;
+            let receiver_before = state.get(&tx.payload.to).cloned();
+            let total = tx
+                .payload
+                .amount
+                .checked_add(tx.payload.fee as u128)
+                .ok_or_else(|| CircuitError::ConstraintViolation("amount overflow".into()))?;
+            let sender_after_balance = sender
+                .balance
+                .checked_sub(total)
+                .ok_or_else(|| CircuitError::ConstraintViolation("insufficient balance".into()))?;
+
+            let sender_mut = state
+                .get_mut(&tx.payload.from)
+                .ok_or_else(|| CircuitError::ConstraintViolation("sender missing".into()))?;
+            sender_mut.balance = sender_after_balance;
+            sender_mut.nonce = sender.nonce + 1;
+
+            let recipient_entry = state
+                .entry(tx.payload.to.clone())
+                .or_insert_with(|| Account::new(tx.payload.to.clone(), 0, Stake::default()));
+            let receiver_balance_before = receiver_before
+                .as_ref()
+                .map(|account| account.balance)
+                .unwrap_or(0);
+            let receiver_balance_after = recipient_entry.balance.saturating_add(tx.payload.amount);
+            recipient_entry.balance = receiver_balance_after;
+            recipient_entry
+                .reputation
+                .recompute_score(&self.witness.reputation_weights, current_timestamp());
+
+            let row = vec![
+                string_to_field(parameters, &tx.payload.from),
+                string_to_field(parameters, &tx.payload.to),
+                parameters.element_from_u128(tx.payload.amount),
+                parameters.element_from_u64(tx.payload.fee as u64),
+                parameters.element_from_u128(sender.balance),
+                parameters.element_from_u128(sender_after_balance),
+                parameters.element_from_u128(receiver_balance_before),
+                parameters.element_from_u128(receiver_balance_after),
+                parameters.element_from_u64(sender.nonce),
+                parameters.element_from_u64(sender.nonce + 1),
+            ];
+            transition_rows.push(row);
+        }
+
+        let transitions_segment = TraceSegment::new(
+            "transitions",
+            vec![
+                "sender".to_string(),
+                "receiver".to_string(),
+                "amount".to_string(),
+                "fee".to_string(),
+                "sender_balance_before".to_string(),
+                "sender_balance_after".to_string(),
+                "receiver_balance_before".to_string(),
+                "receiver_balance_after".to_string(),
+                "nonce_before".to_string(),
+                "nonce_after".to_string(),
+            ],
+            transition_rows,
+        )?;
+
+        let mut accounts_before = self.witness.accounts_before.clone();
+        let mut accounts_after = self.witness.accounts_after.clone();
+        let computed_prev_root = Self::compute_root(&mut accounts_before);
+        let computed_new_root = Self::compute_root(&mut accounts_after);
+        let summary_row = vec![
+            string_to_field(parameters, &self.witness.prev_state_root),
+            string_to_field(parameters, &computed_prev_root),
+            string_to_field(parameters, &self.witness.new_state_root),
+            string_to_field(parameters, &computed_new_root),
+            parameters.element_from_u64(self.witness.transactions.len() as u64),
+        ];
+        let summary_segment = TraceSegment::new(
+            "roots",
+            vec![
+                "prev_root_witness".to_string(),
+                "prev_root_computed".to_string(),
+                "new_root_witness".to_string(),
+                "new_root_computed".to_string(),
+                "tx_count".to_string(),
+            ],
+            vec![summary_row],
+        )?;
+
+        ExecutionTrace::from_segments(vec![transitions_segment, summary_segment])
+    }
+
+    fn define_air(
+        &self,
+        parameters: &StarkParameters,
+        trace: &ExecutionTrace,
+    ) -> Result<AirDefinition, CircuitError> {
+        let transitions_segment = "transitions";
+        let sender_before = AirColumn::new(transitions_segment, "sender_balance_before");
+        let sender_after = AirColumn::new(transitions_segment, "sender_balance_after");
+        let amount = AirColumn::new(transitions_segment, "amount");
+        let fee = AirColumn::new(transitions_segment, "fee");
+        let receiver_before = AirColumn::new(transitions_segment, "receiver_balance_before");
+        let receiver_after = AirColumn::new(transitions_segment, "receiver_balance_after");
+        let nonce_before = AirColumn::new(transitions_segment, "nonce_before");
+        let nonce_after = AirColumn::new(transitions_segment, "nonce_after");
+
+        let roots_segment = "roots";
+        let prev_root_witness = AirColumn::new(roots_segment, "prev_root_witness");
+        let prev_root_computed = AirColumn::new(roots_segment, "prev_root_computed");
+        let new_root_witness = AirColumn::new(roots_segment, "new_root_witness");
+        let new_root_computed = AirColumn::new(roots_segment, "new_root_computed");
+        let tx_count = AirColumn::new(roots_segment, "tx_count");
+
+        let one = parameters.element_from_u64(1);
+        let tx_len = parameters.element_from_u64(self.witness.transactions.len() as u64);
+
+        let mut constraints = vec![
+            AirConstraint::new(
+                "state_sender_balance",
+                transitions_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    sender_before.expr(),
+                    AirExpression::sum(vec![sender_after.expr(), amount.expr(), fee.expr()]),
+                ),
+            ),
+            AirConstraint::new(
+                "state_receiver_balance",
+                transitions_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    receiver_after.expr(),
+                    AirExpression::sum(vec![receiver_before.expr(), amount.expr()]),
+                ),
+            ),
+            AirConstraint::new(
+                "state_nonce_increment",
+                transitions_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    AirExpression::difference(nonce_after.expr(), nonce_before.expr()),
+                    AirExpression::constant(one.clone()),
+                ),
+            ),
+            AirConstraint::new(
+                "state_prev_root_matches",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(prev_root_witness.expr(), prev_root_computed.expr()),
+            ),
+            AirConstraint::new(
+                "state_new_root_matches",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(new_root_witness.expr(), new_root_computed.expr()),
+            ),
+            AirConstraint::new(
+                "state_tx_count",
+                roots_segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(tx_count.expr(), AirExpression::constant(tx_len)),
+            ),
+        ];
+
+        if trace
+            .segments
+            .iter()
+            .find(|segment| segment.name == transitions_segment)
+            .map(|segment| segment.rows.is_empty())
+            .unwrap_or(false)
+        {
+            constraints.retain(|constraint| constraint.segment != transitions_segment);
+        }
+
+        Ok(AirDefinition::new(constraints))
+    }
+}

--- a/src/stwo/circuit/transaction.rs
+++ b/src/stwo/circuit/transaction.rs
@@ -1,0 +1,249 @@
+//! Transaction STARK constraints blueprint implementation.
+
+use crate::reputation::{ReputationWeights, Tier};
+use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, ConstraintDomain};
+use crate::stwo::params::{FieldElement, StarkParameters};
+use crate::types::{Account, SignedTransaction};
+
+use super::{CircuitError, ExecutionTrace, StarkCircuit, TraceSegment, string_to_field};
+
+/// Witness data required to validate a transaction constraint system.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TransactionWitness {
+    pub signed_tx: SignedTransaction,
+    pub sender_account: Account,
+    pub receiver_account: Option<Account>,
+    pub required_tier: Tier,
+    pub reputation_weights: ReputationWeights,
+}
+
+impl TransactionWitness {
+    pub fn sender_balance(&self) -> u128 {
+        self.sender_account.balance
+    }
+}
+
+/// Circuit capturing the constraints for a single transaction proof.
+#[derive(Debug)]
+pub struct TransactionCircuit {
+    pub witness: TransactionWitness,
+}
+
+impl TransactionCircuit {
+    pub fn new(witness: TransactionWitness) -> Self {
+        Self { witness }
+    }
+
+    fn check_signature(&self) -> Result<(), CircuitError> {
+        self.witness
+            .signed_tx
+            .verify()
+            .map_err(|err| CircuitError::ConstraintViolation(err.to_string()))
+    }
+
+    fn check_balances(&self) -> Result<(), CircuitError> {
+        let tx = &self.witness.signed_tx.payload;
+        let total = tx
+            .amount
+            .checked_add(tx.fee as u128)
+            .ok_or_else(|| CircuitError::ConstraintViolation("amount overflow".into()))?;
+        if self.witness.sender_account.balance < total {
+            return Err(CircuitError::ConstraintViolation(
+                "sender balance insufficient".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn check_nonce(&self) -> Result<(), CircuitError> {
+        let tx = &self.witness.signed_tx.payload;
+        if self.witness.sender_account.nonce + 1 != tx.nonce {
+            return Err(CircuitError::ConstraintViolation(
+                "sender nonce does not match witness".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn check_tier(&self) -> Result<(), CircuitError> {
+        if self.witness.sender_account.reputation.tier < self.witness.required_tier {
+            return Err(CircuitError::ConstraintViolation(format!(
+                "sender tier {} below required {}",
+                self.witness.sender_account.reputation.tier, self.witness.required_tier
+            )));
+        }
+        Ok(())
+    }
+
+    fn check_reputation_decay(&self) -> Result<(), CircuitError> {
+        let tx_timestamp = self.witness.signed_tx.payload.timestamp;
+        if tx_timestamp < self.witness.sender_account.reputation.last_decay_timestamp {
+            return Err(CircuitError::ConstraintViolation(
+                "transaction timestamp precedes reputation decay reference".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl StarkCircuit for TransactionCircuit {
+    fn name(&self) -> &'static str {
+        "transaction"
+    }
+
+    fn evaluate_constraints(&self) -> Result<(), CircuitError> {
+        self.check_signature()?;
+        self.check_balances()?;
+        self.check_nonce()?;
+        self.check_tier()?;
+        self.check_reputation_decay()?;
+
+        let receiver = &self.witness.receiver_account;
+        if let Some(receiver_account) = receiver {
+            if receiver_account.address != self.witness.signed_tx.payload.to {
+                return Err(CircuitError::ConstraintViolation(
+                    "receiver account mismatch".into(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn generate_trace(&self, parameters: &StarkParameters) -> Result<ExecutionTrace, CircuitError> {
+        let tx = &self.witness.signed_tx;
+        let payload = &tx.payload;
+        let total = payload
+            .amount
+            .checked_add(payload.fee as u128)
+            .ok_or_else(|| CircuitError::ConstraintViolation("amount overflow".into()))?;
+        let sender_balance_before = self.witness.sender_account.balance;
+        let sender_balance_after = sender_balance_before
+            .checked_sub(total)
+            .ok_or_else(|| CircuitError::ConstraintViolation("sender balance underflow".into()))?;
+        let (receiver_balance_before, receiver_balance_after) = match &self.witness.receiver_account
+        {
+            Some(account) => {
+                let before = account.balance;
+                let after = before.saturating_add(payload.amount);
+                (before, after)
+            }
+            None => (0u128, payload.amount),
+        };
+
+        let tier_to_field = |tier: &Tier| -> FieldElement {
+            let rank = match tier {
+                Tier::Tl0 => 0u64,
+                Tier::Tl1 => 1u64,
+                Tier::Tl2 => 2u64,
+                Tier::Tl3 => 3u64,
+                Tier::Tl4 => 4u64,
+                Tier::Tl5 => 5u64,
+            };
+            parameters.element_from_u64(rank)
+        };
+
+        let signature_flag = parameters.element_from_u64(1);
+        let columns = vec![
+            "sender".to_string(),
+            "receiver".to_string(),
+            "amount".to_string(),
+            "fee".to_string(),
+            "total_spent".to_string(),
+            "sender_balance_before".to_string(),
+            "sender_balance_after".to_string(),
+            "receiver_balance_before".to_string(),
+            "receiver_balance_after".to_string(),
+            "nonce_before".to_string(),
+            "nonce_after".to_string(),
+            "required_tier".to_string(),
+            "actual_tier".to_string(),
+            "signature_valid".to_string(),
+        ];
+        let row = vec![
+            string_to_field(parameters, &payload.from),
+            string_to_field(parameters, &payload.to),
+            parameters.element_from_u128(payload.amount),
+            parameters.element_from_u64(payload.fee as u64),
+            parameters.element_from_u128(total),
+            parameters.element_from_u128(sender_balance_before),
+            parameters.element_from_u128(sender_balance_after),
+            parameters.element_from_u128(receiver_balance_before),
+            parameters.element_from_u128(receiver_balance_after),
+            parameters.element_from_u64(self.witness.sender_account.nonce),
+            parameters.element_from_u64(payload.nonce),
+            tier_to_field(&self.witness.required_tier),
+            tier_to_field(&self.witness.sender_account.reputation.tier),
+            signature_flag,
+        ];
+        let segment = TraceSegment::new("transaction", columns, vec![row])?;
+        ExecutionTrace::single(segment)
+    }
+
+    fn define_air(
+        &self,
+        parameters: &StarkParameters,
+        _trace: &ExecutionTrace,
+    ) -> Result<AirDefinition, CircuitError> {
+        let segment = "transaction";
+        let amount = AirColumn::new(segment, "amount");
+        let fee = AirColumn::new(segment, "fee");
+        let total = AirColumn::new(segment, "total_spent");
+        let sender_before = AirColumn::new(segment, "sender_balance_before");
+        let sender_after = AirColumn::new(segment, "sender_balance_after");
+        let receiver_before = AirColumn::new(segment, "receiver_balance_before");
+        let receiver_after = AirColumn::new(segment, "receiver_balance_after");
+        let nonce_before = AirColumn::new(segment, "nonce_before");
+        let nonce_after = AirColumn::new(segment, "nonce_after");
+        let signature_valid = AirColumn::new(segment, "signature_valid");
+
+        let one = parameters.element_from_u64(1);
+
+        let constraints = vec![
+            AirConstraint::new(
+                "total_matches_amount_fee",
+                segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    total.expr(),
+                    AirExpression::sum(vec![amount.expr(), fee.expr()]),
+                ),
+            ),
+            AirConstraint::new(
+                "sender_balance_updates",
+                segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    sender_before.expr(),
+                    AirExpression::sum(vec![sender_after.expr(), total.expr()]),
+                ),
+            ),
+            AirConstraint::new(
+                "receiver_balance_updates",
+                segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    receiver_after.expr(),
+                    AirExpression::sum(vec![receiver_before.expr(), amount.expr()]),
+                ),
+            ),
+            AirConstraint::new(
+                "nonce_increments",
+                segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(
+                    AirExpression::difference(nonce_after.expr(), nonce_before.expr()),
+                    AirExpression::constant(one.clone()),
+                ),
+            ),
+            AirConstraint::new(
+                "signature_flag_set",
+                segment,
+                ConstraintDomain::AllRows,
+                AirExpression::difference(signature_valid.expr(), AirExpression::constant(one)),
+            ),
+        ];
+
+        Ok(AirDefinition::new(constraints))
+    }
+}

--- a/src/stwo/ffi/mod.rs
+++ b/src/stwo/ffi/mod.rs
@@ -1,0 +1,32 @@
+//! FFI and accelerator bindings for the STWO/STARK stack.
+
+/// Placeholder trait capturing GPU or specialized prover acceleration.
+pub trait ProverAccelerator {
+    /// Returns whether the accelerator is currently available.
+    fn is_available(&self) -> bool;
+
+    /// Submits a witness computation job and returns a handle to the result bytes.
+    fn submit_job(&self, witness: &[u8]) -> Result<Vec<u8>, AcceleratorError>;
+}
+
+/// Errors raised while interacting with external accelerators.
+#[derive(Debug, thiserror::Error)]
+pub enum AcceleratorError {
+    #[error("accelerator backend not configured")]
+    NotConfigured,
+    #[error("accelerator job failed: {0}")]
+    JobFailed(String),
+}
+
+/// No-op accelerator used while native integrations are under development.
+pub struct NullAccelerator;
+
+impl ProverAccelerator for NullAccelerator {
+    fn is_available(&self) -> bool {
+        false
+    }
+
+    fn submit_job(&self, _witness: &[u8]) -> Result<Vec<u8>, AcceleratorError> {
+        Err(AcceleratorError::NotConfigured)
+    }
+}

--- a/src/stwo/fri.rs
+++ b/src/stwo/fri.rs
@@ -1,0 +1,232 @@
+//! Deterministic FRI-style polynomial commitment scaffolding.
+//!
+//! This module provides a lightweight polynomial commitment builder that
+//! emulates the structure of a FRI prover. While it does not implement the
+//! full low-level cryptographic primitives of a production STARK backend, the
+//! scaffolding computes deterministic folding challenges, evaluation queries,
+//! and Poseidon-backed Merkle commitments so that verifiers can faithfully
+//! reproduce the prover's output. The resulting artifacts are embedded in
+//! [`StarkProof`](crate::stwo::proof::StarkProof) instances.
+
+use std::collections::HashSet;
+
+use num_bigint::BigUint;
+use num_traits::ToPrimitive;
+
+use crate::stwo::circuit::ExecutionTrace;
+use crate::stwo::params::{FieldElement, PoseidonHasher, StarkParameters};
+use crate::stwo::proof::{FriProof, FriQuery, PolynomialCommitment};
+
+/// Number of queries collected for every column commitment.
+const DEFAULT_QUERY_COUNT: usize = 4;
+
+/// Helper encapsulating the deterministic FRI-style commitment process.
+pub struct FriProver<'a> {
+    parameters: &'a StarkParameters,
+    hasher: PoseidonHasher,
+    query_count: usize,
+}
+
+impl<'a> FriProver<'a> {
+    /// Create a prover helper backed by the supplied STARK parameters.
+    pub fn new(parameters: &'a StarkParameters) -> Self {
+        Self {
+            parameters,
+            hasher: parameters.poseidon_hasher(),
+            query_count: DEFAULT_QUERY_COUNT,
+        }
+    }
+
+    /// Override the number of queries collected for every column commitment.
+    #[allow(dead_code)]
+    pub fn with_query_count(mut self, queries: usize) -> Self {
+        self.query_count = queries.max(1);
+        self
+    }
+
+    /// Generate a deterministic FRI-style commitment proof for the supplied
+    /// execution trace and public inputs.
+    pub fn prove(&self, trace: &ExecutionTrace, public_inputs: &[FieldElement]) -> FriProof {
+        let challenges = self.derive_challenges(trace, public_inputs);
+        let mut commitments = Vec::new();
+        for segment in &trace.segments {
+            let domain_size = next_power_of_two(segment.rows.len());
+            for (column_index, column_name) in segment.columns.iter().enumerate() {
+                let mut evaluations = Vec::with_capacity(domain_size);
+                for row in &segment.rows {
+                    evaluations.push(row[column_index].clone());
+                }
+                while evaluations.len() < domain_size {
+                    evaluations.push(FieldElement::zero(self.parameters.modulus()));
+                }
+                let leaf_hashes = self.hash_leaves(&evaluations);
+                let tree = build_merkle_tree(&self.hasher, leaf_hashes);
+                let root = tree
+                    .last()
+                    .and_then(|level| level.first())
+                    .cloned()
+                    .unwrap_or_else(|| FieldElement::zero(self.parameters.modulus()));
+                let label = format!("{}::{}", segment.name, column_name);
+                let queries = self.build_queries(
+                    &label,
+                    domain_size,
+                    &evaluations,
+                    &tree,
+                    public_inputs,
+                    &challenges,
+                );
+                commitments.push(PolynomialCommitment {
+                    segment: segment.name.clone(),
+                    column: column_name.clone(),
+                    domain_size,
+                    merkle_root: root,
+                    queries,
+                });
+            }
+        }
+        FriProof {
+            commitments,
+            challenges,
+        }
+    }
+
+    fn derive_challenges(
+        &self,
+        trace: &ExecutionTrace,
+        public_inputs: &[FieldElement],
+    ) -> Vec<FieldElement> {
+        let mut sponge = self.hasher.sponge();
+        sponge.absorb_elements(public_inputs);
+        for segment in &trace.segments {
+            let name_element =
+                FieldElement::from_bytes(segment.name.as_bytes(), self.hasher.modulus());
+            sponge.absorb_elements(&[name_element]);
+            for column in &segment.columns {
+                let column_element =
+                    FieldElement::from_bytes(column.as_bytes(), self.hasher.modulus());
+                sponge.absorb_elements(&[column_element]);
+            }
+        }
+        sponge.finish_absorbing();
+        sponge.squeeze_many(2)
+    }
+
+    fn build_queries(
+        &self,
+        label: &str,
+        domain_size: usize,
+        evaluations: &[FieldElement],
+        tree: &[Vec<FieldElement>],
+        public_inputs: &[FieldElement],
+        challenges: &[FieldElement],
+    ) -> Vec<FriQuery> {
+        let indices = self.derive_query_indices(label, domain_size, public_inputs, challenges);
+        indices
+            .into_iter()
+            .map(|index| {
+                let evaluation = evaluations[index].clone();
+                let auth_path = build_authentication_path(tree, index);
+                FriQuery {
+                    index,
+                    evaluation,
+                    auth_path,
+                }
+            })
+            .collect()
+    }
+
+    fn derive_query_indices(
+        &self,
+        label: &str,
+        domain_size: usize,
+        public_inputs: &[FieldElement],
+        challenges: &[FieldElement],
+    ) -> Vec<usize> {
+        if domain_size == 0 {
+            return vec![];
+        }
+        let mut sponge = self.hasher.sponge();
+        sponge.absorb_elements(public_inputs);
+        sponge.absorb_elements(challenges);
+        sponge.absorb_bytes(&[label.as_bytes().to_vec()]);
+        sponge.finish_absorbing();
+        let modulus = BigUint::from(domain_size);
+        let mut indices = Vec::with_capacity(self.query_count);
+        let mut seen = HashSet::new();
+        while indices.len() < self.query_count {
+            let element = sponge.squeeze();
+            let value = element.value() % &modulus;
+            let index = value
+                .to_usize()
+                .unwrap_or_else(|| (value % &modulus).to_usize().unwrap_or(0));
+            if seen.insert(index) {
+                indices.push(index);
+            }
+        }
+        indices.sort_unstable();
+        indices
+    }
+
+    fn hash_leaves(&self, evaluations: &[FieldElement]) -> Vec<FieldElement> {
+        evaluations
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let index_element = FieldElement::from_u64(index as u64, self.parameters.modulus());
+                self.hasher.hash(&[value.clone(), index_element])
+            })
+            .collect()
+    }
+}
+
+fn next_power_of_two(value: usize) -> usize {
+    match value {
+        0 => 1,
+        1 => 1,
+        _ => value.next_power_of_two(),
+    }
+}
+
+fn build_merkle_tree(hasher: &PoseidonHasher, leaves: Vec<FieldElement>) -> Vec<Vec<FieldElement>> {
+    let mut levels = Vec::new();
+    if leaves.is_empty() {
+        return levels;
+    }
+    let mut current = leaves;
+    levels.push(current.clone());
+    while current.len() > 1 {
+        if current.len() % 2 == 1 {
+            let last = current.last().cloned().unwrap();
+            current.push(last);
+        }
+        let mut next = Vec::with_capacity(current.len() / 2);
+        for chunk in current.chunks(2) {
+            let left = chunk[0].clone();
+            let right = chunk[1].clone();
+            next.push(hasher.hash(&[left, right]));
+        }
+        levels.push(next.clone());
+        current = next;
+    }
+    levels
+}
+
+fn build_authentication_path(tree: &[Vec<FieldElement>], mut index: usize) -> Vec<FieldElement> {
+    let mut path = Vec::new();
+    if tree.is_empty() {
+        return path;
+    }
+    for level in tree.iter() {
+        if level.len() == 1 {
+            break;
+        }
+        let sibling_index = if index % 2 == 0 { index + 1 } else { index - 1 };
+        let sibling = level
+            .get(sibling_index)
+            .cloned()
+            .unwrap_or_else(|| level[index].clone());
+        path.push(sibling);
+        index /= 2;
+    }
+    path
+}

--- a/src/stwo/mod.rs
+++ b/src/stwo/mod.rs
@@ -1,0 +1,11 @@
+//! STWO/STARK integration module hierarchy.
+
+pub mod aggregation;
+pub mod air;
+pub mod circuit;
+pub mod ffi;
+pub mod fri;
+pub mod params;
+pub mod proof;
+pub mod prover;
+pub mod verifier;

--- a/src/stwo/params/mod.rs
+++ b/src/stwo/params/mod.rs
@@ -1,0 +1,655 @@
+//! Domain parameters and primitives for STWO/STARK integration.
+
+use blake2::{Blake2s256, Digest};
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::{One, Signed, Zero};
+use serde::{Deserialize, Serialize};
+
+/// Convenience alias for results returned by field arithmetic helpers.
+pub type FieldResult<T> = Result<T, FieldError>;
+
+/// Errors that can be raised while working inside the STARK field.
+#[derive(Debug, thiserror::Error)]
+pub enum FieldError {
+    #[error("field modulus mismatch")]
+    ModulusMismatch,
+    #[error("element has no multiplicative inverse")]
+    NotInvertible,
+}
+
+/// Represents an element of the prime field used by the STARK circuits.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldElement {
+    value: BigUint,
+    modulus: BigUint,
+}
+
+impl FieldElement {
+    /// Create a new field element reducing `value` modulo `modulus`.
+    pub fn new(value: BigUint, modulus: BigUint) -> Self {
+        debug_assert!(!modulus.is_zero(), "field modulus must be non-zero");
+        let value = value % &modulus;
+        Self { value, modulus }
+    }
+
+    /// Construct an element from a native `u64` value.
+    pub fn from_u64(value: u64, modulus: &BigUint) -> Self {
+        Self::new(BigUint::from(value), modulus.clone())
+    }
+
+    /// Construct an element from a native `u128` value.
+    pub fn from_u128(value: u128, modulus: &BigUint) -> Self {
+        Self::new(BigUint::from(value), modulus.clone())
+    }
+
+    /// Construct an element from an arbitrary byte slice.
+    pub fn from_bytes(bytes: &[u8], modulus: &BigUint) -> Self {
+        Self::new(BigUint::from_bytes_be(bytes), modulus.clone())
+    }
+
+    /// Return the canonical big integer representation of the element.
+    pub fn value(&self) -> &BigUint {
+        &self.value
+    }
+
+    /// Return the modulus that defines the prime field.
+    pub fn modulus(&self) -> &BigUint {
+        &self.modulus
+    }
+
+    fn ensure_same_modulus(&self, other: &FieldElement) -> FieldResult<()> {
+        if self.modulus == other.modulus {
+            Ok(())
+        } else {
+            Err(FieldError::ModulusMismatch)
+        }
+    }
+
+    /// Add two field elements.
+    pub fn add(&self, other: &FieldElement) -> FieldResult<FieldElement> {
+        self.ensure_same_modulus(other)?;
+        Ok(FieldElement::new(
+            (&self.value + &other.value) % &self.modulus,
+            self.modulus.clone(),
+        ))
+    }
+
+    /// Subtract one field element from another.
+    pub fn sub(&self, other: &FieldElement) -> FieldResult<FieldElement> {
+        self.ensure_same_modulus(other)?;
+        let mut lhs = self.value.clone();
+        if lhs >= other.value {
+            lhs -= &other.value;
+        } else {
+            lhs = (&lhs + &self.modulus) - &other.value;
+        }
+        Ok(FieldElement::new(lhs % &self.modulus, self.modulus.clone()))
+    }
+
+    /// Multiply two field elements.
+    pub fn mul(&self, other: &FieldElement) -> FieldResult<FieldElement> {
+        self.ensure_same_modulus(other)?;
+        Ok(FieldElement::new(
+            (&self.value * &other.value) % &self.modulus,
+            self.modulus.clone(),
+        ))
+    }
+
+    /// Compute the multiplicative inverse of the element.
+    pub fn inverse(&self) -> FieldResult<FieldElement> {
+        if self.value.is_zero() {
+            return Err(FieldError::NotInvertible);
+        }
+        match mod_inverse(&self.value, &self.modulus) {
+            Some(inv) => Ok(FieldElement::new(inv, self.modulus.clone())),
+            None => Err(FieldError::NotInvertible),
+        }
+    }
+
+    /// Raise the element to an unsigned power.
+    pub fn pow(&self, exponent: u64) -> FieldElement {
+        if exponent == 0 {
+            return FieldElement::new(BigUint::one(), self.modulus.clone());
+        }
+        let mut result = FieldElement::new(BigUint::one(), self.modulus.clone());
+        let mut base = self.clone();
+        let mut exp = exponent;
+        while exp > 0 {
+            if exp & 1 == 1 {
+                result = result.mul(&base).expect("modulus matches");
+            }
+            base = base.mul(&base).expect("modulus matches");
+            exp >>= 1;
+        }
+        result
+    }
+
+    /// Return the canonical big-endian bytes of the element.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.value.to_bytes_be()
+    }
+
+    /// Encode the element as a hex string for public inputs.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.to_bytes())
+    }
+
+    /// Create the additive identity of the field.
+    pub fn zero(modulus: &BigUint) -> Self {
+        FieldElement::new(BigUint::zero(), modulus.clone())
+    }
+
+    /// Create the multiplicative identity of the field.
+    pub fn one(modulus: &BigUint) -> Self {
+        FieldElement::new(BigUint::one(), modulus.clone())
+    }
+
+    /// Returns `true` when the element equals zero.
+    pub fn is_zero(&self) -> bool {
+        self.value.is_zero()
+    }
+}
+
+fn mod_inverse(value: &BigUint, modulus: &BigUint) -> Option<BigUint> {
+    let mut t = BigInt::zero();
+    let mut new_t = BigInt::one();
+    let mut r = BigInt::from_biguint(Sign::Plus, modulus.clone());
+    let mut new_r = BigInt::from_biguint(Sign::Plus, value.clone());
+
+    while !new_r.is_zero() {
+        let quotient = &r / &new_r;
+
+        let temp_t = t - &quotient * &new_t;
+        t = new_t;
+        new_t = temp_t;
+
+        let temp_r = r - &quotient * &new_r;
+        r = new_r;
+        new_r = temp_r;
+    }
+
+    if r != BigInt::one() {
+        return None;
+    }
+
+    if t.is_negative() {
+        t += BigInt::from_biguint(Sign::Plus, modulus.clone());
+    }
+
+    t.to_biguint()
+}
+
+/// Poseidon hash configuration parameters derived from the blueprint.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PoseidonConfig {
+    /// State width parameter (t).
+    pub width: usize,
+    /// Number of full rounds.
+    pub full_rounds: usize,
+    /// Number of partial rounds.
+    pub partial_rounds: usize,
+}
+
+impl Default for PoseidonConfig {
+    fn default() -> Self {
+        Self {
+            width: 3,
+            full_rounds: 8,
+            partial_rounds: 57,
+        }
+    }
+}
+
+/// Centralized container combining field and hash parameters.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StarkParameters {
+    pub field_modulus: BigUint,
+    pub poseidon: PoseidonConfig,
+}
+
+impl StarkParameters {
+    /// Returns the default parameters matching the STWO blueprint.
+    pub fn blueprint_default() -> Self {
+        let modulus = BigUint::parse_bytes(
+            b"18446744069414584321", // 2^64 - 2^32 + 1, a 64-bit prime.
+            10,
+        )
+        .expect("valid prime modulus");
+        Self {
+            field_modulus: modulus,
+            poseidon: PoseidonConfig::default(),
+        }
+    }
+
+    /// Return the prime field modulus.
+    pub fn modulus(&self) -> &BigUint {
+        &self.field_modulus
+    }
+
+    /// Convert a byte slice into a field element under the blueprint modulus.
+    pub fn element_from_bytes(&self, bytes: &[u8]) -> FieldElement {
+        FieldElement::from_bytes(bytes, &self.field_modulus)
+    }
+
+    /// Convert an unsigned 64-bit value into a field element.
+    pub fn element_from_u64(&self, value: u64) -> FieldElement {
+        FieldElement::from_u64(value, &self.field_modulus)
+    }
+
+    /// Convert an unsigned 128-bit value into a field element.
+    pub fn element_from_u128(&self, value: u128) -> FieldElement {
+        FieldElement::from_u128(value, &self.field_modulus)
+    }
+
+    /// Instantiate a Poseidon sponge over the blueprint parameters.
+    pub fn poseidon_hasher(&self) -> PoseidonHasher {
+        PoseidonHasher::new(self.poseidon.clone(), self.field_modulus.clone())
+    }
+}
+
+/// Minimal Poseidon permutation and sponge used for hashing public inputs. The
+/// parameters follow the STWO blueprint (t = 3, full = 8, partial = 57).
+#[derive(Clone, Debug)]
+pub struct PoseidonHasher {
+    params: PoseidonConfig,
+    modulus: BigUint,
+    round_constants: Vec<FieldElement>,
+    mds_matrix: Vec<Vec<FieldElement>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_arithmetic_behaves_under_blueprint_modulus() {
+        let params = StarkParameters::blueprint_default();
+        let modulus = params.modulus().clone();
+        let a = FieldElement::from_u64(5, &modulus);
+        let b = FieldElement::from_u64(7, &modulus);
+
+        let sum = a.add(&b).expect("matching moduli");
+        assert_eq!(sum, FieldElement::from_u64(12, &modulus));
+
+        let product = a.mul(&b).expect("matching moduli");
+        assert_eq!(product, FieldElement::from_u64(35, &modulus));
+
+        let inverse = a.inverse().expect("element invertible");
+        let identity = a.mul(&inverse).expect("matching moduli");
+        assert_eq!(identity, FieldElement::one(&modulus));
+
+        let power = b.pow(3);
+        assert_eq!(power, FieldElement::from_u64(343, &modulus));
+    }
+
+    #[test]
+    fn poseidon_hash_is_deterministic_and_input_sensitive() {
+        let params = StarkParameters::blueprint_default();
+        let hasher = params.poseidon_hasher();
+
+        let inputs = vec![
+            params.element_from_u64(1),
+            params.element_from_u64(2),
+            params.element_from_u64(3),
+        ];
+
+        let first = hasher.hash(&inputs);
+        let second = hasher.hash(&inputs);
+        assert_eq!(first, second, "hashing must be deterministic");
+
+        let mut tweaked = inputs.clone();
+        tweaked[1] = params.element_from_u64(5);
+        let different = hasher.hash(&tweaked);
+        assert_ne!(first, different, "different inputs must change the digest");
+    }
+}
+
+impl PoseidonHasher {
+    pub fn new(params: PoseidonConfig, modulus: BigUint) -> Self {
+        let round_constants = Self::derive_round_constants(&params, &modulus);
+        let mds_matrix = Self::derive_mds_matrix(&params, &modulus);
+        Self {
+            params,
+            modulus,
+            round_constants,
+            mds_matrix,
+        }
+    }
+
+    /// Return the underlying field modulus.
+    pub fn modulus(&self) -> &BigUint {
+        &self.modulus
+    }
+
+    fn derive_round_constants(params: &PoseidonConfig, modulus: &BigUint) -> Vec<FieldElement> {
+        let total_rounds = params.full_rounds + params.partial_rounds;
+        let mut constants = Vec::with_capacity(total_rounds * params.width);
+        for round in 0..total_rounds {
+            for position in 0..params.width {
+                let mut hasher = Blake2s256::new();
+                hasher.update(b"STWO_POSEIDON_RC");
+                hasher.update(&(round as u64).to_be_bytes());
+                hasher.update(&(position as u64).to_be_bytes());
+                let digest = hasher.finalize();
+                constants.push(FieldElement::from_bytes(&digest, modulus));
+            }
+        }
+        constants
+    }
+
+    fn derive_mds_matrix(params: &PoseidonConfig, modulus: &BigUint) -> Vec<Vec<FieldElement>> {
+        let width = params.width;
+        let mut attempt: u64 = 0;
+        loop {
+            let mut rows = Vec::with_capacity(width);
+            for row_idx in 0..width {
+                let mut row = Vec::with_capacity(width);
+                for col_idx in 0..width {
+                    let mut hasher = Blake2s256::new();
+                    hasher.update(b"STWO_POSEIDON_MDS");
+                    hasher.update(&attempt.to_be_bytes());
+                    hasher.update(&(row_idx as u64).to_be_bytes());
+                    hasher.update(&(col_idx as u64).to_be_bytes());
+                    let digest = hasher.finalize();
+                    let element = FieldElement::from_bytes(&digest, modulus);
+                    row.push(element);
+                }
+                rows.push(row);
+            }
+
+            if matrix_is_invertible(&rows) {
+                return rows;
+            }
+            attempt = attempt.checked_add(1).expect("attempt counter overflow");
+        }
+    }
+
+    fn apply_sbox(&self, state: &mut [FieldElement]) {
+        for element in state.iter_mut() {
+            *element = element.pow(5);
+        }
+    }
+
+    fn apply_partial_sbox(&self, state: &mut [FieldElement]) {
+        if let Some(first) = state.first_mut() {
+            *first = first.pow(5);
+        }
+    }
+
+    fn apply_mds(&self, state: &mut [FieldElement]) {
+        let mut new_state = Vec::with_capacity(state.len());
+        for row in &self.mds_matrix {
+            let mut acc = FieldElement::zero(&self.modulus);
+            for (value, coeff) in state.iter().zip(row.iter()) {
+                let product = coeff.mul(value).expect("modulus matches");
+                acc = acc.add(&product).expect("modulus matches");
+            }
+            new_state.push(acc);
+        }
+        for (slot, updated) in state.iter_mut().zip(new_state.into_iter()) {
+            *slot = updated;
+        }
+    }
+
+    fn add_round_constants(&self, state: &mut [FieldElement], round: usize) {
+        let offset = round * self.params.width;
+        for (idx, element) in state.iter_mut().enumerate() {
+            let constant = &self.round_constants[offset + idx];
+            *element = element.add(constant).expect("modulus matches");
+        }
+    }
+
+    fn permute_state(&self, state: &mut [FieldElement]) {
+        let total_rounds = self.params.full_rounds + self.params.partial_rounds;
+        for round in 0..total_rounds {
+            self.add_round_constants(state, round);
+            if round < self.params.full_rounds / 2
+                || round >= self.params.full_rounds / 2 + self.params.partial_rounds
+            {
+                self.apply_sbox(state);
+            } else {
+                self.apply_partial_sbox(state);
+            }
+            self.apply_mds(state);
+        }
+    }
+
+    /// Create a new sponge instance backed by this permutation.
+    pub fn sponge(&self) -> PoseidonSponge {
+        PoseidonSponge::new(self.clone())
+    }
+
+    /// Hash a slice of field elements into a single field element commitment.
+    pub fn hash(&self, inputs: &[FieldElement]) -> FieldElement {
+        let mut sponge = self.sponge();
+        sponge.absorb_elements(inputs);
+        sponge.finish_absorbing();
+        sponge.squeeze()
+    }
+
+    /// Convenience helper hashing raw byte slices.
+    pub fn hash_bytes(&self, inputs: &[Vec<u8>]) -> FieldElement {
+        let elements: Vec<FieldElement> = inputs
+            .iter()
+            .map(|bytes| FieldElement::from_bytes(bytes, &self.modulus))
+            .collect();
+        self.hash(&elements)
+    }
+}
+
+/// Sponge wrapper around the Poseidon permutation.
+#[derive(Clone, Debug)]
+pub struct PoseidonSponge {
+    hasher: PoseidonHasher,
+    state: Vec<FieldElement>,
+    rate: usize,
+    _capacity: usize,
+    position: usize,
+    mode: SpongeMode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SpongeMode {
+    Absorbing,
+    Squeezing,
+}
+
+impl PoseidonSponge {
+    fn new(hasher: PoseidonHasher) -> Self {
+        let state = vec![FieldElement::zero(hasher.modulus()); hasher.params.width];
+        let rate = hasher.params.width - 1;
+        let capacity = hasher.params.width - rate;
+        Self {
+            hasher,
+            state,
+            rate,
+            _capacity: capacity,
+            position: 0,
+            mode: SpongeMode::Absorbing,
+        }
+    }
+
+    /// Absorb a slice of field elements into the sponge state.
+    pub fn absorb_elements(&mut self, inputs: &[FieldElement]) {
+        if inputs.is_empty() {
+            return;
+        }
+        if self.mode == SpongeMode::Squeezing {
+            self.hasher.permute_state(&mut self.state);
+            self.position = 0;
+            self.mode = SpongeMode::Absorbing;
+        }
+        for element in inputs {
+            if self.position == self.rate {
+                self.hasher.permute_state(&mut self.state);
+                self.position = 0;
+            }
+            let updated = self.state[self.position]
+                .add(element)
+                .expect("modulus matches");
+            self.state[self.position] = updated;
+            self.position += 1;
+        }
+    }
+
+    /// Absorb raw byte messages using field conversion.
+    pub fn absorb_bytes(&mut self, inputs: &[Vec<u8>]) {
+        let elements: Vec<FieldElement> = inputs
+            .iter()
+            .map(|bytes| FieldElement::from_bytes(bytes, self.hasher.modulus()))
+            .collect();
+        self.absorb_elements(&elements);
+    }
+
+    /// Finalize the absorbing phase and prepare for squeezing outputs.
+    pub fn finish_absorbing(&mut self) {
+        if self.mode == SpongeMode::Squeezing {
+            return;
+        }
+        if self.position == self.rate {
+            self.hasher.permute_state(&mut self.state);
+            self.position = 0;
+        }
+        let one = FieldElement::one(self.hasher.modulus());
+        let updated = self.state[self.position]
+            .add(&one)
+            .expect("modulus matches");
+        self.state[self.position] = updated;
+        self.hasher.permute_state(&mut self.state);
+        self.position = 0;
+        self.mode = SpongeMode::Squeezing;
+    }
+
+    /// Squeeze a single field element from the sponge.
+    pub fn squeeze(&mut self) -> FieldElement {
+        if self.mode == SpongeMode::Absorbing {
+            self.finish_absorbing();
+        }
+        if self.position == self.rate {
+            self.hasher.permute_state(&mut self.state);
+            self.position = 0;
+        }
+        let result = self.state[self.position].clone();
+        self.position += 1;
+        result
+    }
+
+    /// Squeeze multiple field elements from the sponge.
+    pub fn squeeze_many(&mut self, count: usize) -> Vec<FieldElement> {
+        (0..count).map(|_| self.squeeze()).collect()
+    }
+}
+
+fn matrix_is_invertible(matrix: &[Vec<FieldElement>]) -> bool {
+    let size = matrix.len();
+    if size == 0 {
+        return false;
+    }
+    if size == 1 {
+        return !matrix[0][0].is_zero();
+    }
+    if size == 2 {
+        let a = &matrix[0][0];
+        let b = &matrix[0][1];
+        let c = &matrix[1][0];
+        let d = &matrix[1][1];
+        let ad = a.mul(d).expect("modulus matches");
+        let bc = b.mul(c).expect("modulus matches");
+        return !ad.sub(&bc).expect("modulus matches").is_zero();
+    }
+    if size == 3 {
+        let m = matrix;
+        let term1 = m[0][0]
+            .mul(&m[1][1])
+            .expect("modulus matches")
+            .mul(&m[2][2])
+            .expect("modulus matches");
+        let term2 = m[0][1]
+            .mul(&m[1][2])
+            .expect("modulus matches")
+            .mul(&m[2][0])
+            .expect("modulus matches");
+        let term3 = m[0][2]
+            .mul(&m[1][0])
+            .expect("modulus matches")
+            .mul(&m[2][1])
+            .expect("modulus matches");
+        let term4 = m[0][2]
+            .mul(&m[1][1])
+            .expect("modulus matches")
+            .mul(&m[2][0])
+            .expect("modulus matches");
+        let term5 = m[0][0]
+            .mul(&m[1][2])
+            .expect("modulus matches")
+            .mul(&m[2][1])
+            .expect("modulus matches");
+        let term6 = m[0][1]
+            .mul(&m[1][0])
+            .expect("modulus matches")
+            .mul(&m[2][2])
+            .expect("modulus matches");
+
+        let det = term1
+            .add(&term2)
+            .expect("modulus matches")
+            .add(&term3)
+            .expect("modulus matches")
+            .sub(&term4)
+            .expect("modulus matches")
+            .sub(&term5)
+            .expect("modulus matches")
+            .sub(&term6)
+            .expect("modulus matches");
+        return !det.is_zero();
+    }
+
+    // Fallback: perform Gaussian elimination to compute determinant != 0.
+    gaussian_invertible(matrix)
+}
+
+fn gaussian_invertible(matrix: &[Vec<FieldElement>]) -> bool {
+    let size = matrix.len();
+    let mut mat: Vec<Vec<FieldElement>> = matrix
+        .iter()
+        .map(|row| row.iter().cloned().collect())
+        .collect();
+
+    for pivot in 0..size {
+        let mut pivot_row = pivot;
+        while pivot_row < size && mat[pivot_row][pivot].is_zero() {
+            pivot_row += 1;
+        }
+        if pivot_row == size {
+            return false;
+        }
+        if pivot_row != pivot {
+            mat.swap(pivot_row, pivot);
+        }
+        let pivot_value = mat[pivot][pivot].clone();
+        let pivot_inv = match pivot_value.inverse() {
+            Ok(inv) => inv,
+            Err(_) => return false,
+        };
+
+        for col in pivot..size {
+            mat[pivot][col] = mat[pivot][col].mul(&pivot_inv).expect("modulus matches");
+        }
+
+        for row in 0..size {
+            if row == pivot {
+                continue;
+            }
+            let factor = mat[row][pivot].clone();
+            if factor.is_zero() {
+                continue;
+            }
+            for col in pivot..size {
+                let product = factor.mul(&mat[pivot][col]).expect("modulus matches");
+                mat[row][col] = mat[row][col].sub(&product).expect("modulus matches");
+            }
+        }
+    }
+
+    true
+}

--- a/src/stwo/proof.rs
+++ b/src/stwo/proof.rs
@@ -1,0 +1,104 @@
+//! Common proof artifacts emitted by the STWO scaffolding.
+
+use serde::{Deserialize, Serialize};
+
+use super::circuit::ExecutionTrace;
+use super::params::FieldElement;
+use super::params::{PoseidonHasher, StarkParameters};
+
+/// Authentication query associated with a polynomial evaluation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FriQuery {
+    pub index: usize,
+    pub evaluation: FieldElement,
+    pub auth_path: Vec<FieldElement>,
+}
+
+/// Commitment to a single execution-trace column.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PolynomialCommitment {
+    pub segment: String,
+    pub column: String,
+    pub domain_size: usize,
+    pub merkle_root: FieldElement,
+    pub queries: Vec<FriQuery>,
+}
+
+/// Deterministic FRI-style proof emitted by the prover scaffold.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FriProof {
+    pub commitments: Vec<PolynomialCommitment>,
+    pub challenges: Vec<FieldElement>,
+}
+
+/// Enumeration describing which circuit produced a proof artifact.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProofKind {
+    Transaction,
+    State,
+    Pruning,
+    Recursive,
+}
+
+/// Serialized witness payloads embedded in placeholder proofs. In a production
+/// STARK this data would be committed to rather than stored verbatim, but for
+/// the blueprint scaffold we keep it around so verifiers can re-execute the
+/// constraints deterministically.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ProofPayload {
+    Transaction(super::circuit::transaction::TransactionWitness),
+    State(super::circuit::state::StateWitness),
+    Pruning(super::circuit::pruning::PruningWitness),
+    Recursive(super::circuit::recursive::RecursiveWitness),
+}
+
+/// High-level container describing a STARK-style proof.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StarkProof {
+    pub kind: ProofKind,
+    pub commitment: String,
+    pub public_inputs: Vec<String>,
+    pub payload: ProofPayload,
+    pub trace: ExecutionTrace,
+    pub fri_proof: FriProof,
+}
+
+impl StarkProof {
+    /// Build a proof from a payload and the associated public inputs.
+    pub fn new(
+        kind: ProofKind,
+        payload: ProofPayload,
+        public_inputs: Vec<FieldElement>,
+        trace: ExecutionTrace,
+        fri_proof: FriProof,
+        hasher: &PoseidonHasher,
+    ) -> Self {
+        let commitment_element = hasher.hash(&public_inputs);
+        let commitment = commitment_element.to_hex();
+        let public_inputs = public_inputs
+            .into_iter()
+            .map(|element| element.to_hex())
+            .collect();
+        Self {
+            kind,
+            commitment,
+            public_inputs,
+            payload,
+            trace,
+            fri_proof,
+        }
+    }
+
+    /// Convenience constructor relying on the blueprint default parameters.
+    pub fn with_blueprint_hasher(
+        kind: ProofKind,
+        payload: ProofPayload,
+        inputs: Vec<FieldElement>,
+        trace: ExecutionTrace,
+        fri_proof: FriProof,
+    ) -> Self {
+        let params = StarkParameters::blueprint_default();
+        let hasher = params.poseidon_hasher();
+        Self::new(kind, payload, inputs, trace, fri_proof, &hasher)
+    }
+}

--- a/src/stwo/prover/mod.rs
+++ b/src/stwo/prover/mod.rs
@@ -1,0 +1,298 @@
+//! Prover-side integration for STWO/STARK proofs.
+
+use std::collections::HashMap;
+
+use crate::errors::{ChainError, ChainResult};
+use crate::ledger::compute_merkle_root;
+use crate::reputation::{ReputationWeights, Tier};
+use crate::storage::Storage;
+use crate::types::{Account, PruningProof, SignedTransaction, Stake};
+
+use super::aggregation::RecursiveAggregator;
+use super::circuit::{
+    CircuitError, StarkCircuit,
+    pruning::{PruningCircuit, PruningWitness},
+    recursive::{RecursiveCircuit, RecursiveWitness},
+    state::{StateCircuit, StateWitness},
+    transaction::{TransactionCircuit, TransactionWitness},
+};
+use super::fri::FriProver;
+use super::params::{FieldElement, StarkParameters};
+use super::proof::{ProofKind, ProofPayload, StarkProof};
+
+/// Trait implemented by STWO proof generators embedded in the wallet.
+pub trait StarkProver {
+    /// Generates the transaction-level proof for ownership, balance and nonce checks.
+    fn prove_transaction(&self, witness: TransactionWitness) -> ChainResult<StarkProof>;
+
+    /// Generates a batched state transition proof for a sequence of transactions.
+    fn prove_state_transition(&self, witness: StateWitness) -> ChainResult<StarkProof>;
+
+    /// Generates the pruning proof used to attest correct ledger pruning.
+    fn prove_pruning(&self, witness: PruningWitness) -> ChainResult<StarkProof>;
+
+    /// Aggregates individual proofs recursively.
+    fn prove_recursive(&self, witness: RecursiveWitness) -> ChainResult<StarkProof>;
+}
+
+fn map_circuit_error(err: CircuitError) -> ChainError {
+    ChainError::Crypto(err.to_string())
+}
+
+fn string_to_field(parameters: &StarkParameters, value: &str) -> FieldElement {
+    let bytes = hex::decode(value).unwrap_or_else(|_| value.as_bytes().to_vec());
+    parameters.element_from_bytes(&bytes)
+}
+
+/// Wallet-integrated prover that derives witnesses from local state.
+pub struct WalletProver<'a> {
+    pub storage: &'a Storage,
+    parameters: StarkParameters,
+    reputation_weights: ReputationWeights,
+    minimum_tier: Tier,
+}
+
+impl<'a> WalletProver<'a> {
+    pub fn new(storage: &'a Storage) -> Self {
+        Self {
+            storage,
+            parameters: StarkParameters::blueprint_default(),
+            reputation_weights: ReputationWeights::default(),
+            minimum_tier: Tier::Tl1,
+        }
+    }
+
+    pub fn with_minimum_tier(mut self, tier: Tier) -> Self {
+        self.minimum_tier = tier;
+        self
+    }
+
+    pub fn with_parameters(mut self, parameters: StarkParameters) -> Self {
+        self.parameters = parameters;
+        self
+    }
+
+    fn hasher(&self) -> super::params::PoseidonHasher {
+        self.parameters.poseidon_hasher()
+    }
+
+    pub fn build_transaction_witness(
+        &self,
+        tx: &SignedTransaction,
+    ) -> ChainResult<TransactionWitness> {
+        let sender_account = self
+            .storage
+            .read_account(&tx.payload.from)?
+            .ok_or_else(|| ChainError::Transaction("sender account not found".into()))?;
+        let receiver_account = self.storage.read_account(&tx.payload.to)?;
+        Ok(TransactionWitness {
+            signed_tx: tx.clone(),
+            sender_account,
+            receiver_account,
+            required_tier: self.minimum_tier.clone(),
+            reputation_weights: self.reputation_weights.clone(),
+        })
+    }
+
+    pub fn build_state_witness(
+        &self,
+        prev_state_root: &str,
+        new_state_root: &str,
+        transactions: &[SignedTransaction],
+    ) -> ChainResult<StateWitness> {
+        let accounts_before = self.storage.load_accounts()?;
+        let mut state: HashMap<_, _> = accounts_before
+            .iter()
+            .cloned()
+            .map(|account| (account.address.clone(), account))
+            .collect();
+        for tx in transactions {
+            let sender = state
+                .get_mut(&tx.payload.from)
+                .ok_or_else(|| ChainError::Transaction("sender missing from state".into()))?;
+            let total = tx
+                .payload
+                .amount
+                .checked_add(tx.payload.fee as u128)
+                .ok_or_else(|| ChainError::Transaction("transaction amount overflow".into()))?;
+            if sender.balance < total {
+                return Err(ChainError::Transaction("insufficient balance".into()));
+            }
+            sender.balance -= total;
+            sender.nonce += 1;
+            let recipient = state
+                .entry(tx.payload.to.clone())
+                .or_insert_with(|| Account::new(tx.payload.to.clone(), 0, Stake::default()));
+            recipient.balance = recipient.balance.saturating_add(tx.payload.amount);
+            recipient.reputation.recompute_score(
+                &self.reputation_weights,
+                crate::reputation::current_timestamp(),
+            );
+        }
+        let accounts_after = state.into_values().collect();
+        Ok(StateWitness {
+            prev_state_root: prev_state_root.to_string(),
+            new_state_root: new_state_root.to_string(),
+            transactions: transactions.to_vec(),
+            accounts_before,
+            accounts_after,
+            required_tier: self.minimum_tier.clone(),
+            reputation_weights: self.reputation_weights.clone(),
+        })
+    }
+
+    pub fn build_pruning_witness(
+        &self,
+        previous_txs: &[SignedTransaction],
+        pruning: &PruningProof,
+        removed: Vec<String>,
+    ) -> PruningWitness {
+        let mut leaves = previous_txs.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
+        let previous_tx_root = hex::encode(compute_merkle_root(&mut leaves));
+        let original_transactions = previous_txs
+            .iter()
+            .map(|tx| hex::encode(tx.hash()))
+            .collect();
+        PruningWitness {
+            previous_tx_root,
+            pruned_tx_root: pruning.pruned_tx_root.clone(),
+            original_transactions,
+            removed_transactions: removed,
+        }
+    }
+
+    pub fn build_recursive_witness(
+        &self,
+        previous_recursive: Option<&StarkProof>,
+        tx_proofs: &[StarkProof],
+        state_proof: &StarkProof,
+        pruning_proof: &StarkProof,
+        block_height: u64,
+    ) -> ChainResult<RecursiveWitness> {
+        let aggregator = RecursiveAggregator::new(self.parameters.clone());
+        aggregator.build_witness(
+            previous_recursive,
+            tx_proofs,
+            state_proof,
+            pruning_proof,
+            block_height,
+        )
+    }
+}
+
+impl<'a> StarkProver for WalletProver<'a> {
+    fn prove_transaction(&self, witness: TransactionWitness) -> ChainResult<StarkProof> {
+        let circuit = TransactionCircuit::new(witness.clone());
+        circuit.evaluate_constraints().map_err(map_circuit_error)?;
+        let trace = circuit
+            .generate_trace(&self.parameters)
+            .map_err(map_circuit_error)?;
+        circuit
+            .verify_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
+        let tx = &witness.signed_tx.payload;
+        let inputs = vec![
+            string_to_field(&self.parameters, &tx.from),
+            string_to_field(&self.parameters, &tx.to),
+            self.parameters.element_from_u128(tx.amount),
+            self.parameters.element_from_u64(tx.fee as u64),
+            self.parameters.element_from_u64(tx.nonce),
+        ];
+        let hasher = self.hasher();
+        let fri_prover = FriProver::new(&self.parameters);
+        let fri_proof = fri_prover.prove(&trace, &inputs);
+        Ok(StarkProof::new(
+            ProofKind::Transaction,
+            ProofPayload::Transaction(witness),
+            inputs,
+            trace,
+            fri_proof,
+            &hasher,
+        ))
+    }
+
+    fn prove_state_transition(&self, witness: StateWitness) -> ChainResult<StarkProof> {
+        let circuit = StateCircuit::new(witness.clone());
+        circuit.evaluate_constraints().map_err(map_circuit_error)?;
+        let trace = circuit
+            .generate_trace(&self.parameters)
+            .map_err(map_circuit_error)?;
+        circuit
+            .verify_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
+        let inputs = vec![
+            string_to_field(&self.parameters, &witness.prev_state_root),
+            string_to_field(&self.parameters, &witness.new_state_root),
+            self.parameters
+                .element_from_u64(witness.transactions.len() as u64),
+        ];
+        let hasher = self.hasher();
+        let fri_prover = FriProver::new(&self.parameters);
+        let fri_proof = fri_prover.prove(&trace, &inputs);
+        Ok(StarkProof::new(
+            ProofKind::State,
+            ProofPayload::State(witness),
+            inputs,
+            trace,
+            fri_proof,
+            &hasher,
+        ))
+    }
+
+    fn prove_pruning(&self, witness: PruningWitness) -> ChainResult<StarkProof> {
+        let circuit = PruningCircuit::new(witness.clone());
+        circuit.evaluate_constraints().map_err(map_circuit_error)?;
+        let trace = circuit
+            .generate_trace(&self.parameters)
+            .map_err(map_circuit_error)?;
+        circuit
+            .verify_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
+        let inputs = vec![
+            string_to_field(&self.parameters, &witness.previous_tx_root),
+            string_to_field(&self.parameters, &witness.pruned_tx_root),
+            self.parameters
+                .element_from_u64(witness.removed_transactions.len() as u64),
+        ];
+        let hasher = self.hasher();
+        let fri_prover = FriProver::new(&self.parameters);
+        let fri_proof = fri_prover.prove(&trace, &inputs);
+        Ok(StarkProof::new(
+            ProofKind::Pruning,
+            ProofPayload::Pruning(witness),
+            inputs,
+            trace,
+            fri_proof,
+            &hasher,
+        ))
+    }
+
+    fn prove_recursive(&self, witness: RecursiveWitness) -> ChainResult<StarkProof> {
+        let circuit = RecursiveCircuit::new(witness.clone());
+        circuit.evaluate_constraints().map_err(map_circuit_error)?;
+        let trace = circuit
+            .generate_trace(&self.parameters)
+            .map_err(map_circuit_error)?;
+        circuit
+            .verify_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
+        let prev = witness.previous_commitment.clone().unwrap_or_default();
+        let inputs = vec![
+            string_to_field(&self.parameters, &prev),
+            string_to_field(&self.parameters, &witness.aggregated_commitment),
+            self.parameters
+                .element_from_u64(witness.tx_commitments.len() as u64),
+        ];
+        let hasher = self.hasher();
+        let fri_prover = FriProver::new(&self.parameters);
+        let fri_proof = fri_prover.prove(&trace, &inputs);
+        Ok(StarkProof::new(
+            ProofKind::Recursive,
+            ProofPayload::Recursive(witness),
+            inputs,
+            trace,
+            fri_proof,
+            &hasher,
+        ))
+    }
+}

--- a/src/stwo/verifier/mod.rs
+++ b/src/stwo/verifier/mod.rs
@@ -1,0 +1,306 @@
+//! Verifier-side integration for STWO/STARK proofs.
+
+use crate::errors::{ChainError, ChainResult};
+
+use super::aggregation::RecursiveAggregator;
+use super::circuit::{
+    CircuitError, ExecutionTrace, StarkCircuit, pruning::PruningCircuit,
+    recursive::RecursiveCircuit, state::StateCircuit, transaction::TransactionCircuit,
+};
+use super::fri::FriProver;
+use super::params::{FieldElement, StarkParameters};
+use super::proof::{ProofKind, ProofPayload, StarkProof};
+
+/// Trait implemented by STWO proof verifiers on the node side.
+pub trait StarkVerifier {
+    /// Verify a transaction proof payload.
+    fn verify_transaction(&self, proof: &StarkProof) -> ChainResult<()>;
+
+    /// Verify a state transition proof.
+    fn verify_state(&self, proof: &StarkProof) -> ChainResult<()>;
+
+    /// Verify a pruning proof payload.
+    fn verify_pruning(&self, proof: &StarkProof) -> ChainResult<()>;
+
+    /// Verify the recursive aggregation proof.
+    fn verify_recursive(&self, proof: &StarkProof) -> ChainResult<()>;
+}
+
+fn string_to_field(parameters: &StarkParameters, value: &str) -> FieldElement {
+    let bytes = hex::decode(value).unwrap_or_else(|_| value.as_bytes().to_vec());
+    parameters.element_from_bytes(&bytes)
+}
+
+fn map_circuit_error(err: CircuitError) -> ChainError {
+    ChainError::Crypto(err.to_string())
+}
+
+/// Lightweight verifier that recomputes commitments by replaying circuits.
+pub struct NodeVerifier {
+    parameters: StarkParameters,
+}
+
+impl NodeVerifier {
+    pub fn new() -> Self {
+        Self {
+            parameters: StarkParameters::blueprint_default(),
+        }
+    }
+
+    fn check_commitment(&self, proof: &StarkProof) -> ChainResult<Vec<FieldElement>> {
+        let inputs = proof
+            .public_inputs
+            .iter()
+            .map(|input| string_to_field(&self.parameters, input))
+            .collect::<Vec<_>>();
+        let hasher = self.parameters.poseidon_hasher();
+        let expected = hasher.hash(&inputs).to_hex();
+        if expected != proof.commitment {
+            return Err(ChainError::Crypto("proof commitment mismatch".into()));
+        }
+        Ok(inputs)
+    }
+
+    fn expect_kind(&self, proof: &StarkProof, kind: ProofKind) -> ChainResult<()> {
+        if proof.kind != kind {
+            return Err(ChainError::Crypto("proof kind mismatch".into()));
+        }
+        Ok(())
+    }
+
+    fn check_trace(&self, circuit_trace: ExecutionTrace, proof: &StarkProof) -> ChainResult<()> {
+        if proof.trace != circuit_trace {
+            return Err(ChainError::Crypto("proof trace mismatch".into()));
+        }
+        Ok(())
+    }
+
+    fn check_fri(
+        &self,
+        proof: &StarkProof,
+        public_inputs: &[FieldElement],
+        trace: &ExecutionTrace,
+    ) -> ChainResult<()> {
+        let fri_prover = FriProver::new(&self.parameters);
+        let expected = fri_prover.prove(trace, public_inputs);
+        if proof.fri_proof != expected {
+            return Err(ChainError::Crypto("fri proof mismatch".into()));
+        }
+        Ok(())
+    }
+
+    fn compute_recursive_commitment(
+        &self,
+        witness: &super::circuit::recursive::RecursiveWitness,
+    ) -> FieldElement {
+        let aggregator = RecursiveAggregator::new(self.parameters.clone());
+        aggregator.aggregate_commitment(
+            witness.previous_commitment.as_deref(),
+            &witness.tx_commitments,
+            &witness.state_commitment,
+            &witness.pruning_commitment,
+            witness.block_height,
+        )
+    }
+}
+
+impl Default for NodeVerifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StarkVerifier for NodeVerifier {
+    fn verify_transaction(&self, proof: &StarkProof) -> ChainResult<()> {
+        self.expect_kind(proof, ProofKind::Transaction)?;
+        let public_inputs = self.check_commitment(proof)?;
+        if let ProofPayload::Transaction(witness) = &proof.payload {
+            let circuit = TransactionCircuit::new(witness.clone());
+            circuit.evaluate_constraints().map_err(map_circuit_error)?;
+            let trace = circuit
+                .generate_trace(&self.parameters)
+                .map_err(map_circuit_error)?;
+            circuit
+                .verify_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
+            self.check_trace(trace.clone(), proof)?;
+            self.check_fri(proof, &public_inputs, &trace)
+        } else {
+            Err(ChainError::Crypto(
+                "transaction proof payload mismatch".into(),
+            ))
+        }
+    }
+
+    fn verify_state(&self, proof: &StarkProof) -> ChainResult<()> {
+        self.expect_kind(proof, ProofKind::State)?;
+        let public_inputs = self.check_commitment(proof)?;
+        if let ProofPayload::State(witness) = &proof.payload {
+            let circuit = StateCircuit::new(witness.clone());
+            circuit.evaluate_constraints().map_err(map_circuit_error)?;
+            let trace = circuit
+                .generate_trace(&self.parameters)
+                .map_err(map_circuit_error)?;
+            circuit
+                .verify_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
+            self.check_trace(trace.clone(), proof)?;
+            self.check_fri(proof, &public_inputs, &trace)
+        } else {
+            Err(ChainError::Crypto("state proof payload mismatch".into()))
+        }
+    }
+
+    fn verify_pruning(&self, proof: &StarkProof) -> ChainResult<()> {
+        self.expect_kind(proof, ProofKind::Pruning)?;
+        let public_inputs = self.check_commitment(proof)?;
+        if let ProofPayload::Pruning(witness) = &proof.payload {
+            let circuit = PruningCircuit::new(witness.clone());
+            circuit.evaluate_constraints().map_err(map_circuit_error)?;
+            let trace = circuit
+                .generate_trace(&self.parameters)
+                .map_err(map_circuit_error)?;
+            circuit
+                .verify_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
+            self.check_trace(trace.clone(), proof)?;
+            self.check_fri(proof, &public_inputs, &trace)
+        } else {
+            Err(ChainError::Crypto("pruning proof payload mismatch".into()))
+        }
+    }
+
+    fn verify_recursive(&self, proof: &StarkProof) -> ChainResult<()> {
+        self.expect_kind(proof, ProofKind::Recursive)?;
+        let public_inputs = self.check_commitment(proof)?;
+        if let ProofPayload::Recursive(witness) = &proof.payload {
+            let circuit = RecursiveCircuit::new(witness.clone());
+            circuit.evaluate_constraints().map_err(map_circuit_error)?;
+            let trace = circuit
+                .generate_trace(&self.parameters)
+                .map_err(map_circuit_error)?;
+            circuit
+                .verify_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
+            self.check_trace(trace.clone(), proof)?;
+            self.check_fri(proof, &public_inputs, &trace)
+        } else {
+            Err(ChainError::Crypto(
+                "recursive proof payload mismatch".into(),
+            ))
+        }
+    }
+}
+
+impl NodeVerifier {
+    /// Verify a full bundle of proofs associated with a block.
+    pub fn verify_bundle(
+        &self,
+        tx_proofs: &[StarkProof],
+        state_proof: &StarkProof,
+        pruning_proof: &StarkProof,
+        recursive_proof: &StarkProof,
+        expected_previous_commitment: Option<&str>,
+    ) -> ChainResult<String> {
+        if tx_proofs.is_empty() && expected_previous_commitment.is_some() {
+            return Err(ChainError::Crypto(
+                "recursive bundle must include at least one transaction proof".into(),
+            ));
+        }
+
+        for proof in tx_proofs {
+            self.verify_transaction(proof)?;
+        }
+        self.verify_state(state_proof)?;
+        self.verify_pruning(pruning_proof)?;
+        self.verify_recursive(recursive_proof)?;
+
+        let witness = match &recursive_proof.payload {
+            ProofPayload::Recursive(witness) => witness,
+            _ => {
+                return Err(ChainError::Crypto(
+                    "recursive proof payload mismatch".into(),
+                ));
+            }
+        };
+
+        if witness.tx_commitments.len() != tx_proofs.len() {
+            return Err(ChainError::Crypto(
+                "recursive witness transaction commitment count mismatch".into(),
+            ));
+        }
+        for (expected_commitment, proof) in witness.tx_commitments.iter().zip(tx_proofs) {
+            if expected_commitment != &proof.commitment {
+                return Err(ChainError::Crypto(
+                    "recursive witness transaction commitment mismatch".into(),
+                ));
+            }
+        }
+
+        if witness.state_commitment != state_proof.commitment {
+            return Err(ChainError::Crypto(
+                "recursive witness state commitment mismatch".into(),
+            ));
+        }
+        if witness.pruning_commitment != pruning_proof.commitment {
+            return Err(ChainError::Crypto(
+                "recursive witness pruning commitment mismatch".into(),
+            ));
+        }
+
+        if let Some(expected) = expected_previous_commitment {
+            match &witness.previous_commitment {
+                Some(actual) if actual == expected => {}
+                Some(_) => {
+                    return Err(ChainError::Crypto(
+                        "recursive witness previous commitment mismatch".into(),
+                    ));
+                }
+                None => {
+                    return Err(ChainError::Crypto(
+                        "recursive witness missing previous commitment".into(),
+                    ));
+                }
+            }
+        }
+
+        let aggregated = self.compute_recursive_commitment(witness);
+        let aggregated_hex = aggregated.to_hex();
+        if aggregated_hex != witness.aggregated_commitment {
+            return Err(ChainError::Crypto(
+                "recursive witness aggregated commitment mismatch".into(),
+            ));
+        }
+
+        if let Some(previous_input) = recursive_proof.public_inputs.get(0) {
+            let expected_previous = witness.previous_commitment.clone().unwrap_or_default();
+            if previous_input != &expected_previous {
+                return Err(ChainError::Crypto(
+                    "recursive proof public inputs do not encode previous commitment".into(),
+                ));
+            }
+        }
+
+        if let Some(aggregated_input) = recursive_proof.public_inputs.get(1) {
+            if aggregated_input != &witness.aggregated_commitment {
+                return Err(ChainError::Crypto(
+                    "recursive proof public inputs do not encode aggregated commitment".into(),
+                ));
+            }
+        }
+
+        if let Some(tx_count_input) = recursive_proof.public_inputs.get(2) {
+            let expected_tx_count = self
+                .parameters
+                .element_from_u64(witness.tx_commitments.len() as u64)
+                .to_hex();
+            if tx_count_input != &expected_tx_count {
+                return Err(ChainError::Crypto(
+                    "recursive proof public inputs do not encode transaction count".into(),
+                ));
+            }
+        }
+
+        Ok(aggregated_hex)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,9 +1,11 @@
 mod account;
 mod block;
+mod stwo;
 mod transaction;
 
 pub use account::{Account, Stake};
 pub use block::{Block, BlockHeader, BlockMetadata, ProofSystem, PruningProof, RecursiveProof};
+pub use stwo::{BlockStarkProofs, TransactionProofBundle};
 pub use transaction::{SignedTransaction, Transaction, TransactionEnvelope};
 
 pub type Address = String;

--- a/src/types/stwo.rs
+++ b/src/types/stwo.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+use crate::stwo::proof::StarkProof;
+
+use super::transaction::SignedTransaction;
+
+/// Bundle tying a signed transaction with its STARK proof.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionProofBundle {
+    pub transaction: SignedTransaction,
+    pub proof: StarkProof,
+}
+
+impl TransactionProofBundle {
+    pub fn new(transaction: SignedTransaction, proof: StarkProof) -> Self {
+        Self { transaction, proof }
+    }
+
+    pub fn hash(&self) -> String {
+        hex::encode(self.transaction.hash())
+    }
+}
+
+/// Collection of STARK artifacts associated with a block.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockStarkProofs {
+    pub transaction_proofs: Vec<StarkProof>,
+    pub state_proof: StarkProof,
+    pub pruning_proof: StarkProof,
+    pub recursive_proof: StarkProof,
+}
+
+impl BlockStarkProofs {
+    pub fn new(
+        transaction_proofs: Vec<StarkProof>,
+        state_proof: StarkProof,
+        pruning_proof: StarkProof,
+        recursive_proof: StarkProof,
+    ) -> Self {
+        Self {
+            transaction_proofs,
+            state_proof,
+            pruning_proof,
+            recursive_proof,
+        }
+    }
+}

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -10,7 +10,7 @@ use crate::errors::{ChainError, ChainResult};
 
 use super::Address;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Transaction {
     pub from: Address,
     pub to: Address,
@@ -54,7 +54,7 @@ impl Transaction {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SignedTransaction {
     pub id: Uuid,
     pub payload: Transaction,
@@ -86,7 +86,7 @@ impl SignedTransaction {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TransactionEnvelope {
     pub tx: SignedTransaction,
     pub hash: String,


### PR DESCRIPTION
## Summary
- add unit tests covering field arithmetic and Poseidon hashing over the STWO blueprint parameters
- exercise the recursive aggregator with deterministic dummy proofs to verify commitment folding and error handling

## Testing
- `cargo fmt`
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_68cdc8c16c8483269ec55de3b33cfd33