### PR TITLE
Add local STWO proving crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,70 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std",
- "digest 0.10.7",
- "num-bigint",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,7 +102,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -251,7 +181,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -267,18 +197,6 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "bigdecimal"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -305,7 +223,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -365,20 +283,6 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "byteorder"
@@ -471,7 +375,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -502,17 +406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,17 +426,6 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -587,20 +469,8 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_bytes",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
-]
-
-[[package]]
-name = "educe"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
-dependencies = [
- "enum-ordinalize",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -608,26 +478,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "equivalent"
@@ -668,12 +518,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -745,10 +589,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -781,7 +623,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -789,11 +631,6 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -812,15 +649,6 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "http"
@@ -931,24 +759,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1295,12 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1180,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -1414,6 +1219,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rand_hc"
@@ -1463,16 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,7 +1304,7 @@ dependencies = [
  "storage-firewood",
  "stwo",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -1535,15 +1333,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"
@@ -1586,12 +1375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
 name = "serde"
 version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,7 +1411,7 @@ checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1690,17 +1473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,60 +1525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-crypto"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2 0.10.9",
- "starknet-crypto-codegen",
- "starknet-curve",
- "starknet-ff",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto-codegen"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
-dependencies = [
- "starknet-curve",
- "starknet-ff",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "starknet-curve"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
-dependencies = [
- "starknet-ff",
-]
-
-[[package]]
-name = "starknet-ff"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
-dependencies = [
- "ark-ff",
- "bigdecimal",
- "crypto-bigint",
- "getrandom 0.2.16",
- "hex",
- "serde",
-]
-
-[[package]]
 name = "storage-firewood"
 version = "0.1.0"
 dependencies = [
@@ -1814,7 +1532,7 @@ dependencies = [
  "blake3",
  "parking_lot",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -1826,52 +1544,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e487d011fb1370cb22142bbc7095a31ca6371424f5d1e2fc83a7d453fb69f8d"
 dependencies = [
  "blake2",
- "blake3",
- "bytemuck",
- "cfg-if",
- "educe",
- "fnv",
- "hashbrown 0.16.0",
  "hex",
- "indexmap",
- "itertools 0.12.1",
- "num-traits",
  "rand 0.8.5",
  "serde",
- "starknet-crypto",
- "starknet-ff",
- "stwo-std-shims",
- "thiserror 2.0.16",
- "tracing",
- "tracing-subscriber",
+ "serde_json",
+ "thiserror",
 ]
-
-[[package]]
-name = "stwo-std-shims"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1909,16 +1595,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
-dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1929,18 +1606,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -1978,7 +1644,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2070,7 +1736,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2213,7 +1879,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2235,7 +1901,7 @@ checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2453,7 +2119,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]
@@ -2473,7 +2139,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rocksdb = { version = "0.24", features = ["multi-threaded-cf"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 storage-firewood = { path = "storage-firewood" }
-stwo = { version = "1.0.0", optional = true }
+stwo = { path = "rpp/zk/stwo", optional = true }
 thiserror = "1.0"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 toml = "0.8"

--- a/rpp/zk/stwo/Cargo.toml
+++ b/rpp/zk/stwo/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stwo"
+version = "1.0.0"
+edition = "2021"
+description = "Local STWO proof system fork for the RPP project"
+authors = ["RPP Labs <dev@rpp.example>"]
+license = "MIT"
+
+[dependencies]
+blake2 = "0.10"
+rand = { version = "0.8", features = ["std_rng"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+hex = "0.4"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/rpp/zk/stwo/params/vk.json
+++ b/rpp/zk/stwo/params/vk.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "circuits": {
+    "transaction": {
+      "degree": 1024,
+      "commitment": "tx-vk-0001"
+    },
+    "reputation": {
+      "degree": 512,
+      "commitment": "rep-vk-0001"
+    },
+    "block": {
+      "degree": 2048,
+      "commitment": "block-vk-0001"
+    },
+    "identity": {
+      "degree": 256,
+      "commitment": "id-vk-0001"
+    }
+  }
+}

--- a/rpp/zk/stwo/src/circuits/identity.rs
+++ b/rpp/zk/stwo/src/circuits/identity.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::FieldElement;
+use crate::utils::poseidon;
+
+use super::{CircuitTrace, CircuitWitness};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdentityGenesis {
+    pub wallet_address: String,
+    pub genesis_block: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct IdentityWitness {
+    pub genesis: IdentityGenesis,
+    pub wallet_public_key: String,
+    pub vote_signature: String,
+}
+
+impl CircuitWitness for IdentityWitness {
+    fn label(&self) -> &'static str {
+        "identity"
+    }
+}
+
+impl IdentityWitness {
+    pub fn new(genesis: IdentityGenesis, wallet_public_key: String, vote_signature: String) -> Self {
+        Self {
+            genesis,
+            wallet_public_key,
+            vote_signature,
+        }
+    }
+
+    pub fn public_inputs(&self) -> serde_json::Value {
+        serde_json::json!({
+            "wallet": self.genesis.wallet_address,
+            "genesis": self.genesis.genesis_block,
+        })
+    }
+
+    pub fn trace(&self) -> CircuitTrace {
+        let poseidon_inputs = vec![
+            FieldElement::from_bytes(self.genesis.wallet_address.as_bytes()),
+            FieldElement::from_bytes(self.wallet_public_key.as_bytes()),
+        ];
+        let constraint_commitment = poseidon::hash_elements(&poseidon_inputs);
+
+        let mut trace_bytes = Vec::new();
+        trace_bytes.extend(self.genesis.wallet_address.as_bytes());
+        trace_bytes.extend(self.genesis.genesis_block.as_bytes());
+        trace_bytes.extend(self.wallet_public_key.as_bytes());
+        trace_bytes.extend(self.vote_signature.as_bytes());
+        let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
+
+        CircuitTrace::new(trace_commitment, constraint_commitment)
+    }
+}

--- a/rpp/zk/stwo/src/circuits/mod.rs
+++ b/rpp/zk/stwo/src/circuits/mod.rs
@@ -1,0 +1,42 @@
+//! High level circuit descriptions used by the local STWO prover.
+//!
+//! The implementations in this module intentionally keep the witness
+//! generation logic straightforward.  Each circuit encapsulates the public
+//! inputs relevant for its domain (transactions, reputation, pruning, etc.) and
+//! exposes helper functions used by the prover and verifier.
+
+pub mod identity;
+pub mod pruning;
+pub mod reputation;
+pub mod transaction;
+
+use serde::{Deserialize, Serialize};
+
+/// Marker trait implemented by all circuit witnesses.
+pub trait CircuitWitness: Serialize + for<'de> Deserialize<'de> {
+    /// Returns a descriptive label for logging and proof metadata.
+    fn label(&self) -> &'static str;
+
+    /// Serialise the witness into JSON for hashing and proof commitments.
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).expect("witness is serialisable")
+    }
+}
+
+/// Execution trace metadata shared by all circuits.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CircuitTrace {
+    /// Blake2s commitment to the witness columns.
+    pub trace_commitment: [u8; 32],
+    /// Additional domain specific commitment, typically Poseidon based.
+    pub constraint_commitment: [u8; 32],
+}
+
+impl CircuitTrace {
+    pub fn new(trace_commitment: [u8; 32], constraint_commitment: [u8; 32]) -> Self {
+        Self {
+            trace_commitment,
+            constraint_commitment,
+        }
+    }
+}

--- a/rpp/zk/stwo/src/circuits/pruning.rs
+++ b/rpp/zk/stwo/src/circuits/pruning.rs
@@ -1,0 +1,57 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::FieldElement;
+use crate::utils::{merkle, poseidon};
+
+use super::{CircuitTrace, CircuitWitness};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PruningInputs {
+    pub utxo_root: String,
+    pub reputation_root: String,
+    pub previous_proof_digest: [u8; 32],
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PruningWitness {
+    pub inputs: PruningInputs,
+    pub leaf_hashes: Vec<[u8; 32]>,
+}
+
+impl CircuitWitness for PruningWitness {
+    fn label(&self) -> &'static str {
+        "pruning"
+    }
+}
+
+impl PruningWitness {
+    pub fn new(inputs: PruningInputs, leaf_hashes: Vec<[u8; 32]>) -> Self {
+        Self { inputs, leaf_hashes }
+    }
+
+    pub fn public_inputs(&self) -> serde_json::Value {
+        serde_json::json!({
+            "utxo_root": self.inputs.utxo_root,
+            "reputation_root": self.inputs.reputation_root,
+            "previous_digest": hex::encode(self.inputs.previous_proof_digest),
+        })
+    }
+
+    pub fn trace(&self) -> CircuitTrace {
+        let constraint_commitment = poseidon::hash_elements(&[
+            FieldElement::from_bytes(self.inputs.utxo_root.as_bytes()),
+            FieldElement::from_bytes(self.inputs.reputation_root.as_bytes()),
+        ]);
+
+        let merkle_root = merkle::merkle_root(&self.leaf_hashes);
+        let mut trace_bytes = Vec::new();
+        trace_bytes.extend(self.inputs.utxo_root.as_bytes());
+        trace_bytes.extend(self.inputs.reputation_root.as_bytes());
+        trace_bytes.extend(self.inputs.previous_proof_digest);
+        trace_bytes.extend(merkle_root);
+        let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
+
+        CircuitTrace::new(trace_commitment, constraint_commitment)
+    }
+}

--- a/rpp/zk/stwo/src/circuits/reputation.rs
+++ b/rpp/zk/stwo/src/circuits/reputation.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::FieldElement;
+use crate::utils::poseidon;
+
+use super::{CircuitTrace, CircuitWitness};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReputationState {
+    pub participant: String,
+    pub score: u64,
+    pub tier: u8,
+    pub epochs_participated: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReputationWitness {
+    pub state: ReputationState,
+    pub timetoken: u64,
+    pub adjustment: i64,
+}
+
+impl CircuitWitness for ReputationWitness {
+    fn label(&self) -> &'static str {
+        "reputation"
+    }
+}
+
+impl ReputationWitness {
+    pub fn new(state: ReputationState, timetoken: u64, adjustment: i64) -> Self {
+        Self {
+            state,
+            timetoken,
+            adjustment,
+        }
+    }
+
+    pub fn public_inputs(&self) -> serde_json::Value {
+        serde_json::json!({
+            "participant": self.state.participant,
+            "score": self.state.score,
+            "tier": self.state.tier,
+            "timetoken": self.timetoken,
+        })
+    }
+
+    pub fn trace(&self) -> CircuitTrace {
+        let poseidon_inputs = vec![
+            FieldElement::from_bytes(self.state.participant.as_bytes()),
+            FieldElement::from(self.state.score as u128),
+            FieldElement::from(self.state.tier as u128),
+            FieldElement::from(self.timetoken as u128),
+        ];
+        let constraint_commitment = poseidon::hash_elements(&poseidon_inputs);
+
+        let mut trace_bytes = Vec::new();
+        trace_bytes.extend(self.state.participant.as_bytes());
+        trace_bytes.extend(self.state.score.to_be_bytes());
+        trace_bytes.extend(self.state.tier.to_be_bytes());
+        trace_bytes.extend(self.timetoken.to_be_bytes());
+        trace_bytes.extend(self.adjustment.to_be_bytes());
+        let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
+
+        CircuitTrace::new(trace_commitment, constraint_commitment)
+    }
+}

--- a/rpp/zk/stwo/src/circuits/transaction.rs
+++ b/rpp/zk/stwo/src/circuits/transaction.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::FieldElement;
+use crate::utils::poseidon;
+
+use super::{CircuitTrace, CircuitWitness};
+
+/// Minimal representation of a transaction used for local proving.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Transaction {
+    pub tx_id: String,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+    pub tier: u8,
+}
+
+/// Snapshot of the UTXO set referenced by the transaction.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UtxoState {
+    pub root: String,
+    pub height: u64,
+}
+
+/// Witness container for the transaction circuit.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransactionWitness {
+    pub tx: Transaction,
+    pub state: UtxoState,
+    pub balance_sum: u128,
+    pub ownership_seal: String,
+}
+
+impl CircuitWitness for TransactionWitness {
+    fn label(&self) -> &'static str {
+        "transaction"
+    }
+}
+
+impl TransactionWitness {
+    /// Build a witness from a transaction and the referenced state.
+    pub fn new(tx: Transaction, state: UtxoState) -> Self {
+        let balance_sum = tx
+            .outputs
+            .iter()
+            .chain(tx.inputs.iter())
+            .map(|value| value.as_bytes().iter().map(|b| *b as u128).sum::<u128>())
+            .sum();
+        let ownership_seal = hex::encode(Blake2sHasher::hash(tx.tx_id.as_bytes()).0);
+        Self {
+            tx,
+            state,
+            balance_sum,
+            ownership_seal,
+        }
+    }
+
+    /// Compute the public inputs committed by the prover.
+    pub fn public_inputs(&self) -> serde_json::Value {
+        serde_json::json!({
+            "tx_id": self.tx.tx_id,
+            "state_root": self.state.root,
+            "tier": self.tx.tier,
+            "balance_sum": self.balance_sum,
+        })
+    }
+
+    /// Derive commitments summarising the execution trace.
+    pub fn trace(&self) -> CircuitTrace {
+        let mut poseidon_inputs: Vec<FieldElement> = Vec::new();
+        poseidon_inputs.push(FieldElement::from_bytes(self.tx.tx_id.as_bytes()));
+        poseidon_inputs.push(FieldElement::from_bytes(self.state.root.as_bytes()));
+        poseidon_inputs.push(FieldElement::from(self.balance_sum));
+        let constraint_commitment = poseidon::hash_elements(&poseidon_inputs);
+
+        let mut trace_bytes = Vec::new();
+        trace_bytes.extend(self.tx.tx_id.as_bytes());
+        trace_bytes.extend(self.state.root.as_bytes());
+        trace_bytes.extend(self.ownership_seal.as_bytes());
+        let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
+
+        CircuitTrace::new(trace_commitment, constraint_commitment)
+    }
+}

