### PR TITLE
Distribute consensus rewards with leader bonus

### DIFF
--- a/docs/cross_cutting_concerns.md
+++ b/docs/cross_cutting_concerns.md
@@ -1,0 +1,131 @@
+# Malachite BFT – Cross-Cutting Concerns
+
+Dieses Dokument fasst übergreifende Anforderungen für die vollständige Umsetzung des Malachite-BFT-Blueprints in der RPP-Blockchain zusammen. Es dient als Ergänzung zur Anforderungsanalyse & Architekturplanung und soll sicherstellen, dass alle begleitenden Querschnittsthemen (Konfiguration, Telemetrie, Dokumentation, Tests, Betrieb) konsistent adressiert werden.
+
+## 1. Konfiguration & Parametrisierung
+
+### 1.1 Zentrale Parameterdatei
+* **Ziel**: Einfache Anpassung der Blueprint-Parameter ohne Codeänderung.
+* **Umsetzung**: Einführung einer dedizierten Konfigurationsdatei `config/malachite.toml` (oder YAML), die von Node- und Konsensdiensten geladen wird.
+* **Konfigurations-Layer**: Priorität `CLI-Flags → Umgebungsvariablen → Config-Datei → Default-Werte`.
+
+### 1.2 Relevante Parametergruppen
+1. **Validator- & Leader-Selektion**
+   * `validator_set_size`, `witness_count` – maximale Teilnehmer je Epoche.
+   * `vrf_threshold_curve` – Funktionsdefinition zur Ableitung der Schwelle aus der Timetoke-Balance.
+   * `epoch_duration`, `round_timeout`, `max_round_extensions` – Steuerung des Konsens-Tempos.
+2. **Reputation & Timetoke**
+   * `tier_thresholds` – Score-Grenzen für Tier 3+.
+   * `timetoke_decay_rate`, `timetoke_accrual_rate`, `timetoke_cap` – Stabilisierung der Uptime-Gewichtung.
+   * `snapshot_interval`, `max_snapshot_age` – Synchronisationsfenster.
+3. **Rewards & Slashing**
+   * `base_block_reward`, `leader_bonus_pct`, `witness_reward_pct` – Split des Reward-Pools.
+   * `double_sign_penalty`, `fake_proof_penalty`, `inactivity_penalty` – Reputation- und Balance-Abzüge.
+4. **Proof-System**
+   * `proof_batch_size`, `proof_cache_ttl`, `max_recursive_depth` – Performance- und Speichersteuerung.
+5. **Netzwerk & Ressourcen**
+   * `gossip_fanout`, `max_channel_buffer`, `rate_limit_per_channel` – Stabilität der P2P-Kanäle.
+   * `max_block_size`, `max_votes_per_round` – DoS- und Kapazitätsbegrenzung.
+
+### 1.3 Versionsverwaltung & Migration
+* Konfigurationsschema per SemVer kennzeichnen, z. B. `config_version = "1.0"`.
+* Node startet nur, wenn Config-Version kompatibel ist; andernfalls Migrationshinweis.
+* Dokumentation von Default-Werten und deren Rationale in `docs/config_reference.md`.
+
+## 2. Telemetrie, Observability & Auditierbarkeit
+
+### 2.1 Metriken
+* **Konsens**: Round-Dauer, Leader-Rotation, VRF-Erfolgsrate, Quorum-Latenz, Anzahl Re-Rounds.
+* **Reputation & Timetoke**: Durchschnittliche Timetoke-Balance, Anzahl Promotion/Demotion-Events, Reputation-Decay-Statistiken.
+* **Rewards**: Verteilte Rewards pro Epoche, Leader-Bonus-Anteil, Witness-Ausschüttungen.
+* **Anti-Abuse**: Detektierte Double-Signs, Fake-Proofs, Zensurmeldungen, angewandte Slashing-Fälle.
+* **Netzwerk**: Nachrichtenvolumen pro Kanal (`blocks`, `votes`, `proofs`, `snapshots`, `meta`), Fehlerquoten, Rate-Limits.
+* **Proofs**: Erstellungszeit, Verifizierungszeit, Cache-Hitrate.
+
+### 2.2 Logging & Tracing
+* **Structured Logging**: JSON/Protobuf-Logs mit Feldern `round_id`, `epoch`, `leader_id`, `validator_id`, `tier`, `timetoke_balance`, `event_type`.
+* **Tracing**: OpenTelemetry-Integration, Spans für VRF-Auswertung, Leader-Wahl, Proof-Building, Netzwerk-Dispatch.
+* **Log-Level-Policy**: Debug für Testnet, Info/Warn für Produktion, Audit-relevante Events auf Warn oder höher.
+
+### 2.3 Audit-Trail & Compliance
+* Signierte Audit-Logs für Anti-Abuse-Ereignisse, bereitgestellt über gesicherten Export (z. B. S3, IPFS).
+* Datenschutzbeachtung: Pseudonymisierte Validator-IDs, keine Klartext-IP-Adressen in Public-Logs.
+* Aufbewahrungsfristen pro Netzwerkumgebung festlegen (z. B. Testnet 30 Tage, Mainnet ≥ 1 Jahr).
+
+## 3. Dokumentation & Entwickler-Experience
+
+### 3.1 Blueprint- und API-Dokumente
+* **Blueprint Coverage**: Fortlaufende Pflege eines Coverage-Index (z. B. `docs/blueprint_coverage.md`) mit Status `geplant → in Arbeit → umgesetzt` pro Blueprint-Feature.
+* **API-Referenzen**: Rustdoc-Generierung und separate Markdown-Guides für Konsens-, Reward- und Netzwerk-Schnittstellen.
+* **Sequenzdiagramme**: BPMN/PlantUML-Diagramme für Konsensrunde, Timetoke-Sync und Rewards.
+
+### 3.2 Entwicklerleitfäden
+* Quickstart-Guide für lokale Validator-Nodes inkl. Konfigurationsbeispiele.
+* Troubleshooting-Playbook für häufige Fehler (z. B. fehlende Timetoke-Snapshots, VRF-Mismatch).
+* Coding-Guidelines für neue Module (z. B. Fehlerbehandlung, Telemetrie-Hooks, Test-Patterns).
+
+### 3.3 Kommunikationskanäle
+* Changelog-Struktur mit Fokus auf Konsensänderungen.
+* RFC-Prozess für größere Anpassungen (Proof-System, Slashing-Politik).
+
+## 4. Teststrategie & Qualitäts­sicherung
+
+### 4.1 Testpyramide
+1. **Unit-Tests**: Deterministische Tests für VRF-Thresholds, Reward-Berechnung, Reputation-/Timetoke-Funktionen.
+2. **Property-Based Tests**: QuickCheck/Proptest-Szenarien für Leader-Auswahl, Validator-Set-Größe und Reward-Verteilungen.
+3. **Integrationstests**: Simulierte Konsensrunden mit Mock-Netzwerk, um Quorum und Proof-Embedding zu verifizieren.
+4. **Systemtests / Testnet**: Mehrknoten-Simulation mit realem Netzwerkstack und Telemetrie-Sammlung.
+5. **Fuzzing**: Eingabe-Fuzzing für Netzwerk-Nachrichten und Proof-Verifizierer.
+6. **Performance- & Lasttests**: Messung von Blockzeiten, Proof-Latenzen, Ressourcenverbrauch.
+
+### 4.2 Testautomatisierung
+* **CI/CD**: Pipeline-Stufen `fmt → clippy → unit → integration → fuzz-nightly → performance-weekly`.
+* **Artefakte**: Testberichte, Coverage-Metriken, Benchmark-Charts.
+* **Gatekeeper**: Merge nur bei `ci_status == green` und dokumentiertem Blueprint-Fortschritt.
+
+### 4.3 Testdaten & Fixtures
+* Generierung deterministischer Seeds für VRF-Tests, Reputationsprofile, Timetoke-Snapshots.
+* Nutzung synthetischer Netzwerkevents (z. B. Delay, Packet Loss) für Stabilitätsprüfungen.
+* Dummy-Recursive-Proofs zur Validierung der Einbettung, bevor echte STWO-Proofs vorliegen.
+
+## 5. Betriebs- & Rollout-Aspekte
+
+### 5.1 Feature-Flags & Kompatibilität
+* Einführen von Feature-Toggles für: `malachite_consensus`, `timetoke_rewards`, `witness_network`.
+* Legacy-Knoten erkennen über Gossip den aktivierten Feature-Set-Status und handeln entsprechend (Fallback-Modus oder Sync-Anweisung).
+
+### 5.2 Deployments & Migrationen
+* Rolloutplan: Devnet → Testnet → Canary-Mainnet → Vollständiges Mainnet.
+* Datenmigrationen versionieren, Backups vor Aktivierung der neuen Module erzwingen.
+* Automatisierte Health-Checks vor/ nach Aktivierung (Validator-Set-Größe, Telemetrie-Signale, Proof-Validierung).
+
+### 5.3 Betrieb & SRE
+* Runbooks für Incident Response (z. B. Leader-Ausfall, Proof-Verifikationsfehler, Netzwerkpartitionen).
+* Alerting-Regeln für kritische Metriken (Leader-Wechselrate, VRF-Fehler, Snapshot-Verzug, Slashing-Spikes).
+* Kapazitätsplanung: Ressourcenbedarf pro Node (CPU für Proofs, Speicher für Snapshots, Bandbreite pro Kanal).
+
+### 5.4 Sicherheitsmaßnahmen
+* Secrets-Management für VRF-Schlüssel (z. B. HSM, Vault-Integration).
+* Härtung der P2P-Schicht (TLS/Noise, Peer-Authentifizierung, Sybil-Resistenz).
+* Regelmäßige Security-Audits & Bug-Bounty-Programme.
+
+## 6. Offene Aufgaben & Verantwortlichkeiten
+
+| Bereich | Owner | Deliverable | Status |
+| --- | --- | --- | --- |
+| Konfigurationsdatei & Loader | Core Platform Team | `config/malachite.toml`, Parsing-Module | offen |
+| Telemetrie-Integration | SRE Team | Metrics-Exporter, Grafana-Dashboards | offen |
+| Dokumentationspaket | Developer Relations | API-Guides, Flowcharts, Changelog | offen |
+| Testautomatisierung | QA Team | CI-Pipeline mit Nightly-Fuzzing | offen |
+| Rollout-Planung | DevOps | Stufenplan & Runbooks | offen |
+| Sicherheitskonzept | Security Guild | Secrets-Policy, Audit-Plan | offen |
+
+## 7. Nächste Schritte
+
+1. Config-Schema und Default-Werte finalisieren, anschließend Loader-Modul implementieren.
+2. Telemetrie-Schnittstellen in Konsens-, Reputation- und Netzwerkmodulen definieren.
+3. Dokumentationspaket strukturieren, Verantwortlichkeiten im Team bestätigen.
+4. CI/CD-Pipeline um Property- und Integrationstests erweitern.
+5. Rollout- und Sicherheitskonzepte mit Stakeholdern abstimmen.
+
+Diese Cross-Cutting-Übersicht bildet die Basis, um in weiteren Iterationen konkrete Implementierungen, Tests und Betriebskonzepte auszuarbeiten und die vollständige Blueprint-Umsetzung abzusichern.

