### PR TITLE
Implement full timetoke accrual from uptime proofs

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@ mod block;
 mod identity;
 mod stwo;
 mod transaction;
+mod uptime;
 
 pub use crate::identity_tree::IdentityCommitmentProof;
 pub use account::{Account, IdentityBinding, Stake, WalletBindingChange};
@@ -10,5 +11,6 @@ pub use block::{Block, BlockHeader, BlockMetadata, ProofSystem, PruningProof, Re
 pub use identity::{IdentityDeclaration, IdentityGenesis, IdentityProof};
 pub use stwo::{BlockStarkProofs, TransactionProofBundle};
 pub use transaction::{SignedTransaction, Transaction, TransactionEnvelope};
+pub use uptime::UptimeProof;
 
 pub type Address = String;

--- a/src/types/uptime.rs
+++ b/src/types/uptime.rs
@@ -1,0 +1,29 @@
+use hex;
+use serde::{Deserialize, Serialize};
+use stwo::core::vcs::blake2_hash::Blake2sHasher;
+
+use super::Address;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UptimeProof {
+    pub wallet_address: Address,
+    pub window_start: u64,
+    pub window_end: u64,
+    pub proof_commitment: String,
+}
+
+impl UptimeProof {
+    pub fn commitment_bytes(address: &str, window_start: u64, window_end: u64) -> [u8; 32] {
+        let mut data = Vec::new();
+        data.extend_from_slice(address.as_bytes());
+        data.extend_from_slice(&window_start.to_be_bytes());
+        data.extend_from_slice(&window_end.to_be_bytes());
+        Blake2sHasher::hash(&data).into()
+    }
+
+    pub fn verify_commitment(&self) -> bool {
+        let expected =
+            Self::commitment_bytes(&self.wallet_address, self.window_start, self.window_end);
+        hex::encode(expected) == self.proof_commitment
+    }
+}

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2,6 +2,7 @@ pub mod proofs;
 pub mod tabs;
 pub mod wallet;
 
-pub use proofs::{ProofGenerator, TxProof, UptimeProof};
+pub use crate::types::UptimeProof;
+pub use proofs::{ProofGenerator, TxProof};
 pub use tabs::{HistoryEntry, HistoryStatus, NodeTabMetrics, ReceiveTabAddress, SendPreview};
 pub use wallet::Wallet;

--- a/src/wallet/proofs.rs
+++ b/src/wallet/proofs.rs
@@ -3,20 +3,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::Serialize;
 use stwo::core::vcs::blake2_hash::Blake2sHasher;
 
-use crate::types::{Address, SignedTransaction};
+use crate::types::{Address, SignedTransaction, UptimeProof};
 
 #[derive(Clone, Debug, Serialize)]
 pub struct TxProof {
     pub wallet_address: Address,
     pub tx_hash: String,
-    pub proof_commitment: String,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct UptimeProof {
-    pub wallet_address: Address,
-    pub window_start: u64,
-    pub window_end: u64,
     pub proof_commitment: String,
 }
 
@@ -48,11 +40,7 @@ impl ProofGenerator {
             .unwrap_or_default()
             .as_secs();
         let window_start = now.saturating_sub(3600);
-        let mut data = Vec::new();
-        data.extend_from_slice(self.wallet_address.as_bytes());
-        data.extend_from_slice(&window_start.to_be_bytes());
-        data.extend_from_slice(&now.to_be_bytes());
-        let commitment: [u8; 32] = Blake2sHasher::hash(&data).into();
+        let commitment = UptimeProof::commitment_bytes(&self.wallet_address, window_start, now);
         UptimeProof {
             wallet_address: self.wallet_address.clone(),
             window_start,

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -14,10 +14,12 @@ use crate::reputation::Tier;
 use crate::storage::Storage;
 use crate::stwo::circuit::identity::IdentityWitness;
 use crate::stwo::prover::{StarkProver, WalletProver};
-use crate::types::{Address, SignedTransaction, Transaction, TransactionProofBundle};
-use crate::types::{IdentityDeclaration, IdentityGenesis, IdentityProof};
+use crate::types::{
+    Address, IdentityDeclaration, IdentityGenesis, IdentityProof, SignedTransaction, Transaction,
+    TransactionProofBundle, UptimeProof,
+};
 
-use super::proofs::{ProofGenerator, UptimeProof};
+use super::proofs::ProofGenerator;
 use super::tabs::{HistoryEntry, HistoryStatus, NodeTabMetrics, ReceiveTabAddress, SendPreview};
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- update timetoke recording to grant one credit per provable online hour and guard against overlapping proofs
- extend ledger uptime proof handling tests to cover multi-hour windows and partial overlap accrual

## Testing
- cargo test apply_uptime_proof_updates_timetokes
- cargo test reject_duplicate_uptime_proofs
- cargo test uptime_proof_only_counts_new_hours

------
https://chatgpt.com/codex/tasks/task_e_68cec2cb519083268a953d7860febcb3