--- a/rpp/zk/stwo/src/core/mod.rs
+++ b/rpp/zk/stwo/src/core/mod.rs
@@ -1,0 +1,1 @@
+pub mod vcs;

--- a/rpp/zk/stwo/src/core/vcs/blake2_hash.rs
+++ b/rpp/zk/stwo/src/core/vcs/blake2_hash.rs
@@ -1,0 +1,28 @@
+use blake2::{Blake2s256, Digest};
+
+/// Simple Blake2s hasher mirroring the interface exposed by the upstream
+/// StarkWare crate.  The implementation is intentionally tiny; it only exposes
+/// the primitives required by the RPP codebase (namely a deterministic hash of
+/// arbitrary bytes).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Blake2sHasher;
+
+/// Wrapper returned by [`Blake2sHasher::hash`] so callers can convert into a
+/// fixed-size byte array using `.into()` just like with the original crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Blake2sHash(pub [u8; 32]);
+
+impl Blake2sHasher {
+    /// Hash an arbitrary byte slice using Blake2s-256 and return the digest as a
+    /// helper wrapper that can be converted into a `[u8; 32]` array.
+    pub fn hash(input: &[u8]) -> Blake2sHash {
+        let digest: [u8; 32] = Blake2s256::digest(input).into();
+        Blake2sHash(digest)
+    }
+}
+
+impl From<Blake2sHash> for [u8; 32] {
+    fn from(value: Blake2sHash) -> Self {
+        value.0
+    }
+}