--- a/docs/malachite_bft_architecture.md
+++ b/docs/malachite_bft_architecture.md
@@ -1,0 +1,143 @@
+# Malachite BFT – Anforderungsanalyse & Architekturplan
+
+## Zielsetzung
+Diese Analyse übersetzt den aktualisierten Malachite-BFT-Blueprint (mit Leader-Bonus) in konkrete Architekturentscheidungen für die bestehende RPP-Blockchain-Codebasis. Sie dokumentiert die funktionalen und nicht-funktionalen Anforderungen, identifiziert Lücken gegenüber dem Ist-Zustand und beschreibt die daraus abgeleiteten Komponenten- und Schnittstellenerweiterungen.
+
+## Überblick über Blueprint-Anforderungen
+* **Reputation, Timetoke & Tiers**: Teilnahmeberechtigung und Gewichtung der Konsensrollen basieren auf Reputation (Tier ≥ 3), Timetoke-Balance (Uptime) sowie VRF-Outputs.
+* **Validator-, Leader- und Witness-Rollen**: Auswahl über VRF + Timetoke, Leader nach Tier/Timetoke/VRF, Witnesses als zusätzliche Prüfer.
+* **Konsensfluss**: Proposal → Pre-Vote → Pre-Commit → Commit mit eingebettetem Konsens-Proof.
+* **Rewards**: Gleichmäßige Validator-Rewards plus Leader-Bonus (z. B. +20 %).
+* **Proof-Integration**: Rekursiver Block-Proof mit Nachweis korrekter Auswahl, Quorum und Leader-Bestimmung.
+* **Anti-Abuse**: Maßnahmen gegen Double-Signs, Fake-Proofs, Leader-Zensur, Inaktivität.
+* **Nachrichtenkanäle**: `blocks`, `votes`, `proofs`, `snapshots`, `meta`.
+* **Rust-Schnittstellen**: Traits/Module für Konsens, Wirtschaftlichkeit, Netzwerk, Clients.
+
+## Ist-Zustand der Codebasis (Kurzfassung)
+* **Reputation & Stake**: Reputation wird nur als Score für Stake-Gewichtung verwendet; Timetoke fehlt vollständig.
+* **Validator-/Proposer-Selektion**: Stake-gewichtete Lotterie auf Basis von VRF(seed, round, addr); Tier- und Timetoke-Tiebreaker fehlen.
+* **Rewards**: Proposer erhält 100 % des Blockrewards; kein Validator-Split, kein Leader-Bonus.
+* **Proofs**: STWO-Workflow prüft Signaturen und Quorum, aber keine VRF-/Leader-Verifikation.
+* **Anti-Abuse**: Allgemeines Slashing vorhanden, jedoch ohne blueprint-spezifische Checks.
+* **Netzwerk**: BFT-Nachrichten sind nicht entlang der geforderten Kanalstruktur organisiert.
+* **Rust-Interfaces**: Traits fokussieren auf Stake-BFT, ohne Reputation-/Timetoke-Einbindung.
+
+## Gap-Analyse nach Funktionsbereichen
+| Bereich | Blueprint-Soll | Ist | Lücke |
+| --- | --- | --- | --- |
+| Reputation/Tiers | Tier ≥ 3 als Mindestanforderung; Reputation beeinflusst Eintritt | Reputation nur Score, keine Tier-Filter | Tier- und Reputation-Gate implementieren |
+| Timetoke | Gewichtung/Thresholds, Decay, Synchronisation | Nicht vorhanden | Timetoke-Datenmodell + Runtime/Storage + Sync |
+| VRF & Validator-Set | VRF Input = (sk, epoch_nonce, timetoke) + Threshold aus Timetoke | Input ohne Timetoke, Threshold aus Stake | VRF-Modul erweitern, Threshold-Formel anpassen |
+| Leader-Selektion | Priorität: Tier → Timetoke → VRF | Stake-Lotterie | Neue Leader-Selektion auf Basis Validator-Set |
+| Witness-Rolle | Externe Verifikation | Nicht differenziert | Witness-Protokoll und Interfaces |
+| Rewards | Gleichmäßig + Leader-Bonus | Nur Proposer | Reward-Engine erweitern |
+| Proofs | Nachweis VRF/Leader/Quorum in Block-Proof | Nur Signatur-Check | Proof-Komponenten erweitern |
+| Anti-Abuse | Double-Sign, Fake-Proof, Zensur, Inaktivität | Teilweise generisch | Spezifische Erkennungslogik |
+| Netzwerk | Dedizierte Kanäle | Mischverkehr | Messaging-Layer modularisieren |
+| Schnittstellen | Konsens-/Ökonomie-/Netzwerk-Traits | Stake-zentriert | Neue Traits/Adapter |
+
+## Architekturentscheidungen & Komponenten
+### Domänenmodelle
+1. **Reputation & Tier Registry**
+   * Datenstrukturen: `ReputationScore`, `Tier`, `TierThresholds`.
+   * Storage: Map `<ValidatorId, ReputationState>` mit Feldern für Score, Tier, letzte Aktualisierung.
+   * APIs: `update_reputation`, `apply_slash`, `apply_decay`, `promote_tier`, `demote_tier`.
+
+2. **Timetoke Ledger**
+   * Datenstrukturen: `TimetokeBalance`, `TimetokeParams` (Decay-Rate, Cap, Sync-interval).
+   * Storage: Map `<ValidatorId, TimetokeState>` mit Feldern für Balance, letzte Aktivität, Sync-Marker.
+   * APIs: `credit_uptime`, `debit_penalty`, `snapshot_state`, `sync_state(peer)`.
+
+3. **Validator Set Snapshot**
+   * `ValidatorCandidate { id, tier, reputation_score, timetoke_balance, vrf_output }`.
+   * `ValidatorSet { epoch, members: Vec<ValidatorCandidate>, witnesses: Vec<WitnessId> }`.
+
+### Konsens- und Auswahlmodule
+1. **VRF Engine**
+   * Input: `(secret_key, epoch_nonce, timetoke_balance, validator_id)`.
+   * Output: `(vrf_output, proof)`.
+   * Threshold-Funktion: `threshold = f(timetoke_balance, network_params)` (z. B. logistischer Anstieg).
+   * Interface: `trait VrfProvider { fn evaluate(&self, ctx: VrfContext) -> VrfResult; }`.
+
+2. **Validator Selection Service**
+   * Schritte: Filter Tier ≥ 3 → VRF Evaluation → Threshold-Check → Sortierung nach Score.
+   * Persistiert `ValidatorSet` pro Epoche.
+   * Interface: `trait ValidatorSelector { fn select(epoch: EpochId) -> ValidatorSet; }`.
+
+3. **Leader Selection**
+   * Input: `ValidatorSet`.
+   * Algorithmus: sortiere nach `tier desc`, `timetoke desc`, `vrf_output asc`.
+   * Output: `LeaderAssignment { leader_id, witnesses, proof_ref }`.
+   * Interface: `trait LeaderStrategy { fn elect(set: &ValidatorSet) -> LeaderAssignment; }`.
+
+4. **Witness Coordination**
+   * Konfigurierbarer Anteil externer Nodes (z. B. Top-N Reputation außerhalb Sets).
+   * Interfaces für `WitnessValidator` mit Proof-Übermittlung.
+
+### Belohnungsengine
+* Konfigurierbare Parameter: `leader_bonus_pct`, `base_reward`, `epoch_reward_pool`.
+* Funktion: `calculate_rewards(set: &ValidatorSet, leader_id)` → `Vec<RewardPayout>`.
+* Integration in Wirtschaftsschicht mit Treasury/Emissionen.
+
+### Proof-Pipeline
+1. **ConsensusProofBuilder**
+   * Aggregiert VRF-Proofs, Validator-Set, Leader-Auswahl, Quorum-Zertifikat.
+   * Output eingebettet in Block-Header `ConsensusProof { vrf_bundle, validator_set_hash, leader_proof, quorum_signature }`.
+
+2. **Verifier**
+   * Prüft VRF-Outputs gegen Timetoke, Leader-Ranking, Quorum ≥ 2/3, Signatur.
+   * Exponiert API für Clients/Witnesses.
+
+### Anti-Abuse Framework
+* **Double-Sign Detection**: Beobachtete Signaturen pro Runde persistieren; bei Konflikt → Reputation 0, Slash, Bannflag.
+* **Fake-Proof Detection**: Proof-Verifier → invalid? → Slash + Audit-Event.
+* **Leader Censorship**: Witness-Feedback-Kanal `meta` meldet Anomalien → Reputation-Decay.
+* **Inaktivität**: Timetoke-Decay & Timeout-Tracking pro Validator.
+
+### Netzwerk & Messaging
+* Einführung eines Multiplexers, der folgende Streams bereitstellt:
+  * `blocks`: Leader-Proposals (Block + ConsensusProof).
+  * `votes`: Pre-Vote/Pre-Commit Nachrichten (mit Validator-ID, Proof-Refs).
+  * `proofs`: Weiterleitung aggregierter Proofs (VRF, Consensus, Recursive).
+  * `snapshots`: Timetoke/Reputation State-Sync.
+  * `meta`: Peer-Discovery, Reputation-Events, Misbehavior-Reports.
+* Verwendung eines Topic-Tagging-Systems innerhalb vorhandener P2P-Schicht.
+
+### Schnittstellen & Crate-Organisation
+* **Neue Crates/Module**:
+  * `consensus::malachite` – VRF/Validator-/Leader-Logik, Konsensfluss.
+  * `economics::rewards` – Reward-Splitting + Leader-Bonus.
+  * `identity::reputation` – Reputation & Tier Management.
+  * `uptime::timetoke` – Timetoke Ledger & Sync.
+* **Trait-Erweiterungen**:
+  * `ConsensusEngine` erweitert um `fn validator_set(&self, epoch)`, `fn leader(&self, epoch)`.
+  * `RewardDistributor` mit Leader-Bonus Parametrisierung.
+  * `NetworkBroadcaster` mit kanalisiertem Senden/Empfangen.
+
+### Konfiguration & Parameter
+* Globales Config-File `config/malachite.toml` (Folgeiteration) mit Parametern:
+  * `leader_bonus_pct`
+  * `validator_set_size`, `witness_count`
+  * `timetoke_decay_rate`, `timetoke_threshold_curve`
+  * `slash_penalties`
+  * `proof_batch_size`
+
+### Telemetrie & Observability
+* Metriken für Timetoke-Distribution, VRF-Erfolgsraten, Leader-Rotation, Slashing-Events.
+* Structured Logging für Konsensentscheidungen (Validator/Leader-Selektion).
+* Audit-Log für Anti-Abuse-Aktionen.
+
+## Risikoanalyse & Offene Fragen
+* **Timetoke-Synchronisation**: Wie werden Offline-Validatoren re-synchronisiert, ohne Angriffsfläche für Replays zu öffnen?
+* **VRF Threshold Design**: Welche Funktionsform garantiert faire Gewichtung ohne Dominanz einzelner Validatoren?
+* **Leader-Bonus Finanzierung**: Stammt Bonus aus zusätzlicher Emission oder Umverteilung innerhalb Reward-Pool?
+* **Witness-Anreize**: Brauchen Witnesses eigene Rewards/Slashing-Mechanismen?
+* **Proof-Komplexität**: Performance-Auswirkungen der erweiterten Konsens-Proofs müssen modelliert werden.
+
+## Nächste Schritte
+1. Detaillierte Spezifikation der Datenmodelle (Serde-Schemas, Storage-Keys).
+2. Prototypische Implementierung des Timetoke-Ledgers und der VRF-Erweiterung in isolierten Modulen.
+3. Ausarbeitung der Reward-Distribution und Konfigurationsparameter.
+4. Festlegung der Proof-Verifizierungsanforderungen mit Kryptoteam.
+5. Definition der Netzwerkkanäle in der P2P-Schicht inkl. Backwards-Kompatibilitätsplan.
+

