### PR TITLE
refactor(storage-firewood): remove external deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "storage-firewood",
  "stwo",
  "tempfile",
  "thiserror 1.0.69",
@@ -1792,6 +1793,13 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "serde",
+]
+
+[[package]]
+name = "storage-firewood"
+version = "0.1.0"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.7"
 rocksdb = { version = "0.24", features = ["multi-threaded-cf"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+storage-firewood = { path = "storage-firewood" }
 stwo = { version = "1.0.0", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }

--- a/storage-firewood/Cargo.toml
+++ b/storage-firewood/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "storage-firewood"
+version = "0.1.0"
+edition = "2024"

--- a/storage-firewood/src/api.rs
+++ b/storage-firewood/src/api.rs
@@ -1,0 +1,29 @@
+use crate::state::StateRoot;
+
+/// High-level state update submitted through the public API layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateUpdate {
+    /// Logical schema identifier targeted by the update.
+    pub schema: String,
+    /// Raw key payload in schema-specific format.
+    pub key: Vec<u8>,
+    /// Presence or absence of a value represents insert/update vs. delete.
+    pub value: Option<Vec<u8>>,
+}
+
+/// Public interface exposed by the Firewood storage backend to other subsystems.
+pub trait StateApi {
+    /// Error type surfaced through the API.
+    type Error;
+    /// Proof object returned when querying membership or non-membership.
+    type Proof;
+
+    /// Query the latest state for a schema/key pair.
+    fn query(&self, schema: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Apply a batch of state updates and return the resulting root hash.
+    fn apply_updates(&self, updates: Vec<StateUpdate>) -> Result<StateRoot, Self::Error>;
+
+    /// Produce a proof of inclusion or exclusion for the supplied key.
+    fn prove(&self, schema: &str, key: &[u8]) -> Result<Option<Self::Proof>, Self::Error>;
+}

--- a/storage-firewood/src/kv.rs
+++ b/storage-firewood/src/kv.rs
@@ -1,0 +1,331 @@
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    error::Error as StdError,
+    fmt,
+    fs::{self, File, OpenOptions},
+    io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write},
+    iter::Iterator,
+    path::{Path, PathBuf},
+};
+
+/// Core interface for the Firewood key-value engine.
+pub trait KeyValueEngine {
+    /// Engine-specific error type.
+    type Error;
+
+    /// Append or update the value associated with `key`.
+    fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Self::Error>;
+
+    /// Fetch the value associated with `key`.
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Remove the value associated with `key`.
+    fn delete(&mut self, key: &[u8]) -> Result<(), Self::Error>;
+
+    /// Flush any buffered state to durable storage.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+
+    /// Iterate over all key/value pairs that share the provided prefix.
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+    ) -> Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + '_>, Self::Error>;
+}
+
+/// Error type emitted by [`FirewoodKv`].
+#[derive(Debug)]
+pub enum FirewoodKvError {
+    /// Wrapper around I/O failures.
+    Io(io::Error),
+    /// The on-disk log is corrupted and cannot be parsed safely.
+    Corrupt,
+}
+
+impl fmt::Display for FirewoodKvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FirewoodKvError::Io(err) => write!(f, "i/o error: {}", err),
+            FirewoodKvError::Corrupt => f.write_str("corrupted key-value log"),
+        }
+    }
+}
+
+impl StdError for FirewoodKvError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            FirewoodKvError::Io(err) => Some(err),
+            FirewoodKvError::Corrupt => None,
+        }
+    }
+}
+
+impl From<io::Error> for FirewoodKvError {
+    fn from(err: io::Error) -> Self {
+        FirewoodKvError::Io(err)
+    }
+}
+
+const RECORD_HEADER_LEN: usize = 9;
+const FLAG_TOMBSTONE: u8 = 0x01;
+
+#[derive(Clone, Copy)]
+struct ValuePointer {
+    offset: u64,
+    len: u32,
+}
+
+/// Simple append-only Firewood key-value engine backed by a single log file.
+///
+/// The engine maintains an in-memory index mapping keys to their most recent
+/// value location in the on-disk log. Values are read lazily from disk on
+/// demand and new mutations are appended to the end of the log, enabling fast
+/// sequential writes while keeping the implementation minimal.
+pub struct FirewoodKv {
+    log_path: PathBuf,
+    writer: BufWriter<File>,
+    reader: RefCell<File>,
+    index: BTreeMap<Vec<u8>, ValuePointer>,
+}
+
+impl FirewoodKv {
+    /// Open a Firewood key-value instance rooted at `directory`.
+    pub fn open<P: AsRef<Path>>(directory: P) -> Result<Self, FirewoodKvError> {
+        let directory = directory.as_ref();
+        fs::create_dir_all(directory)?;
+        let log_path = directory.join("firewood.kv");
+
+        if !log_path.exists() {
+            File::create(&log_path)?;
+        }
+
+        let reader_file = OpenOptions::new().read(true).open(&log_path)?;
+        let writer_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&log_path)?;
+
+        let mut kv = FirewoodKv {
+            log_path,
+            writer: BufWriter::new(writer_file),
+            reader: RefCell::new(reader_file),
+            index: BTreeMap::new(),
+        };
+
+        kv.rebuild_index()?;
+        Ok(kv)
+    }
+
+    fn rebuild_index(&mut self) -> Result<(), FirewoodKvError> {
+        self.index.clear();
+
+        let reader_file = File::open(&self.log_path)?;
+        let mut reader = BufReader::new(reader_file);
+        let mut offset = 0u64;
+
+        loop {
+            let mut header = [0u8; RECORD_HEADER_LEN];
+            match reader.read_exact(&mut header) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => break,
+                Err(err) => return Err(FirewoodKvError::Io(err)),
+            }
+
+            let flags = header[0];
+            let key_len = u32::from_le_bytes([header[1], header[2], header[3], header[4]]) as usize;
+            let value_len = u32::from_le_bytes([header[5], header[6], header[7], header[8]]) as usize;
+
+            let mut key = vec![0u8; key_len];
+            reader.read_exact(&mut key).map_err(|err| match err.kind() {
+                io::ErrorKind::UnexpectedEof => FirewoodKvError::Corrupt,
+                _ => FirewoodKvError::Io(err),
+            })?;
+
+            let value_offset = offset + RECORD_HEADER_LEN as u64 + key_len as u64;
+            if value_len > 0 {
+                reader
+                    .seek(SeekFrom::Current(value_len as i64))
+                    .map_err(FirewoodKvError::Io)?;
+            }
+
+            if flags & FLAG_TOMBSTONE != 0 {
+                self.index.remove(&key);
+            } else {
+                self.index.insert(
+                    key,
+                    ValuePointer {
+                        offset: value_offset,
+                        len: value_len as u32,
+                    },
+                );
+            }
+
+            offset += RECORD_HEADER_LEN as u64 + key_len as u64 + value_len as u64;
+        }
+
+        Ok(())
+    }
+
+    fn read_value(&self, pointer: ValuePointer) -> Result<Vec<u8>, FirewoodKvError> {
+        let mut reader = self.reader.borrow_mut();
+        reader.seek(SeekFrom::Start(pointer.offset))?;
+        let mut buf = vec![0u8; pointer.len as usize];
+        reader.read_exact(&mut buf)?;
+        Ok(buf)
+    }
+
+    fn append_record(&mut self, key: &[u8], value: Option<&[u8]>) -> Result<(), FirewoodKvError> {
+        let flags = if value.is_some() { 0 } else { FLAG_TOMBSTONE };
+        let value_len = value.map(|v| v.len()).unwrap_or(0) as u32;
+        let key_len = key.len() as u32;
+
+        let mut header = [0u8; RECORD_HEADER_LEN];
+        header[0] = flags;
+        header[1..5].copy_from_slice(&key_len.to_le_bytes());
+        header[5..9].copy_from_slice(&value_len.to_le_bytes());
+
+        let offset = self.writer.seek(SeekFrom::End(0))?;
+        self.writer.write_all(&header)?;
+        self.writer.write_all(key)?;
+        if let Some(value) = value {
+            self.writer.write_all(value)?;
+        }
+        self.writer.flush()?;
+
+        if let Some(value) = value {
+            self.index.insert(
+                key.to_vec(),
+                ValuePointer {
+                    offset: offset + RECORD_HEADER_LEN as u64 + key.len() as u64,
+                    len: value.len() as u32,
+                },
+            );
+        } else {
+            self.index.remove(key);
+        }
+
+        Ok(())
+    }
+}
+
+impl KeyValueEngine for FirewoodKv {
+    type Error = FirewoodKvError;
+
+    fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Self::Error> {
+        self.append_record(&key, Some(&value))
+    }
+
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        if let Some(pointer) = self.index.get(key) {
+            Ok(Some(self.read_value(*pointer)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn delete(&mut self, key: &[u8]) -> Result<(), Self::Error> {
+        self.append_record(key, None)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.writer.flush()?;
+        self.writer.get_ref().sync_data()?;
+        Ok(())
+    }
+
+    fn scan_prefix(
+        &self,
+        prefix: &[u8],
+    ) -> Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + '_>, Self::Error> {
+        let mut results = Vec::new();
+        let start = prefix.to_vec();
+        for (key, pointer) in self.index.range(start..) {
+            if !key.starts_with(prefix) {
+                break;
+            }
+            results.push((key.clone(), self.read_value(*pointer)?));
+        }
+        Ok(Box::new(results.into_iter()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FirewoodKv, KeyValueEngine};
+    use std::{
+        env,
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    static NEXT_DIR_ID: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new() -> Self {
+            let mut path = env::temp_dir();
+            let id = NEXT_DIR_ID.fetch_add(1, Ordering::Relaxed);
+            path.push(format!("firewood-test-{}", id));
+            fs::create_dir_all(&path).expect("create temp dir");
+            TestDir { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn put_get_roundtrip_persists() {
+        let tempdir = TestDir::new();
+        {
+            let mut kv = FirewoodKv::open(tempdir.path()).expect("open");
+            kv.put(b"alpha".to_vec(), b"one".to_vec()).expect("put");
+            kv.flush().expect("flush");
+        }
+
+        let kv = FirewoodKv::open(tempdir.path()).expect("reopen");
+        assert_eq!(kv.get(b"alpha").expect("get"), Some(b"one".to_vec()));
+    }
+
+    #[test]
+    fn delete_writes_tombstone() {
+        let tempdir = TestDir::new();
+        let mut kv = FirewoodKv::open(tempdir.path()).expect("open");
+        kv.put(b"key".to_vec(), b"value".to_vec()).expect("put");
+        kv.delete(b"key").expect("delete");
+        kv.flush().expect("flush");
+        drop(kv);
+
+        let kv = FirewoodKv::open(tempdir.path()).expect("reopen");
+        assert!(kv.get(b"key").expect("get").is_none());
+    }
+
+    #[test]
+    fn scan_prefix_returns_ordered_results() {
+        let tempdir = TestDir::new();
+        let mut kv = FirewoodKv::open(tempdir.path()).expect("open");
+        kv.put(b"user:1".to_vec(), b"alice".to_vec()).expect("put1");
+        kv.put(b"user:2".to_vec(), b"bob".to_vec()).expect("put2");
+        kv.put(b"order:1".to_vec(), b"pizza".to_vec()).expect("put3");
+
+        let results: Vec<_> = kv
+            .scan_prefix(b"user:")
+            .expect("scan")
+            .collect();
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], (b"user:1".to_vec(), b"alice".to_vec()));
+        assert_eq!(results[1], (b"user:2".to_vec(), b"bob".to_vec()));
+    }
+}

--- a/storage-firewood/src/lib.rs
+++ b/storage-firewood/src/lib.rs
@@ -1,0 +1,78 @@
+pub mod api;
+pub mod kv;
+pub mod pruning;
+pub mod schema;
+pub mod state;
+pub mod tree;
+pub mod wal;
+
+#[cfg(test)]
+mod tests {
+    use super::state::{StateManager, StateReader, StateRoot, StateTransaction};
+
+    struct NoopState;
+
+    #[derive(Clone)]
+    struct NoopReader;
+
+    struct NoopTransaction;
+
+    #[derive(Debug)]
+    struct Error;
+
+    impl StateReader for NoopReader {
+        type Error = Error;
+
+        fn get_raw(&self, _schema: &str, _key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+            Ok(None)
+        }
+
+        fn root_hash(&self) -> StateRoot {
+            Vec::new()
+        }
+    }
+
+    impl StateTransaction for NoopTransaction {
+        type Error = Error;
+
+        fn put_raw(&mut self, _schema: &str, _key: Vec<u8>, _value: Vec<u8>) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn delete_raw(&mut self, _schema: &str, _key: &[u8]) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn commit(self) -> Result<StateRoot, Self::Error> {
+            Ok(Vec::new())
+        }
+
+        fn rollback(self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    impl StateManager for NoopState {
+        type Error = Error;
+        type Transaction = NoopTransaction;
+        type Reader = NoopReader;
+
+        fn reader(&self) -> Result<Self::Reader, Self::Error> {
+            Ok(NoopReader)
+        }
+
+        fn begin_transaction(&self) -> Result<Self::Transaction, Self::Error> {
+            Ok(NoopTransaction)
+        }
+    }
+
+    #[test]
+    fn traits_can_be_implemented() {
+        let state = NoopState;
+        let reader = state.reader().expect("reader");
+        assert!(reader.root_hash().is_empty());
+
+        let tx = state.begin_transaction().expect("tx");
+        tx.commit().expect("commit");
+    }
+}

--- a/storage-firewood/src/pruning.rs
+++ b/storage-firewood/src/pruning.rs
@@ -1,0 +1,17 @@
+/// Trait describing the pruning subsystem that reclaims historical data while
+/// preserving proof material.
+pub trait PruningLayer {
+    /// Error emitted by the pruning logic.
+    type Error;
+    /// Marker type that identifies prune checkpoints (e.g. block heights or epochs).
+    type Marker: Clone + Ord;
+
+    /// Register that data up to `marker` has become eligible for pruning.
+    fn mark_compactable(&mut self, marker: Self::Marker) -> Result<(), Self::Error>;
+
+    /// Remove all compacted data whose marker is less than or equal to `marker`.
+    fn prune_until(&mut self, marker: &Self::Marker) -> Result<usize, Self::Error>;
+
+    /// Inspect the oldest marker that still requires pruning.
+    fn oldest_pending(&self) -> Option<Self::Marker>;
+}

--- a/storage-firewood/src/schema.rs
+++ b/storage-firewood/src/schema.rs
@@ -1,0 +1,43 @@
+/// Errors that can occur when encoding or decoding schema-specific values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SchemaError {
+    /// The provided input could not be represented within the schema.
+    Encode(&'static str),
+    /// Stored data failed to decode into the expected schema type.
+    Decode(&'static str),
+}
+
+pub type SchemaResult<T> = Result<T, SchemaError>;
+
+/// Trait implemented by logical schemas stored inside Firewood.
+pub trait Schema {
+    /// Logical name of the schema (e.g. "utxo", "reputation").
+    fn name() -> &'static str;
+    /// Key type stored in the schema.
+    type Key;
+    /// Value type stored in the schema.
+    type Value;
+
+    /// Encode a logical key into its storage representation.
+    fn encode_key(key: &Self::Key) -> SchemaResult<Vec<u8>>;
+    /// Encode a logical value into its storage representation.
+    fn encode_value(value: &Self::Value) -> SchemaResult<Vec<u8>>;
+    /// Decode a stored key back into its logical form.
+    fn decode_key(data: &[u8]) -> SchemaResult<Self::Key>;
+    /// Decode a stored value back into its logical form.
+    fn decode_value(data: &[u8]) -> SchemaResult<Self::Value>;
+}
+
+/// Registry that tracks the schemas made available to the storage backend.
+pub trait SchemaRegistry {
+    /// Error type raised by registry implementations.
+    type Error;
+
+    /// Register a schema with the registry.
+    fn register<S>(&mut self) -> Result<(), Self::Error>
+    where
+        S: Schema;
+
+    /// Determine whether a schema with the supplied `name` is registered.
+    fn is_registered(&self, name: &str) -> bool;
+}

--- a/storage-firewood/src/state.rs
+++ b/storage-firewood/src/state.rs
@@ -1,0 +1,48 @@
+/// Canonical representation of the state root hash produced after every commit.
+pub type StateRoot = Vec<u8>;
+
+/// Read-only view over a committed state snapshot.
+pub trait StateReader {
+    /// Error type returned by reader implementations.
+    type Error;
+
+    /// Fetch a raw value for the provided `schema` and `key` combination.
+    fn get_raw(&self, schema: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Return the root hash for this snapshot.
+    fn root_hash(&self) -> StateRoot;
+}
+
+/// Mutable transaction that stages updates prior to a commit.
+pub trait StateTransaction {
+    /// Error type surfaced during transaction processing.
+    type Error;
+
+    /// Insert or update a value in the given `schema`.
+    fn put_raw(&mut self, schema: &str, key: Vec<u8>, value: Vec<u8>) -> Result<(), Self::Error>;
+
+    /// Remove an entry from the given `schema`.
+    fn delete_raw(&mut self, schema: &str, key: &[u8]) -> Result<(), Self::Error>;
+
+    /// Finalize the transaction and return the resulting state root.
+    fn commit(self) -> Result<StateRoot, Self::Error>;
+
+    /// Abort the transaction, discarding staged changes.
+    fn rollback(self) -> Result<(), Self::Error>;
+}
+
+/// High-level state manager that coordinates snapshot access and transactional updates.
+pub trait StateManager {
+    /// Unified error type returned by the manager and its associated components.
+    type Error;
+    /// Transaction type created by `begin_transaction`.
+    type Transaction: StateTransaction<Error = Self::Error>;
+    /// Reader type returned when accessing committed state.
+    type Reader: StateReader<Error = Self::Error>;
+
+    /// Acquire a read-only handle to the latest committed state.
+    fn reader(&self) -> Result<Self::Reader, Self::Error>;
+
+    /// Start a new state transaction.
+    fn begin_transaction(&self) -> Result<Self::Transaction, Self::Error>;
+}

--- a/storage-firewood/src/tree.rs
+++ b/storage-firewood/src/tree.rs
@@ -1,0 +1,36 @@
+/// Abstraction over the sparse Merkle tree maintained for every committed state.
+pub trait SparseMerkleTree {
+    /// Error type for tree operations.
+    type Error;
+    /// Hash output representing the tree root.
+    type Root: Clone + Eq;
+    /// Leaf key type (typically a hash of the logical key).
+    type Key: Clone + Eq;
+    /// Value stored at a leaf position.
+    type Value: Clone;
+    /// Proof object generated for inclusion/exclusion checks.
+    type Proof;
+
+    /// Fetch the current root hash for the tree.
+    fn root(&self) -> Self::Root;
+
+    /// Apply a single leaf update.
+    fn update(&mut self, key: &Self::Key, value: Self::Value) -> Result<Self::Root, Self::Error>;
+
+    /// Apply a batch of leaf updates atomically, returning the resulting root.
+    fn batch_update(
+        &mut self,
+        entries: &[(Self::Key, Self::Value)],
+    ) -> Result<Self::Root, Self::Error>;
+
+    /// Generate a Merkle proof for the supplied key.
+    fn prove(&self, key: &Self::Key) -> Result<Self::Proof, Self::Error>;
+
+    /// Verify a Merkle proof against an expected root.
+    fn verify(
+        root: &Self::Root,
+        key: &Self::Key,
+        value: &Self::Value,
+        proof: &Self::Proof,
+    ) -> Result<bool, Self::Error>;
+}

--- a/storage-firewood/src/wal.rs
+++ b/storage-firewood/src/wal.rs
@@ -1,0 +1,25 @@
+use std::iter::Iterator;
+
+/// Abstraction over the write-ahead log used to guarantee durability and ordering.
+pub trait WriteAheadLog {
+    /// Error type emitted by the WAL implementation.
+    type Error;
+
+    /// Logical sequence identifier that monotonically increases with every append.
+    type SequenceNumber: Copy + Ord;
+
+    /// Append a raw record to the log, returning the assigned sequence number.
+    fn append(&mut self, record: &[u8]) -> Result<Self::SequenceNumber, Self::Error>;
+
+    /// Force buffered log data to be persisted.
+    fn sync(&mut self) -> Result<(), Self::Error>;
+
+    /// Replay the log starting at `sequence`, yielding each record payload in order.
+    fn replay_from(
+        &self,
+        sequence: Self::SequenceNumber,
+    ) -> Result<Box<dyn Iterator<Item = Vec<u8>> + '_>, Self::Error>;
+
+    /// Discard all log entries with sequence numbers strictly greater than `sequence`.
+    fn truncate(&mut self, sequence: Self::SequenceNumber) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
## Summary
- remove the `thiserror` and `tempfile` dependencies from the Firewood crate manifest to keep the fork self-contained
- implement manual display/`std::error::Error` wiring for `FirewoodKvError` and add an in-crate temp directory harness for tests using only the standard library

## Testing
- cargo fmt
- cargo check --manifest-path storage-firewood/Cargo.toml
- cargo test --manifest-path storage-firewood/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d086df23bc8326bdcf672d2b954b00