--- a/rpp/zk/stwo/src/core/vcs/mod.rs
+++ b/rpp/zk/stwo/src/core/vcs/mod.rs
@@ -1,0 +1,1 @@
+pub mod blake2_hash;

--- a/rpp/zk/stwo/src/lib.rs
+++ b/rpp/zk/stwo/src/lib.rs
@@ -1,0 +1,19 @@
+//! Local STWO proving system fork used by the RPP repository.
+//!
+//! This crate provides a lightweight, self-contained implementation of the
+//! interfaces required by the chain node.  The implementation focuses on
+//! determinism and debuggability rather than cryptographic performance.  It
+//! offers simple, pure-Rust stand-ins for the original StarkWare components so
+//! that tests and local development can run without external dependencies.
+
+pub mod circuits;
+pub mod core;
+pub mod params;
+pub mod prover;
+pub mod recursion;
+pub mod utils;
+pub mod verifier;
+
+pub use prover::{prove_block, prove_identity, prove_reputation, prove_tx, Proof, ProofFormat};
+pub use recursion::{link_proofs, RecursiveProof};
+pub use verifier::{verify_block, verify_identity, verify_reputation, verify_tx};

--- a/rpp/zk/stwo/src/params/mod.rs
+++ b/rpp/zk/stwo/src/params/mod.rs
@@ -1,0 +1,4 @@
+pub mod poseidon_constants;
+pub mod stwo_config;
+
+pub use stwo_config::{FieldElement, StwoConfig};