--- a/docs/rollout_plan.md
+++ b/docs/rollout_plan.md
@@ -1,0 +1,100 @@
+# Malachite BFT Rollout Plan
+
+This guide sequences the activities required to roll out the Malachite BFT
+blueprint from development to mainnet. It assumes the supporting reputation,
+timetoke, consensus, proof, and networking features described in the blueprint
+are ready for staging.
+
+## 1. Preparation & Readiness Gates
+
+1. **Freeze interfaces and configuration defaults.** Publish a tagged release
+   candidate once the Rust interface contracts, configuration schema, and
+   telemetry payloads match the blueprint. Future changes should be
+   backward-compatible or staged behind feature gates.
+2. **Complete storage migrations in isolation.** Run migrations on a copy of
+   production state and capture before/after checksums for critical column
+   families (ledger state, timetoke snapshots, consensus metadata). Automate the
+   checksum comparison in CI so the exact migration binary is reproducible.
+3. **Finalize documentation and runbooks.** Ensure the architecture blueprint,
+   cross-cutting concerns, validator lifecycle, and deployment playbooks are all
+   published internally. Rollout cannot begin while key documents are in draft
+   form.
+4. **Run exhaustive test suites.** Finish unit, property-based, integration,
+   fuzzing, and simulation test suites. Block release if any blueprint coverage
+   regression is detected.
+
+## 2. Channel Promotion Strategy
+
+1. **Development channel.** Deploy nightly builds to an internal cluster with
+   synthetic traffic. Validate consensus liveness, proof pipeline throughput,
+   telemetry integrity, and RPC compatibility.
+2. **Testnet channel.** Promote builds that clear development testing. Rotate in
+   community validators, enable snapshot sync, and exercise witness flows for
+   several epochs. Collect feedback on reward distribution and leader rotation.
+3. **Canary channel.** Select a small subset of mainnet validators to run the
+   upcoming release in parallel with existing production binaries. Require
+   regular reporting on consensus metrics, proof latencies, and resource
+   consumption.
+4. **Mainnet channel.** Execute a scheduled maintenance window once canary shows
+   no regressions. Announce the timeline, publish release notes, and cut the
+   final tag.
+
+## 3. Feature Gate Progression
+
+1. **Consensus-only activation.** Enable validator/witness selection and
+   telemetry gates first while keeping reward payouts, slashing, and recursive
+   proof enforcement disabled. Monitor for hotfixes.
+2. **Reward engine activation.** Once consensus stabilizes, enable leader bonus
+   distribution and validator rewards in a single epoch transition. Confirm
+   payouts on-chain and in telemetry.
+3. **Proof enforcement.** Turn on recursive proof enforcement and pruning
+   requirement once the proof cache demonstrates sustained headroom. Update
+   wallet clients and witnesses to reject blocks missing proofs.
+4. **Anti-abuse tooling.** Finally, enable automated slashing for double-signs,
+   fake proofs, censorship, and inactivity. Ensure appeal processes and audit
+   logging are in place before activation.
+
+## 4. Operational Checklist per Channel
+
+1. **Genesis & configuration parity.** Verify every validator uses identical
+   genesis files, reputation tier thresholds, timetoke parameters, and feature
+   gates. Publish the canonical configuration bundle before rollout.
+2. **Monitoring dashboards.** Stand up dashboards and alerts for release
+   channel, feature gates, telemetry loops, consensus health, proof queue depth,
+   and witness participation before promoting the build.
+3. **Incident response rota.** Staff 24/7 on-call coverage during canary and the
+   first 48 hours of mainnet rollout. Provide clear escalation paths for
+   consensus faults or proof verification failures.
+4. **Data retention & backups.** Take coordinated backups of ledger state,
+   timetoke snapshots, and proof caches prior to each promotion. Confirm restore
+   procedures against staging nodes.
+
+## 5. Communication Plan
+
+1. **Validator briefings.** Share the rollout schedule, configuration deltas,
+   and operational expectations with validators at least two weeks in advance.
+   Host Q&A sessions and dry-run walkthroughs.
+2. **Ecosystem updates.** Publish release notes for wallets, witnesses, and
+   explorers describing API changes, telemetry fields, and new proof
+   requirements. Provide migration guides for SDK consumers.
+3. **Real-time status.** During rollout windows, post hourly status updates that
+   include height progression, validator participation, proof latency, and any
+   incidents. Maintain a public status page.
+
+## 6. Post-Rollout Validation & Stabilization
+
+1. **Audit reward distribution.** After the first 10 epochs, audit on-chain
+   rewards to confirm leader bonuses and validator payouts match the expected
+   configuration. Address discrepancies immediately.
+2. **Review telemetry & logs.** Analyze telemetry for missed proofs, delayed
+   votes, or gossip back-pressure. Triage regressions and schedule follow-up
+   patches.
+3. **Capture lessons learned.** Conduct a rollout retrospective within two
+   weeks. Document automation gaps, tooling improvements, and blueprint updates
+   required for the next iteration.
+4. **Establish maintenance cadence.** Define the schedule for subsequent
+   releases, including how feature gates graduate to defaults and how emergency
+   patches are handled.
+
+Following this plan ensures the Malachite BFT blueprint reaches production with
+controlled risk, clear communication, and robust observability.

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -1,0 +1,243 @@
+use std::collections::HashMap;
+
+use malachite::Natural;
+use serde::{Deserialize, Serialize};
+
+use crate::consensus::{SignedBftVote, VrfProof};
+use crate::errors::ChainResult;
+use crate::reputation::{ReputationProfile, Tier};
+use crate::rpp::TimetokeRecord;
+use crate::types::{
+    Address, Block, BlockProofBundle, SignedTransaction, TransactionProofBundle, UptimeProof,
+};
+use crate::wallet::Wallet;
+
+/// Identifier used for epoch-specific consensus state.
+pub type EpochId = u64;
+
+/// Identifier used for consensus rounds within an epoch.
+pub type RoundId = u64;
+
+/// Snapshot of a validator that is eligible for selection into the committee.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatorProfile {
+    pub address: Address,
+    pub stake: Natural,
+    pub reputation: ReputationProfile,
+    pub timetoke: TimetokeRecord,
+    pub custom_metadata: HashMap<String, String>,
+}
+
+impl ValidatorProfile {
+    pub fn new(
+        address: Address,
+        stake: Natural,
+        reputation: ReputationProfile,
+        timetoke: TimetokeRecord,
+    ) -> Self {
+        Self {
+            address,
+            stake,
+            reputation,
+            timetoke,
+            custom_metadata: HashMap::new(),
+        }
+    }
+}
+
+/// Validator candidate enriched with VRF output data for selection.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatorCandidate {
+    pub profile: ValidatorProfile,
+    pub vrf_output: Natural,
+    pub vrf_proof: VrfProof,
+}
+
+/// Witness node metadata communicated during assignments.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WitnessProfile {
+    pub address: Address,
+    pub tier: Tier,
+    pub reliability_score: f64,
+}
+
+/// Ordered validator set for an epoch along with dedicated witnesses.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatorSet {
+    pub epoch: EpochId,
+    pub members: Vec<ValidatorCandidate>,
+    pub witnesses: Vec<WitnessProfile>,
+}
+
+impl ValidatorSet {
+    pub fn top_validator(&self) -> Option<&ValidatorCandidate> {
+        self.members.first()
+    }
+}
+
+/// Leader election result for a specific epoch and round.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LeaderAssignment {
+    pub epoch: EpochId,
+    pub round: RoundId,
+    pub leader: Address,
+    pub tier: Tier,
+    pub timetoke_hours: u64,
+    pub vrf_output: Natural,
+    pub witnesses: Vec<WitnessProfile>,
+}
+
+/// Structured reward payout emitted by the reward engine.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RewardPayout {
+    pub recipient: Address,
+    pub role: RewardRole,
+    pub amount: Natural,
+}
+
+/// Identifies the role a validator or witness played during reward distribution.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RewardRole {
+    Leader,
+    Validator,
+    Witness,
+}
+
+/// Logical broadcast channels used by the consensus overlay network.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ConsensusChannel {
+    Blocks,
+    Votes,
+    Proofs,
+    Snapshots,
+    Meta,
+}
+
+/// Summary emitted by witness nodes once verification concludes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WitnessVerdict {
+    pub block_hash: String,
+    pub accepted: bool,
+    pub notes: Option<String>,
+}
+
+/// Report generated when a witness observes misbehavior.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WitnessReport {
+    pub offender: Address,
+    pub category: MisbehaviorCategory,
+    pub evidence: String,
+}
+
+/// Blueprint-aligned misbehavior categories captured by witnesses.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MisbehaviorCategory {
+    DoubleSign,
+    FakeProof,
+    Censorship,
+    Inactivity,
+    Custom(String),
+}
+
+/// High-level state returned to lightweight clients querying the network.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientStatus {
+    pub height: u64,
+    pub epoch: EpochId,
+    pub leader: Option<Address>,
+    pub validator_set_size: usize,
+}
+
+/// Trait representing the consensus engine integration points required by the blueprint.
+pub trait ConsensusEngine {
+    fn current_epoch(&self) -> EpochId;
+    fn validator_set(&self, epoch: EpochId) -> ChainResult<ValidatorSet>;
+    fn leader_for(&self, epoch: EpochId, round: RoundId) -> ChainResult<LeaderAssignment>;
+    fn submit_proposal(&self, block: Block) -> ChainResult<()>;
+    fn submit_vote(&self, vote: SignedBftVote) -> ChainResult<()>;
+}
+
+/// Abstraction responsible for filtering candidates and building the validator set.
+pub trait ValidatorSelector {
+    fn select(&self, epoch: EpochId, profiles: Vec<ValidatorProfile>) -> ChainResult<ValidatorSet>;
+}
+
+/// Strategy trait for deriving a leader from a validator set.
+pub trait LeaderStrategy {
+    fn elect(
+        &self,
+        epoch: EpochId,
+        round: RoundId,
+        set: &ValidatorSet,
+    ) -> ChainResult<LeaderAssignment>;
+}
+
+/// Coordinates the assignment and reporting flow for witness nodes.
+pub trait WitnessCoordinator {
+    fn assign_witnesses(
+        &self,
+        epoch: EpochId,
+        set: &ValidatorSet,
+    ) -> ChainResult<Vec<WitnessProfile>>;
+    fn record_verdict(&self, verdict: WitnessVerdict) -> ChainResult<()>;
+    fn record_report(&self, report: WitnessReport) -> ChainResult<()>;
+}
+
+/// Reward distribution engine honouring validator and leader roles.
+pub trait RewardDistributor {
+    fn calculate_payouts(
+        &self,
+        assignment: &LeaderAssignment,
+        set: &ValidatorSet,
+        base_reward: Natural,
+    ) -> ChainResult<Vec<RewardPayout>>;
+
+    fn apply(&self, payouts: &[RewardPayout]) -> ChainResult<()>;
+}
+
+/// Network abstraction exposing blueprint-defined gossip channels.
+pub trait ConsensusNetwork {
+    fn broadcast_block(&self, block: &Block) -> ChainResult<()>;
+    fn broadcast_vote(&self, vote: &SignedBftVote) -> ChainResult<()>;
+    fn broadcast_proof(&self, proof: &BlockProofBundle) -> ChainResult<()>;
+    fn broadcast_snapshot(&self, records: &[TimetokeRecord]) -> ChainResult<()>;
+    fn broadcast_meta(&self, event: &NetworkMetaEvent) -> ChainResult<()>;
+}
+
+/// Metadata messages circulated on the meta channel.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NetworkMetaEvent {
+    pub epoch: EpochId,
+    pub address: Address,
+    pub tier: Tier,
+    pub message: String,
+}
+
+/// Primary responsibilities of a validator node participating in consensus.
+pub trait ValidatorNode {
+    fn wallet(&self) -> &Wallet;
+    fn profile(&self) -> ChainResult<ValidatorProfile>;
+    fn propose_block(&self, block: Block) -> ChainResult<()>;
+    fn cast_vote(&self, vote: SignedBftVote) -> ChainResult<()>;
+    fn receive_rewards(&self, payouts: &[RewardPayout]) -> ChainResult<()>;
+}
+
+/// Responsibilities for witness nodes that attest to consensus events.
+pub trait WitnessNode {
+    fn identity(&self) -> Address;
+    fn assigned_epoch(&self) -> EpochId;
+    fn verify_block(
+        &self,
+        block: &Block,
+        proofs: &BlockProofBundle,
+        transactions: &[TransactionProofBundle],
+    ) -> ChainResult<WitnessVerdict>;
+    fn submit_report(&self, report: WitnessReport) -> ChainResult<()>;
+}
+
+/// Lightweight client responsibilities for interacting with the chain.
+pub trait ClientNode {
+    fn submit_transaction(&self, tx: SignedTransaction) -> ChainResult<()>;
+    fn submit_uptime_proof(&self, proof: UptimeProof) -> ChainResult<()>;
+    fn status(&self) -> ChainResult<ClientStatus>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod consensus;
 pub mod crypto;
 pub mod errors;
 pub mod identity_tree;
+pub mod interfaces;
 pub mod ledger;
 pub mod migration;
 pub mod node;

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -179,6 +179,8 @@ impl LegacyBlockV0 {
             vrf_proof: header.vrf_proof,
             timestamp: header.timestamp,
             proposer: header.proposer,
+            leader_tier: "Committed".into(),
+            leader_timetoke: 0,
         };
 
         Block {
@@ -363,6 +365,8 @@ mod tests {
                 vrf_proof: header.vrf_proof.clone(),
                 timestamp: header.timestamp,
                 proposer: header.proposer.clone(),
+                leader_tier: "Committed".into(),
+                leader_timetoke: 0,
             },
             &pruning,
         );

--- a/src/reputation.rs
+++ b/src/reputation.rs
@@ -2,6 +2,9 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::rpp::TimetokeRecord;
+use crate::types::Address;
+
 use hex;
 use serde::{Deserialize, Serialize};
 use stwo::core::vcs::blake2_hash::Blake2sHasher;
@@ -15,6 +18,74 @@ pub struct ReputationWeights {
     pub w_c: f64,
     pub w_p: f64,
     pub w_d: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TierThresholds {
+    pub tier2_min_uptime_hours: u64,
+    pub tier3_min_consensus_success: u64,
+    pub tier4_min_consensus_success: u64,
+    pub tier5_min_score: f64,
+}
+
+impl Default for TierThresholds {
+    fn default() -> Self {
+        Self {
+            tier2_min_uptime_hours: 24,
+            tier3_min_consensus_success: 10,
+            tier4_min_consensus_success: 100,
+            tier5_min_score: 0.75,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReputationParams {
+    pub weights: ReputationWeights,
+    pub tier_thresholds: TierThresholds,
+    pub decay_interval_secs: u64,
+    pub decay_factor: f64,
+}
+
+impl Default for ReputationParams {
+    fn default() -> Self {
+        Self {
+            weights: ReputationWeights::default(),
+            tier_thresholds: TierThresholds::default(),
+            decay_interval_secs: 86_400,
+            decay_factor: 0.05,
+        }
+    }
+}
+
+impl ReputationParams {
+    pub fn with_weights(weights: ReputationWeights) -> Self {
+        Self {
+            weights,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TimetokeParams {
+    pub minimum_window_secs: u64,
+    pub accrual_cap_hours: u64,
+    pub decay_interval_secs: u64,
+    pub decay_step_hours: u64,
+    pub sync_interval_secs: u64,
+}
+
+impl Default for TimetokeParams {
+    fn default() -> Self {
+        Self {
+            minimum_window_secs: 3_600,
+            accrual_cap_hours: 24 * 30,
+            decay_interval_secs: 86_400,
+            decay_step_hours: 1,
+            sync_interval_secs: 600,
+        }
+    }
 }
 
 impl Default for ReputationWeights {
@@ -139,18 +210,26 @@ impl ZsiIdentity {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct TimetokeBalance {
     pub hours_online: u64,
     pub last_proof_timestamp: u64,
+    pub last_decay_timestamp: u64,
+    pub last_sync_timestamp: u64,
 }
 
 impl TimetokeBalance {
-    pub fn record_proof(&mut self, window_start: u64, window_end: u64) -> bool {
+    pub fn record_proof(
+        &mut self,
+        window_start: u64,
+        window_end: u64,
+        params: &TimetokeParams,
+    ) -> Option<u64> {
         if window_end <= window_start {
-            return false;
+            return None;
         }
         if window_end <= self.last_proof_timestamp {
-            return false;
+            return None;
         }
         let effective_start = if self.last_proof_timestamp == 0 {
             window_start
@@ -158,16 +237,108 @@ impl TimetokeBalance {
             window_start.max(self.last_proof_timestamp)
         };
         let duration = window_end.saturating_sub(effective_start);
-        if duration < 3_600 {
-            return false;
+        if duration < params.minimum_window_secs {
+            return None;
         }
         let earned_hours = duration / 3_600;
         if earned_hours == 0 {
+            return None;
+        }
+        let remaining_capacity = params.accrual_cap_hours.saturating_sub(self.hours_online);
+        if remaining_capacity == 0 {
+            self.last_proof_timestamp = window_end;
+            return Some(0);
+        }
+        let credited_hours = earned_hours.min(remaining_capacity);
+        self.hours_online = self.hours_online.saturating_add(credited_hours);
+        self.last_proof_timestamp = window_end;
+        if self.last_decay_timestamp == 0 {
+            self.last_decay_timestamp = window_end;
+        }
+        Some(credited_hours)
+    }
+
+    pub fn debit_penalty(&mut self, penalty_hours: u64) -> u64 {
+        let removed = penalty_hours.min(self.hours_online);
+        self.hours_online = self.hours_online.saturating_sub(removed);
+        removed
+    }
+
+    pub fn apply_decay(&mut self, now: u64, params: &TimetokeParams) -> Option<u64> {
+        if params.decay_interval_secs == 0 || params.decay_step_hours == 0 {
+            return None;
+        }
+        if self.last_decay_timestamp == 0 {
+            self.last_decay_timestamp = now;
+            return None;
+        }
+        if now <= self.last_decay_timestamp {
+            return None;
+        }
+        let elapsed = now.saturating_sub(self.last_decay_timestamp);
+        if elapsed < params.decay_interval_secs {
+            return None;
+        }
+        let periods = elapsed / params.decay_interval_secs;
+        if periods == 0 {
+            return None;
+        }
+        let total_decay = params.decay_step_hours.saturating_mul(periods);
+        let removed = total_decay.min(self.hours_online);
+        if removed == 0 {
+            self.last_decay_timestamp = now;
+            return None;
+        }
+        self.hours_online = self.hours_online.saturating_sub(removed);
+        self.last_decay_timestamp = now;
+        Some(removed)
+    }
+
+    pub fn should_sync(&self, now: u64, params: &TimetokeParams) -> bool {
+        if params.sync_interval_secs == 0 {
             return false;
         }
-        self.hours_online = self.hours_online.saturating_add(earned_hours);
-        self.last_proof_timestamp = window_end;
-        true
+        if self.last_sync_timestamp == 0 {
+            return self.hours_online > 0;
+        }
+        now.saturating_sub(self.last_sync_timestamp) >= params.sync_interval_secs
+    }
+
+    pub fn mark_synced(&mut self, now: u64) {
+        self.last_sync_timestamp = now;
+    }
+
+    pub fn merge_snapshot(&mut self, record: &TimetokeRecord) -> bool {
+        let remote_hours = record.balance.min(u128::from(u64::MAX)) as u64;
+        let mut changed = false;
+        if record.last_update > self.last_proof_timestamp
+            || (record.last_update == self.last_proof_timestamp && remote_hours > self.hours_online)
+        {
+            self.hours_online = remote_hours;
+            self.last_proof_timestamp = record.last_update;
+            changed = true;
+        }
+        if record.last_sync > self.last_sync_timestamp {
+            self.last_sync_timestamp = record.last_sync;
+            changed = true;
+        }
+        if record.last_decay > self.last_decay_timestamp {
+            self.last_decay_timestamp = record.last_decay;
+            changed = true;
+        }
+        changed
+    }
+
+    pub fn as_record(&self, identity: &Address) -> TimetokeRecord {
+        TimetokeRecord {
+            identity: identity.clone(),
+            balance: self.hours_online as u128,
+            epoch_accrual: 0,
+            decay_rate: 1.0,
+            last_update: self.last_proof_timestamp,
+            last_sync: self.last_sync_timestamp,
+            last_decay: self.last_decay_timestamp,
+        }
     }
 }
 
@@ -216,8 +387,14 @@ impl ReputationProfile {
         self.last_decay_timestamp = current_timestamp();
     }
 
-    pub fn record_online_proof(&mut self, window_start: u64, window_end: u64) -> bool {
-        self.timetokes.record_proof(window_start, window_end)
+    pub fn record_online_proof(
+        &mut self,
+        window_start: u64,
+        window_end: u64,
+        params: &TimetokeParams,
+    ) -> Option<u64> {
+        self.timetokes
+            .record_proof(window_start, window_end, params)
     }
 
     pub fn record_consensus_success(&mut self) {
@@ -245,6 +422,12 @@ impl ReputationProfile {
     }
 
     pub fn recompute_score(&mut self, weights: &ReputationWeights, now: u64) {
+        let params = ReputationParams::with_weights(weights.clone());
+        self.recompute_with_params(&params, now);
+    }
+
+    pub fn recompute_with_params(&mut self, params: &ReputationParams, now: u64) {
+        let weights = &params.weights;
         let v = if self.zsi.validated { 1.0 } else { 0.0 };
         let u = Self::saturating_curve(self.timetokes.hours_online as f64, 24.0);
         let c = Self::saturating_curve(self.consensus_success as f64, 128.0);
@@ -253,19 +436,63 @@ impl ReputationProfile {
         self.score = weights.w_v * v + weights.w_u * u + weights.w_c * c + weights.w_p * p
             - weights.w_d * decay;
         self.score = self.score.clamp(0.0, 1.0);
-        self.update_tier();
+        self.update_tier_with(&params.tier_thresholds);
+    }
+
+    pub fn apply_decay_if_needed(&mut self, params: &ReputationParams, now: u64) -> bool {
+        if now <= self.last_decay_timestamp {
+            return false;
+        }
+        let elapsed = now.saturating_sub(self.last_decay_timestamp);
+        if elapsed < params.decay_interval_secs {
+            return false;
+        }
+        if params.decay_factor <= 0.0 || self.score <= 0.0 {
+            self.last_decay_timestamp = now;
+            return false;
+        }
+        let retained = (1.0 - params.decay_factor).clamp(0.0, 1.0);
+        self.score = (self.score * retained).clamp(0.0, 1.0);
+        self.last_decay_timestamp = now;
+        self.update_tier_with(&params.tier_thresholds);
+        true
+    }
+
+    pub fn promote_tier(&mut self, target: Tier) {
+        if target > self.tier {
+            self.tier = target;
+        }
+    }
+
+    pub fn demote_tier(&mut self, target: Tier) {
+        if target < self.tier {
+            self.tier = target;
+        }
+    }
+
+    pub fn apply_slash(&mut self) {
+        self.score = 0.0;
+        self.tier = Tier::Tl0;
+        self.consensus_success = 0;
+        self.peer_feedback = 0;
+        self.timetokes = TimetokeBalance::default();
     }
 
     fn update_tier(&mut self) {
+        let thresholds = TierThresholds::default();
+        self.update_tier_with(&thresholds);
+    }
+
+    fn update_tier_with(&mut self, thresholds: &TierThresholds) {
         self.tier = if !self.zsi.validated {
             Tier::Tl0
-        } else if self.timetokes.hours_online < 24 {
+        } else if self.timetokes.hours_online < thresholds.tier2_min_uptime_hours {
             Tier::Tl1
-        } else if self.consensus_success < 10 {
+        } else if self.consensus_success < thresholds.tier3_min_consensus_success {
             Tier::Tl2
-        } else if self.consensus_success < 100 {
+        } else if self.consensus_success < thresholds.tier4_min_consensus_success {
             Tier::Tl3
-        } else if self.score < 0.75 {
+        } else if self.score < thresholds.tier5_min_score {
             Tier::Tl4
         } else {
             Tier::Tl5

--- a/src/rpp.rs
+++ b/src/rpp.rs
@@ -408,12 +408,29 @@ pub enum AssetType {
 
 /// Snapshot of a node's time-based participation token balance.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TimetokeRecord {
     pub identity: Address,
     pub balance: u128,
     pub epoch_accrual: u64,
     pub decay_rate: f32,
     pub last_update: u64,
+    pub last_sync: u64,
+    pub last_decay: u64,
+}
+
+impl Default for TimetokeRecord {
+    fn default() -> Self {
+        Self {
+            identity: String::new(),
+            balance: 0,
+            epoch_accrual: 0,
+            decay_rate: 1.0,
+            last_update: 0,
+            last_sync: 0,
+            last_decay: 0,
+        }
+    }
 }
 
 /// Consolidated reputation information committed into `rep_root`.
@@ -1622,6 +1639,8 @@ mod tests {
             epoch_accrual: 1,
             decay_rate: 0.0,
             last_update: 100,
+            last_sync: 80,
+            last_decay: 90,
         };
         let updated_timetoke = TimetokeRecord {
             identity: "alice".into(),
@@ -1629,6 +1648,8 @@ mod tests {
             epoch_accrual: 3,
             decay_rate: 0.0,
             last_update: 200,
+            last_sync: 180,
+            last_decay: 190,
         };
         bundle.record_timetoke(TimetokeWitness::new(
             "alice".into(),

--- a/src/state/timetoke.rs
+++ b/src/state/timetoke.rs
@@ -26,6 +26,8 @@ impl TimetokeState {
             epoch_accrual: 0,
             decay_rate: 1.0,
             last_update: account.reputation.timetokes.last_proof_timestamp,
+            last_sync: account.reputation.timetokes.last_sync_timestamp,
+            last_decay: account.reputation.timetokes.last_decay_timestamp,
         };
         self.records.write().insert(account.address.clone(), record);
     }
@@ -36,6 +38,12 @@ impl TimetokeState {
 
     pub fn get(&self, address: &Address) -> Option<TimetokeRecord> {
         self.records.read().get(address).cloned()
+    }
+
+    pub fn snapshot(&self) -> Vec<TimetokeRecord> {
+        let mut records = self.records.read().values().cloned().collect::<Vec<_>>();
+        records.sort_by(|a, b| a.identity.cmp(&b.identity));
+        records
     }
 
     pub fn commitment(&self) -> [u8; 32] {

--- a/src/stwo/circuit/identity.rs
+++ b/src/stwo/circuit/identity.rs
@@ -89,7 +89,7 @@ impl IdentityCircuit {
             ));
         }
         let seed = self.epoch_seed()?;
-        let vrf = evaluate_vrf(&seed, 0, &self.witness.wallet_addr);
+        let vrf = evaluate_vrf(&seed, 0, &self.witness.wallet_addr, 0);
         if vrf.proof != self.witness.vrf_tag {
             return Err(ChainError::Transaction(
                 "VRF tag does not match epoch seed and wallet address".into(),
@@ -139,7 +139,7 @@ impl StarkCircuit for IdentityCircuit {
         let seed = self
             .epoch_seed()
             .map_err(|err| CircuitError::InvalidWitness(err.to_string()))?;
-        let vrf = evaluate_vrf(&seed, 0, &self.witness.wallet_addr);
+        let vrf = evaluate_vrf(&seed, 0, &self.witness.wallet_addr, 0);
         let expected_commitment = self
             .computed_commitment()
             .map_err(|err| CircuitError::InvalidWitness(err.to_string()))?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 use hex;
 use serde::Serialize;
 
+#[cfg(test)]
+use crate::reputation::Tier;
+
 use crate::errors::{ChainError, ChainResult};
 use crate::rpp::GlobalStateCommitments;
 use crate::storage::Storage;
@@ -506,6 +509,8 @@ mod tests {
             height.to_string(),
             format!("vrf{:02}", height),
             format!("proposer{:02}", height),
+            Tier::Tl3.to_string(),
+            height,
         );
         let pruning_proof = PruningProof::from_previous(previous, &header);
         let recursive_proof = match previous {

--- a/src/types/identity.rs
+++ b/src/types/identity.rs
@@ -132,7 +132,7 @@ impl IdentityGenesis {
 
     fn verify_vrf_tag(&self) -> ChainResult<()> {
         let seed = self.epoch_seed()?;
-        let proof = evaluate_vrf(&seed, 0, &self.wallet_addr);
+        let proof = evaluate_vrf(&seed, 0, &self.wallet_addr, 0);
         if proof.proof != self.vrf_tag {
             return Err(ChainError::Transaction(
                 "VRF tag does not match the provided wallet and epoch".into(),

--- a/src/wallet/wallet.rs
+++ b/src/wallet/wallet.rs
@@ -86,7 +86,7 @@ impl Wallet {
 
         let wallet_pk = hex::encode(self.keypair.public.to_bytes());
         let wallet_addr = self.address.clone();
-        let vrf = evaluate_vrf(&epoch_nonce, 0, &wallet_addr);
+        let vrf = evaluate_vrf(&epoch_nonce, 0, &wallet_addr, 0);
         let commitment_proof = ledger.identity_commitment_proof(&wallet_addr);
         let genesis = IdentityGenesis {
             wallet_pk,


### PR DESCRIPTION
## Summary
- add ledger logic to split block rewards across the validator committee while applying the Malachite leader bonus
- update the node proposer flow to use the new reward distribution instead of crediting only the proposer
- cover the reward engine with a unit test that checks balances and reputation updates for the committee

## Testing
- `cargo test distribute_consensus_rewards_with_leader_bonus -- --nocapture` *(aborted after extended compilation time)*
- `cargo check --lib` *(aborted after extended compilation time)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5dff21bc83269dfc9eaefb09e7e5