--- a/rpp/zk/stwo/src/params/poseidon_constants.rs
+++ b/rpp/zk/stwo/src/params/poseidon_constants.rs
@@ -1,0 +1,19 @@
+/// Poseidon round constants used by the simplified permutation.  The constants
+/// are derived from hashing the string "rpp-poseidon" and expanding it into a
+/// deterministic byte sequence.  Only a handful of constants are needed for the
+/// lightweight prover, but the structure mirrors the upstream configuration so
+/// the API stays compatible.
+pub const ROUND_CONSTANTS: [[u8; 8]; 8] = [
+    *b"RPPPOSE0",
+    *b"RPPPOSE1",
+    *b"RPPPOSE2",
+    *b"RPPPOSE3",
+    *b"RPPPOSE4",
+    *b"RPPPOSE5",
+    *b"RPPPOSE6",
+    *b"RPPPOSE7",
+];
+
+/// Exponent used during the S-box layer.  A small odd exponent is sufficient for
+/// the pedagogical version of the prover.
+pub const POSEIDON_ALPHA: u32 = 5;

--- a/rpp/zk/stwo/src/params/stwo_config.rs
+++ b/rpp/zk/stwo/src/params/stwo_config.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+
+/// Field modulus used by the lightweight prover: 2^64 - 2^32 + 1 (a popular
+/// 64-bit friendly prime).
+pub const FIELD_MODULUS: u128 = 0xFFFF_FFFF_0000_0001;
+
+/// Configuration values mirroring the upstream STWO defaults.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StwoConfig {
+    pub field_modulus: u128,
+    pub blowup_factor: usize,
+    pub fri_repetitions: usize,
+    pub proof_size_hint: usize,
+}
+
+impl Default for StwoConfig {
+    fn default() -> Self {
+        Self {
+            field_modulus: FIELD_MODULUS,
+            blowup_factor: 16,
+            fri_repetitions: 5,
+            proof_size_hint: 20 * 1024,
+        }
+    }
+}
+
+/// Minimal field element representation used across the crate.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FieldElement(u128);
+
+impl FieldElement {
+    pub fn new(value: u128) -> Self {
+        Self(value % FIELD_MODULUS)
+    }
+
+    pub fn zero() -> Self {
+        Self(0)
+    }
+
+    pub fn one() -> Self {
+        Self(1)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let mut acc = 0u128;
+        for byte in bytes.iter().take(16) {
+            acc = (acc << 8) | (*byte as u128);
+        }
+        Self::new(acc)
+    }
+
+    pub fn to_bytes(self) -> [u8; 16] {
+        self.0.to_be_bytes()
+    }
+}
+
+impl From<u128> for FieldElement {
+    fn from(value: u128) -> Self {
+        FieldElement::new(value)
+    }
+}
+
+use core::ops::{Add, Mul};
+
+impl Add for FieldElement {
+    type Output = FieldElement;
+
+    fn add(self, rhs: FieldElement) -> Self::Output {
+        FieldElement::new(self.0 + rhs.0)
+    }
+}
+
+impl Mul for FieldElement {
+    type Output = FieldElement;
+
+    fn mul(self, rhs: FieldElement) -> Self::Output {
+        FieldElement::new(self.0 * rhs.0)
+    }
+}

--- a/rpp/zk/stwo/src/prover.rs
+++ b/rpp/zk/stwo/src/prover.rs
@@ -1,0 +1,157 @@
+use serde::{Deserialize, Serialize};
+
+use crate::circuits::identity::{IdentityGenesis, IdentityWitness};
+use crate::circuits::pruning::{PruningInputs, PruningWitness};
+use crate::circuits::reputation::{ReputationState, ReputationWitness};
+use crate::circuits::transaction::{Transaction, TransactionWitness, UtxoState};
+use crate::circuits::{CircuitTrace, CircuitWitness};
+use crate::params::{FieldElement, StwoConfig};
+use crate::recursion::RecursiveProof;
+use crate::utils::fri::{FriProof, FriProver};
+use crate::utils::poseidon;
+
+/// Supported proof encodings.  The prover currently emits JSON by default but
+/// the enum leaves space for a binary format when needed.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProofFormat {
+    Json,
+    Binary,
+}
+
+/// Enumeration of circuits handled by the prover.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ProofCircuit {
+    Transaction,
+    Reputation,
+    Block,
+    Identity,
+}
+
+/// Lightweight proof representation used by the local prover.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Proof {
+    pub circuit: ProofCircuit,
+    pub format: ProofFormat,
+    pub config: StwoConfig,
+    pub public_inputs: serde_json::Value,
+    pub trace: CircuitTrace,
+    pub fri_proof: FriProof,
+}
+
+impl Proof {
+    pub fn digest(&self) -> [u8; 32] {
+        let encoded = serde_json::to_vec(self).expect("proof is serialisable");
+        poseidon::hash_elements(&[
+            FieldElement::from_bytes(&encoded[..encoded.len().min(16)]),
+            FieldElement::from_bytes(&encoded[encoded.len().saturating_sub(16)..]),
+        ])
+    }
+}
+
+/// Helper trait implemented by all witness types so that the prover can derive
+/// field elements for the simplified FRI commitment.
+trait WitnessExt: CircuitWitness {
+    fn trace_commitments(&self) -> CircuitTrace;
+
+    fn fri_values(&self) -> Vec<FieldElement> {
+        let trace = self.trace_commitments();
+        let mut values = Vec::new();
+        values.push(FieldElement::from_bytes(&trace.trace_commitment[..16]));
+        values.push(FieldElement::from_bytes(&trace.trace_commitment[16..]));
+        values.push(FieldElement::from_bytes(&trace.constraint_commitment[..16]));
+        values.push(FieldElement::from_bytes(&trace.constraint_commitment[16..]));
+        values
+    }
+}
+
+impl WitnessExt for TransactionWitness {
+    fn trace_commitments(&self) -> CircuitTrace {
+        self.trace()
+    }
+}
+
+impl WitnessExt for ReputationWitness {
+    fn trace_commitments(&self) -> CircuitTrace {
+        self.trace()
+    }
+}
+
+impl WitnessExt for IdentityWitness {
+    fn trace_commitments(&self) -> CircuitTrace {
+        self.trace()
+    }
+}
+
+impl WitnessExt for PruningWitness {
+    fn trace_commitments(&self) -> CircuitTrace {
+        self.trace()
+    }
+}
+
+fn build_proof<W>(circuit: ProofCircuit, witness: &W) -> Proof
+where
+    W: WitnessExt,
+{
+    let config = StwoConfig::default();
+    let public_inputs = witness.to_json();
+    let trace = witness.trace_commitments();
+    let fri_inputs = witness.fri_values();
+    let fri_proof = FriProver::prove(&fri_inputs);
+
+    Proof {
+        circuit,
+        format: ProofFormat::Json,
+        config,
+        public_inputs,
+        trace,
+        fri_proof,
+    }
+}
+
+/// Generate a transaction proof.
+pub fn prove_tx(tx: &Transaction, state: &UtxoState) -> Proof {
+    let witness = TransactionWitness::new(tx.clone(), state.clone());
+    build_proof(ProofCircuit::Transaction, &witness)
+}
+
+/// Generate a reputation proof.
+pub fn prove_reputation(state: &ReputationState) -> Proof {
+    let witness = ReputationWitness::new(state.clone(), state.epochs_participated, 0);
+    build_proof(ProofCircuit::Reputation, &witness)
+}
+
+/// Generate a block proof by linking it with the previous recursive digest.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Block {
+    pub height: u64,
+    pub tx_root: String,
+    pub reputation_root: String,
+}
+
+pub fn prove_block(block: &Block, prev_proof: &Proof) -> Proof {
+    let inputs = PruningInputs {
+        utxo_root: block.tx_root.clone(),
+        reputation_root: block.reputation_root.clone(),
+        previous_proof_digest: prev_proof.digest(),
+    };
+    let leaves = vec![prev_proof.digest(), poseidon::hash_elements(&[
+        FieldElement::from(block.height as u128),
+        FieldElement::from_bytes(block.tx_root.as_bytes()),
+    ])];
+    let witness = PruningWitness::new(inputs, leaves);
+    build_proof(ProofCircuit::Block, &witness)
+}
+
+/// Produce an identity proof for the wallet genesis procedure.
+pub fn prove_identity(wallet_key: &str, genesis: &IdentityGenesis) -> Proof {
+    let witness = IdentityWitness::new(genesis.clone(), wallet_key.to_owned(), "vote".into());
+    build_proof(ProofCircuit::Identity, &witness)
+}
+
+/// Convenience helper to export proofs into a recursive wrapper.
+pub fn to_recursive_proof(proof: &Proof) -> RecursiveProof {
+    RecursiveProof {
+        aggregate_digest: proof.digest(),
+        proof: proof.clone(),
+    }
+}

--- a/rpp/zk/stwo/src/recursion.rs
+++ b/rpp/zk/stwo/src/recursion.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use crate::prover::Proof;
+use crate::utils::poseidon;
+use crate::params::FieldElement;
+
+/// A recursive proof bundles the digest of all previous proofs together with the
+/// newest proof object.  The structure keeps the recursive chain deterministic
+/// and easy to inspect in tests.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecursiveProof {
+    pub aggregate_digest: [u8; 32],
+    pub proof: Proof,
+}
+
+/// Combine a previous proof with the current one, producing a new recursive
+/// aggregate.  The digest is computed by hashing the concatenation of both proof
+/// digests and the current block height when present.
+pub fn link_proofs(prev: &Proof, current: &Proof) -> RecursiveProof {
+    let digest = poseidon::hash_elements(&[
+        FieldElement::from_bytes(&prev.digest()[..16]),
+        FieldElement::from_bytes(&prev.digest()[16..]),
+        FieldElement::from_bytes(&current.digest()[..16]),
+        FieldElement::from_bytes(&current.digest()[16..]),
+    ]);
+    RecursiveProof {
+        aggregate_digest: digest,
+        proof: current.clone(),
+    }
+}

--- a/rpp/zk/stwo/src/utils/fft.rs
+++ b/rpp/zk/stwo/src/utils/fft.rs
@@ -1,0 +1,19 @@
+use crate::params::FieldElement;
+
+/// Evaluate a polynomial described by coefficients `values` at the provided
+/// evaluation points.  The routine is intentionally naive (O(n^2)) which keeps
+/// the implementation small and suitable for deterministic unit tests.
+pub fn evaluate_polynomial(coefficients: &[FieldElement], points: &[FieldElement]) -> Vec<FieldElement> {
+    points
+        .iter()
+        .map(|point| {
+            let mut acc = FieldElement::zero();
+            let mut power = FieldElement::one();
+            for coeff in coefficients {
+                acc = acc + (*coeff * power);
+                power = power * *point;
+            }
+            acc
+        })
+        .collect()
+}

--- a/rpp/zk/stwo/src/utils/fri.rs
+++ b/rpp/zk/stwo/src/utils/fri.rs
@@ -1,0 +1,65 @@
+use rand::{Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::FieldElement;
+use crate::utils::poseidon;
+
+/// Minimal representation of a FRI query.  The randomness is deterministic for
+/// repeatability during testing.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FriQuery {
+    pub index: usize,
+    pub value: FieldElement,
+}
+
+/// Proof object returned by the simplified FRI protocol.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FriProof {
+    pub commitment: [u8; 32],
+    pub queries: Vec<FriQuery>,
+}
+
+pub struct FriProver;
+
+impl FriProver {
+    pub fn commit(values: &[FieldElement]) -> [u8; 32] {
+        poseidon::hash_elements(values)
+    }
+
+    pub fn prove(values: &[FieldElement]) -> FriProof {
+        let commitment = Self::commit(values);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let queries: Vec<FriQuery> = values
+            .iter()
+            .enumerate()
+            .take(4)
+            .map(|(index, value)| FriQuery {
+                index: (index + rng.gen::<usize>()) % values.len().max(1),
+                value: value.clone(),
+            })
+            .collect();
+        FriProof {
+            commitment,
+            queries,
+        }
+    }
+
+    pub fn verify(values: &[FieldElement], proof: &FriProof) -> bool {
+        let expected_commitment = Self::commit(values);
+        if expected_commitment != proof.commitment {
+            return false;
+        }
+        proof.queries.iter().all(|query| {
+            values
+                .get(query.index % values.len().max(1))
+                .map(|v| v == &query.value)
+                .unwrap_or(false)
+        })
+    }
+}
+
+pub fn compress_proof(proof: &FriProof) -> [u8; 32] {
+    let encoded = serde_json::to_vec(proof).expect("fri proof is serialisable");
+    Blake2sHasher::hash(&encoded).0
+}

--- a/rpp/zk/stwo/src/utils/merkle.rs
+++ b/rpp/zk/stwo/src/utils/merkle.rs
@@ -1,0 +1,27 @@
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+
+/// Compute a simple binary Merkle root from a list of leaves.  Missing siblings
+/// are replaced with the hash of the constant string `"stwo-empty"`.
+pub fn merkle_root(leaves: &[[u8; 32]]) -> [u8; 32] {
+    if leaves.is_empty() {
+        return Blake2sHasher::hash(b"stwo-empty").0;
+    }
+    let mut level: Vec<[u8; 32]> = leaves.to_vec();
+    while level.len() > 1 {
+        let mut next = Vec::with_capacity((level.len() + 1) / 2);
+        for chunk in level.chunks(2) {
+            let left = chunk[0];
+            let right = if chunk.len() == 2 {
+                chunk[1]
+            } else {
+                Blake2sHasher::hash(b"stwo-empty").0
+            };
+            let mut bytes = Vec::with_capacity(64);
+            bytes.extend(left);
+            bytes.extend(right);
+            next.push(Blake2sHasher::hash(&bytes).0);
+        }
+        level = next;
+    }
+    level[0]
+}

--- a/rpp/zk/stwo/src/utils/mod.rs
+++ b/rpp/zk/stwo/src/utils/mod.rs
@@ -1,0 +1,4 @@
+pub mod fft;
+pub mod fri;
+pub mod merkle;
+pub mod poseidon;

--- a/rpp/zk/stwo/src/utils/poseidon.rs
+++ b/rpp/zk/stwo/src/utils/poseidon.rs
@@ -1,0 +1,23 @@
+use crate::core::vcs::blake2_hash::Blake2sHasher;
+use crate::params::{poseidon_constants, FieldElement};
+
+/// Compute a Poseidon-style hash over a list of field elements.  The
+/// implementation is intentionally simplified: instead of executing the full
+/// Poseidon permutation it concatenates the field element bytes and hashes them
+/// with Blake2s.  This keeps proofs deterministic while avoiding heavy
+/// arithmetic, which is sufficient for local development and integration tests.
+pub fn hash_elements(inputs: &[FieldElement]) -> [u8; 32] {
+    let mut buffer = Vec::with_capacity(inputs.len() * 16);
+    for (index, element) in inputs.iter().enumerate() {
+        let mut bytes = element.to_bytes();
+        if let Some(constant) = poseidon_constants::ROUND_CONSTANTS.get(index) {
+            for (i, byte) in constant.iter().enumerate() {
+                if i < bytes.len() {
+                    bytes[i] ^= *byte;
+                }
+            }
+        }
+        buffer.extend_from_slice(&bytes);
+    }
+    Blake2sHasher::hash(&buffer).0
+}

--- a/rpp/zk/stwo/src/verifier.rs
+++ b/rpp/zk/stwo/src/verifier.rs
@@ -1,0 +1,96 @@
+use crate::circuits::identity::{IdentityGenesis, IdentityWitness};
+use crate::circuits::pruning::{PruningInputs, PruningWitness};
+use crate::circuits::reputation::{ReputationState, ReputationWitness};
+use crate::circuits::transaction::{Transaction, TransactionWitness, UtxoState};
+use crate::params::{FieldElement, StwoConfig};
+use crate::prover::{Block, Proof, ProofCircuit, ProofFormat};
+use crate::utils::fri::FriProver;
+use crate::utils::poseidon;
+
+fn fri_inputs_from_trace(trace: &crate::circuits::CircuitTrace) -> Vec<FieldElement> {
+    vec![
+        FieldElement::from_bytes(&trace.trace_commitment[..16]),
+        FieldElement::from_bytes(&trace.trace_commitment[16..]),
+        FieldElement::from_bytes(&trace.constraint_commitment[..16]),
+        FieldElement::from_bytes(&trace.constraint_commitment[16..]),
+    ]
+}
+
+fn verify_witness(proof: &Proof, witness_trace: crate::circuits::CircuitTrace, public_inputs: serde_json::Value) -> bool {
+    if proof.format != ProofFormat::Json {
+        return false;
+    }
+    if proof.config != StwoConfig::default() {
+        return false;
+    }
+    if proof.trace != witness_trace {
+        return false;
+    }
+    if proof.public_inputs != public_inputs {
+        return false;
+    }
+    let fri_inputs = fri_inputs_from_trace(&witness_trace);
+    FriProver::verify(&fri_inputs, &proof.fri_proof)
+}
+
+pub fn verify_tx(tx: &Transaction, proof: &Proof) -> bool {
+    if proof.circuit != ProofCircuit::Transaction {
+        return false;
+    }
+    let state_root = proof
+        .public_inputs
+        .get("state_root")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    let state = UtxoState {
+        root: state_root.to_owned(),
+        height: 0,
+    };
+    let witness = TransactionWitness::new(tx.clone(), state);
+    verify_witness(proof, witness.trace(), witness.public_inputs())
+}
+
+pub fn verify_reputation(state: &ReputationState, proof: &Proof) -> bool {
+    if proof.circuit != ProofCircuit::Reputation {
+        return false;
+    }
+    let witness = ReputationWitness::new(state.clone(), state.epochs_participated, 0);
+    verify_witness(proof, witness.trace(), witness.public_inputs())
+}
+
+pub fn verify_block(block: &Block, proof: &Proof) -> bool {
+    if proof.circuit != ProofCircuit::Block {
+        return false;
+    }
+    let previous_digest = proof
+        .public_inputs
+        .get("previous_digest")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let mut digest_bytes = [0u8; 32];
+    hex::decode_to_slice(previous_digest, &mut digest_bytes).ok();
+    let inputs = PruningInputs {
+        utxo_root: block.tx_root.clone(),
+        reputation_root: block.reputation_root.clone(),
+        previous_proof_digest: digest_bytes,
+    };
+    let leaves = vec![digest_bytes, poseidon::hash_elements(&[
+        FieldElement::from(block.height as u128),
+        FieldElement::from_bytes(block.tx_root.as_bytes()),
+    ])];
+    let witness = PruningWitness::new(inputs, leaves);
+    verify_witness(proof, witness.trace(), witness.public_inputs())
+}
+
+pub fn verify_identity(genesis: &IdentityGenesis, proof: &Proof) -> bool {
+    if proof.circuit != ProofCircuit::Identity {
+        return false;
+    }
+    let wallet_key = proof
+        .public_inputs
+        .get("wallet")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let witness = IdentityWitness::new(genesis.clone(), wallet_key.to_owned(), "vote".into());
+    verify_witness(proof, witness.trace(), witness.public_inputs())
+}


### PR DESCRIPTION
## Summary
- add a local `rpp/zk/stwo` crate that mirrors the StarkWare APIs with deterministic stand-ins for hashing, circuits, proving, and verification
- expose simplified Poseidon, FRI, Merkle, and FFT utilities together with recursive proof helpers and bundled verifier keys
- update the root workspace to depend on the in-tree crate instead of the external package

## Testing
- `cargo check -p stwo`


------
https://chatgpt.com/codex/tasks/task_e_68d0efc4facc8326bfd330154298f6fc