### PR TITLE
Add local RPP P2P blueprint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "rand 0.7.3",
  "rocksdb",
  "rpp-consensus",
+ "rpp-p2p",
  "serde",
  "serde_json",
  "storage-firewood",
@@ -1321,6 +1322,10 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "rpp-p2p"
+version = "0.1.0"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ed25519-dalek = { version = "1.0", features = ["serde"] }
 hex = "0.4"
 malachite = { version = "0.6.1", features = ["enable_serde", "serde"] }
 rpp-consensus = { path = "rpp/consensus" }
+rpp-p2p = { path = "rpp/p2p" }
 parking_lot = "0.12"
 rand = "0.7"
 rocksdb = { version = "0.24", features = ["multi-threaded-cf"] }

--- a/rpp/p2p/Cargo.toml
+++ b/rpp/p2p/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "rpp-p2p"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/rpp/p2p/src/admission.rs
+++ b/rpp/p2p/src/admission.rs
@@ -1,0 +1,236 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::gossip::GossipTopic;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TierLevel {
+    Observer = 0,
+    Tier1 = 1,
+    Tier2 = 2,
+    Tier3 = 3,
+    Tier4 = 4,
+}
+
+impl TierLevel {
+    pub fn from_score(score: f64) -> TierLevel {
+        match score {
+            s if s >= 3.5 => TierLevel::Tier4,
+            s if s >= 2.5 => TierLevel::Tier3,
+            s if s >= 1.5 => TierLevel::Tier2,
+            s if s >= 0.5 => TierLevel::Tier1,
+            _ => TierLevel::Observer,
+        }
+    }
+
+    pub fn required_for_topic(topic: GossipTopic) -> TierLevel {
+        match topic {
+            GossipTopic::Blocks | GossipTopic::Votes => TierLevel::Tier3,
+            GossipTopic::Proofs => TierLevel::Tier1,
+            GossipTopic::Snapshots => TierLevel::Tier2,
+            GossipTopic::Meta => TierLevel::Observer,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PeerReputation {
+    pub peer_id: String,
+    pub score: f64,
+    pub tier: TierLevel,
+    pub uptime: Duration,
+    pub last_updated: Instant,
+}
+
+impl PeerReputation {
+    pub fn new(peer_id: impl Into<String>, score: f64, uptime: Duration) -> Self {
+        let peer_id = peer_id.into();
+        let tier = TierLevel::from_score(score);
+        Self {
+            peer_id,
+            score,
+            tier,
+            uptime,
+            last_updated: Instant::now(),
+        }
+    }
+
+    pub fn set_score(&mut self, score: f64) {
+        self.score = score;
+        self.tier = TierLevel::from_score(score);
+        self.last_updated = Instant::now();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ReputationEvent {
+    pub peer_id: String,
+    pub delta: f64,
+    pub description: String,
+}
+
+impl ReputationEvent {
+    pub fn new(peer_id: impl Into<String>, delta: f64, description: impl Into<String>) -> Self {
+        Self {
+            peer_id: peer_id.into(),
+            delta,
+            description: description.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TokenBucket {
+    capacity: u32,
+    tokens: u32,
+    refill_interval: Duration,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(capacity: u32, refill_interval: Duration) -> Self {
+        Self {
+            capacity,
+            tokens: capacity,
+            refill_interval,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn consume(&mut self, amount: u32) -> bool {
+        self.refill();
+        if self.tokens >= amount {
+            self.tokens -= amount;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        if now.duration_since(self.last_refill) >= self.refill_interval {
+            self.tokens = self.capacity;
+            self.last_refill = now;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AdmissionControl {
+    peers: Mutex<HashMap<String, PeerReputation>>,
+    quarantine: Mutex<HashSet<String>>,
+    rate_limits: Mutex<HashMap<String, TokenBucket>>,
+    default_bucket: TokenBucket,
+}
+
+impl AdmissionControl {
+    pub fn new() -> Self {
+        Self {
+            peers: Mutex::new(HashMap::new()),
+            quarantine: Mutex::new(HashSet::new()),
+            rate_limits: Mutex::new(HashMap::new()),
+            default_bucket: TokenBucket::new(32, Duration::from_secs(1)),
+        }
+    }
+
+    pub fn register_peer(&self, peer: PeerReputation) {
+        let mut peers = self.peers.lock().expect("peers mutex poisoned");
+        peers.insert(peer.peer_id.clone(), peer);
+    }
+
+    pub fn record_event(&self, event: ReputationEvent) {
+        let mut peers = self.peers.lock().expect("peers mutex poisoned");
+        let entry = peers.entry(event.peer_id.clone()).or_insert_with(|| {
+            PeerReputation::new(event.peer_id.clone(), 0.0, Duration::from_secs(0))
+        });
+        let new_score = (entry.score + event.delta).clamp(0.0, 5.0);
+        entry.set_score(new_score);
+    }
+
+    pub fn reputation(&self, peer_id: &str) -> Option<PeerReputation> {
+        self.peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .get(peer_id)
+            .cloned()
+    }
+
+    pub fn quarantine(&self, peer_id: impl Into<String>) {
+        self.quarantine
+            .lock()
+            .expect("quarantine mutex poisoned")
+            .insert(peer_id.into());
+    }
+
+    pub fn is_quarantined(&self, peer_id: &str) -> bool {
+        self.quarantine
+            .lock()
+            .expect("quarantine mutex poisoned")
+            .contains(peer_id)
+    }
+
+    pub fn check_publish(&self, peer_id: &str, topic: GossipTopic) -> bool {
+        if self.is_quarantined(peer_id) {
+            return false;
+        }
+
+        let required_tier = TierLevel::required_for_topic(topic);
+        let tier_ok = self
+            .peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .get(peer_id)
+            .map(|r| r.tier >= required_tier)
+            .unwrap_or(false);
+        if !tier_ok {
+            return false;
+        }
+
+        let mut limits = self
+            .rate_limits
+            .lock()
+            .expect("rate limit mutex poisoned");
+        let bucket = limits
+            .entry(peer_id.to_string())
+            .or_insert_with(|| self.default_bucket.clone());
+        bucket.consume(1)
+    }
+}
+
+impl Clone for TokenBucket {
+    fn clone(&self) -> Self {
+        Self {
+            capacity: self.capacity,
+            tokens: self.tokens,
+            refill_interval: self.refill_interval,
+            last_refill: Instant::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enforces_tier_requirements() {
+        let admission = AdmissionControl::new();
+        admission.register_peer(PeerReputation::new("alice", 3.0, Duration::from_secs(10)));
+        assert!(admission.check_publish("alice", GossipTopic::Blocks));
+        assert!(admission.check_publish("alice", GossipTopic::Votes));
+        assert!(admission.check_publish("alice", GossipTopic::Proofs));
+
+        assert!(!admission.check_publish("unknown", GossipTopic::Proofs));
+    }
+
+    #[test]
+    fn enforces_quarantine() {
+        let admission = AdmissionControl::new();
+        admission.register_peer(PeerReputation::new("carol", 2.0, Duration::from_secs(5)));
+        assert!(admission.check_publish("carol", GossipTopic::Proofs));
+        admission.quarantine("carol");
+        assert!(!admission.check_publish("carol", GossipTopic::Proofs));
+    }
+}

--- a/rpp/p2p/src/discovery.rs
+++ b/rpp/p2p/src/discovery.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use crate::admission::TierLevel;
+use crate::transport::Multiaddr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerRecord {
+    pub peer_id: String,
+    pub address: Multiaddr,
+    pub tier: TierLevel,
+    pub last_seen: Instant,
+}
+
+impl PeerRecord {
+    pub fn new(peer_id: impl Into<String>, address: Multiaddr, tier: TierLevel) -> Self {
+        Self {
+            peer_id: peer_id.into(),
+            address,
+            tier,
+            last_seen: Instant::now(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Discovery {
+    local_peer: String,
+    peers: Mutex<HashMap<String, PeerRecord>>,
+    bootstrap: Vec<PeerRecord>,
+}
+
+impl Discovery {
+    pub fn new(local_peer: impl Into<String>) -> Self {
+        Self {
+            local_peer: local_peer.into(),
+            peers: Mutex::new(HashMap::new()),
+            bootstrap: Vec::new(),
+        }
+    }
+
+    pub fn add_bootstrap_peer(&mut self, peer: PeerRecord) {
+        self.bootstrap.push(peer);
+    }
+
+    pub fn integrate_bootstrap(&self) {
+        let mut guard = self.peers.lock().expect("peers mutex poisoned");
+        for peer in &self.bootstrap {
+            guard.entry(peer.peer_id.clone()).or_insert_with(|| peer.clone());
+        }
+    }
+
+    pub fn register_peer(&self, peer: PeerRecord) {
+        self.peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .insert(peer.peer_id.clone(), peer);
+    }
+
+    pub fn find_peer(&self, peer_id: &str) -> Option<PeerRecord> {
+        self.peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .get(peer_id)
+            .cloned()
+    }
+
+    pub fn known_peers(&self) -> Vec<PeerRecord> {
+        self.peers
+            .lock()
+            .expect("peers mutex poisoned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    pub fn local_peer(&self) -> &str {
+        &self.local_peer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn integrates_bootstrap_peers() {
+        let mut discovery = Discovery::new("node-a");
+        discovery.add_bootstrap_peer(PeerRecord::new(
+            "node-b",
+            Multiaddr::from("/ip4/127.0.0.1/tcp/9000"),
+            TierLevel::Tier2,
+        ));
+        discovery.integrate_bootstrap();
+        let known = discovery.known_peers();
+        assert_eq!(known.len(), 1);
+        assert_eq!(known[0].peer_id, "node-b");
+    }
+}

--- a/rpp/p2p/src/gossip.rs
+++ b/rpp/p2p/src/gossip.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use crate::admission::AdmissionControl;
+use crate::protocol::Message;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GossipTopic {
+    Blocks,
+    Votes,
+    Proofs,
+    Snapshots,
+    Meta,
+}
+
+impl GossipTopic {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            GossipTopic::Blocks => "blocks",
+            GossipTopic::Votes => "votes",
+            GossipTopic::Proofs => "proofs",
+            GossipTopic::Snapshots => "snapshots",
+            GossipTopic::Meta => "meta",
+        }
+    }
+
+    pub fn parse(topic: &str) -> Option<GossipTopic> {
+        match topic {
+            "blocks" => Some(GossipTopic::Blocks),
+            "votes" => Some(GossipTopic::Votes),
+            "proofs" => Some(GossipTopic::Proofs),
+            "snapshots" => Some(GossipTopic::Snapshots),
+            "meta" => Some(GossipTopic::Meta),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageEnvelope {
+    pub topic: GossipTopic,
+    pub message: Message,
+    pub from: String,
+    pub timestamp: SystemTime,
+}
+
+#[derive(Debug)]
+pub enum GossipError {
+    UnknownTopic,
+    AdmissionDenied,
+    DeliveryFailed,
+}
+
+pub type Subscription = Receiver<MessageEnvelope>;
+
+#[derive(Debug)]
+pub struct GossipEngine {
+    local_peer: String,
+    admission: Arc<AdmissionControl>,
+    topics: Mutex<HashMap<GossipTopic, Vec<Sender<MessageEnvelope>>>>,
+}
+
+impl GossipEngine {
+    pub fn new(local_peer: impl Into<String>, admission: Arc<AdmissionControl>) -> Self {
+        Self {
+            local_peer: local_peer.into(),
+            admission,
+            topics: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn subscribe(&self, topic: &str) -> Result<Subscription, GossipError> {
+        let topic = GossipTopic::parse(topic).ok_or(GossipError::UnknownTopic)?;
+        let (tx, rx) = mpsc::channel();
+        let mut guard = self.topics.lock().expect("topics mutex poisoned");
+        guard.entry(topic).or_default().push(tx);
+        Ok(rx)
+    }
+
+    pub fn publish(&self, topic: &str, message: Message) -> Result<(), GossipError> {
+        let topic = GossipTopic::parse(topic).ok_or(GossipError::UnknownTopic)?;
+        if !self.admission.check_publish(&self.local_peer, topic) {
+            return Err(GossipError::AdmissionDenied);
+        }
+
+        let envelope = MessageEnvelope {
+            topic,
+            message,
+            from: self.local_peer.clone(),
+            timestamp: SystemTime::now(),
+        };
+
+        let guard = self.topics.lock().expect("topics mutex poisoned");
+        if let Some(subscribers) = guard.get(&topic) {
+            for subscriber in subscribers.iter() {
+                if subscriber.send(envelope.clone()).is_err() {
+                    return Err(GossipError::DeliveryFailed);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::admission::PeerReputation;
+    use std::time::Duration;
+
+    #[test]
+    fn publishes_to_subscribers() {
+        let admission = Arc::new(AdmissionControl::new());
+        admission.register_peer(PeerReputation::new("node-a", 3.0, Duration::from_secs(10)));
+        let gossip = GossipEngine::new("node-a", admission);
+
+        let rx = gossip.subscribe("blocks").expect("subscribe blocks");
+        let message = Message::block_proposal(1, b"proposal");
+        gossip.publish("blocks", message.clone()).expect("publish");
+
+        let received = rx.recv().expect("gossip message");
+        assert_eq!(received.message, message);
+        assert_eq!(received.topic, GossipTopic::Blocks);
+    }
+
+    #[test]
+    fn denies_publication_without_tier() {
+        let admission = Arc::new(AdmissionControl::new());
+        admission.register_peer(PeerReputation::new("node-b", 0.2, Duration::from_secs(1)));
+        let gossip = GossipEngine::new("node-b", admission);
+        assert!(matches!(
+            gossip.publish("blocks", Message::meta("hello")),
+            Err(GossipError::AdmissionDenied)
+        ));
+    }
+}

--- a/rpp/p2p/src/lib.rs
+++ b/rpp/p2p/src/lib.rs
@@ -1,0 +1,13 @@
+//! RPP P2P stack - local blueprint implementation.
+
+mod admission;
+mod discovery;
+mod gossip;
+mod protocol;
+mod transport;
+
+pub use admission::{AdmissionControl, PeerReputation, ReputationEvent, TierLevel};
+pub use discovery::{Discovery, PeerRecord};
+pub use gossip::{GossipEngine, GossipError, GossipTopic, MessageEnvelope, Subscription};
+pub use protocol::{BlockMsg, Message, MessageType, ProofMsg, SnapshotMsg, VoteMsg};
+pub use transport::{Connection, HandshakeData, Multiaddr, Transport, TransportConfig, TransportError, TransportProtocol};

--- a/rpp/p2p/src/protocol.rs
+++ b/rpp/p2p/src/protocol.rs
@@ -1,0 +1,274 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageType {
+    Block = 1,
+    Vote = 2,
+    Proof = 3,
+    Snapshot = 4,
+    Meta = 5,
+}
+
+impl MessageType {
+    fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            1 => Some(MessageType::Block),
+            2 => Some(MessageType::Vote),
+            3 => Some(MessageType::Proof),
+            4 => Some(MessageType::Snapshot),
+            5 => Some(MessageType::Meta),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockMsg {
+    pub height: u64,
+    pub proposal: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoteMsg {
+    pub height: u64,
+    pub round: u64,
+    pub voter: String,
+    pub signature: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofMsg {
+    pub kind: String,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotMsg {
+    pub version: u64,
+    pub state_digest: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaMsg {
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Message {
+    Block(BlockMsg),
+    Vote(VoteMsg),
+    Proof(ProofMsg),
+    Snapshot(SnapshotMsg),
+    Meta(MetaMsg),
+}
+
+impl Message {
+    pub fn message_type(&self) -> MessageType {
+        match self {
+            Message::Block(_) => MessageType::Block,
+            Message::Vote(_) => MessageType::Vote,
+            Message::Proof(_) => MessageType::Proof,
+            Message::Snapshot(_) => MessageType::Snapshot,
+            Message::Meta(_) => MessageType::Meta,
+        }
+    }
+
+    pub fn block_proposal(height: u64, proposal: &[u8]) -> Self {
+        Message::Block(BlockMsg {
+            height,
+            proposal: proposal.to_vec(),
+        })
+    }
+
+    pub fn vote(height: u64, round: u64, voter: impl Into<String>, signature: &[u8]) -> Self {
+        Message::Vote(VoteMsg {
+            height,
+            round,
+            voter: voter.into(),
+            signature: signature.to_vec(),
+        })
+    }
+
+    pub fn proof(kind: impl Into<String>, payload: &[u8]) -> Self {
+        Message::Proof(ProofMsg {
+            kind: kind.into(),
+            payload: payload.to_vec(),
+        })
+    }
+
+    pub fn snapshot(version: u64, state_digest: &[u8]) -> Self {
+        Message::Snapshot(SnapshotMsg {
+            version,
+            state_digest: state_digest.to_vec(),
+        })
+    }
+
+    pub fn meta(description: impl Into<String>) -> Self {
+        Message::Meta(MetaMsg {
+            description: description.into(),
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut bytes = vec![self.message_type() as u8];
+        match self {
+            Message::Block(msg) => {
+                push_u64(&mut bytes, msg.height);
+                push_bytes(&mut bytes, &msg.proposal);
+            }
+            Message::Vote(msg) => {
+                push_u64(&mut bytes, msg.height);
+                push_u64(&mut bytes, msg.round);
+                push_string(&mut bytes, &msg.voter);
+                push_bytes(&mut bytes, &msg.signature);
+            }
+            Message::Proof(msg) => {
+                push_string(&mut bytes, &msg.kind);
+                push_bytes(&mut bytes, &msg.payload);
+            }
+            Message::Snapshot(msg) => {
+                push_u64(&mut bytes, msg.version);
+                push_bytes(&mut bytes, &msg.state_digest);
+            }
+            Message::Meta(msg) => {
+                push_string(&mut bytes, &msg.description);
+            }
+        }
+        bytes
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ProtocolError> {
+        if bytes.is_empty() {
+            return Err(ProtocolError::Malformed("empty frame".into()));
+        }
+        let message_type = MessageType::from_byte(bytes[0]).ok_or_else(|| {
+            ProtocolError::Malformed(format!("unknown message type: {}", bytes[0]))
+        })?;
+        let mut cursor = 1;
+        match message_type {
+            MessageType::Block => {
+                let height = read_u64(bytes, &mut cursor)?;
+                let proposal = read_bytes(bytes, &mut cursor)?;
+                Ok(Message::Block(BlockMsg { height, proposal }))
+            }
+            MessageType::Vote => {
+                let height = read_u64(bytes, &mut cursor)?;
+                let round = read_u64(bytes, &mut cursor)?;
+                let voter = read_string(bytes, &mut cursor)?;
+                let signature = read_bytes(bytes, &mut cursor)?;
+                Ok(Message::Vote(VoteMsg {
+                    height,
+                    round,
+                    voter,
+                    signature,
+                }))
+            }
+            MessageType::Proof => {
+                let kind = read_string(bytes, &mut cursor)?;
+                let payload = read_bytes(bytes, &mut cursor)?;
+                Ok(Message::Proof(ProofMsg { kind, payload }))
+            }
+            MessageType::Snapshot => {
+                let version = read_u64(bytes, &mut cursor)?;
+                let state_digest = read_bytes(bytes, &mut cursor)?;
+                Ok(Message::Snapshot(SnapshotMsg {
+                    version,
+                    state_digest,
+                }))
+            }
+            MessageType::Meta => {
+                let description = read_string(bytes, &mut cursor)?;
+                Ok(Message::Meta(MetaMsg { description }))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtocolError {
+    Malformed(String),
+    UnexpectedEnd,
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProtocolError::Malformed(msg) => write!(f, "malformed message: {}", msg),
+            ProtocolError::UnexpectedEnd => write!(f, "unexpected end of frame"),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {}
+
+fn push_u64(buffer: &mut Vec<u8>, value: u64) {
+    buffer.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u32(buffer: &mut Vec<u8>, value: u32) {
+    buffer.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_bytes(buffer: &mut Vec<u8>, data: &[u8]) {
+    push_u32(buffer, data.len() as u32);
+    buffer.extend_from_slice(data);
+}
+
+fn push_string(buffer: &mut Vec<u8>, value: &str) {
+    push_bytes(buffer, value.as_bytes());
+}
+
+fn read_u64(bytes: &[u8], cursor: &mut usize) -> Result<u64, ProtocolError> {
+    if *cursor + 8 > bytes.len() {
+        return Err(ProtocolError::UnexpectedEnd);
+    }
+    let mut array = [0u8; 8];
+    array.copy_from_slice(&bytes[*cursor..*cursor + 8]);
+    *cursor += 8;
+    Ok(u64::from_le_bytes(array))
+}
+
+fn read_u32(bytes: &[u8], cursor: &mut usize) -> Result<u32, ProtocolError> {
+    if *cursor + 4 > bytes.len() {
+        return Err(ProtocolError::UnexpectedEnd);
+    }
+    let mut array = [0u8; 4];
+    array.copy_from_slice(&bytes[*cursor..*cursor + 4]);
+    *cursor += 4;
+    Ok(u32::from_le_bytes(array))
+}
+
+fn read_bytes(bytes: &[u8], cursor: &mut usize) -> Result<Vec<u8>, ProtocolError> {
+    let len = read_u32(bytes, cursor)? as usize;
+    if *cursor + len > bytes.len() {
+        return Err(ProtocolError::UnexpectedEnd);
+    }
+    let data = bytes[*cursor..*cursor + len].to_vec();
+    *cursor += len;
+    Ok(data)
+}
+
+fn read_string(bytes: &[u8], cursor: &mut usize) -> Result<String, ProtocolError> {
+    let data = read_bytes(bytes, cursor)?;
+    String::from_utf8(data).map_err(|err| ProtocolError::Malformed(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_block_message() {
+        let message = Message::block_proposal(42, b"proposal");
+        let encoded = message.encode();
+        let decoded = Message::decode(&encoded).expect("decode block");
+        assert_eq!(message, decoded);
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        let data = vec![9u8];
+        let err = Message::decode(&data).expect_err("unknown type");
+        assert!(matches!(err, ProtocolError::Malformed(_)));
+    }
+}

--- a/rpp/p2p/src/transport.rs
+++ b/rpp/p2p/src/transport.rs
@@ -1,0 +1,403 @@
+use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use crate::admission::TierLevel;
+
+#[derive(Debug, Clone)]
+pub enum TransportError {
+    AlreadyListening(Multiaddr),
+    UnknownMultiaddr(Multiaddr),
+    SelfDial,
+    Unreachable,
+    ChannelClosed,
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransportError::AlreadyListening(addr) => {
+                write!(f, "address {} already registered", addr)
+            }
+            TransportError::UnknownMultiaddr(addr) => {
+                write!(f, "unknown multiaddr {}", addr)
+            }
+            TransportError::SelfDial => write!(f, "attempted to dial self"),
+            TransportError::Unreachable => write!(f, "remote transport unreachable"),
+            TransportError::ChannelClosed => write!(f, "connection channel closed"),
+        }
+    }
+}
+
+impl std::error::Error for TransportError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportProtocol {
+    Quic,
+    Tcp,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransportConfig {
+    preferred: TransportProtocol,
+    fallback: TransportProtocol,
+    tier: TierLevel,
+    vrf_tag: [u8; 32],
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            preferred: TransportProtocol::Quic,
+            fallback: TransportProtocol::Tcp,
+            tier: TierLevel::Tier3,
+            vrf_tag: [0u8; 32],
+        }
+    }
+}
+
+impl TransportConfig {
+    pub fn with_preferred(mut self, protocol: TransportProtocol) -> Self {
+        self.preferred = protocol;
+        self
+    }
+
+    pub fn with_vrf_tag(mut self, tag: [u8; 32]) -> Self {
+        self.vrf_tag = tag;
+        self
+    }
+
+    pub fn with_tier(mut self, tier: TierLevel) -> Self {
+        self.tier = tier;
+        self
+    }
+
+    pub fn preferred(&self) -> TransportProtocol {
+        self.preferred
+    }
+
+    pub fn fallback(&self) -> TransportProtocol {
+        self.fallback
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HandshakeData {
+    pub vrf_tag: [u8; 32],
+    pub noise_static_key: [u8; 32],
+    pub established_at: SystemTime,
+}
+
+impl HandshakeData {
+    fn new(vrf_tag: [u8; 32]) -> Self {
+        let established_at = SystemTime::now();
+        let mut noise_static_key = [0u8; 32];
+        let nanos = established_at
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::from_secs(0))
+            .as_nanos();
+        noise_static_key[..16].copy_from_slice(&nanos.to_le_bytes());
+        noise_static_key[16..].copy_from_slice(&vrf_tag[..16]);
+        Self {
+            vrf_tag,
+            noise_static_key,
+            established_at,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Connection {
+    local_peer: String,
+    remote_peer: String,
+    protocol: TransportProtocol,
+    handshake: HandshakeData,
+    outbound: Sender<Vec<u8>>,
+    inbound: Mutex<Receiver<Vec<u8>>>,
+}
+
+impl Connection {
+    fn new(
+        local_peer: String,
+        remote_peer: String,
+        protocol: TransportProtocol,
+        handshake: HandshakeData,
+        outbound: Sender<Vec<u8>>,
+        inbound: Receiver<Vec<u8>>,
+    ) -> Self {
+        Self {
+            local_peer,
+            remote_peer,
+            protocol,
+            handshake,
+            outbound,
+            inbound: Mutex::new(inbound),
+        }
+    }
+
+    pub fn remote_peer(&self) -> &str {
+        &self.remote_peer
+    }
+
+    pub fn local_peer(&self) -> &str {
+        &self.local_peer
+    }
+
+    pub fn protocol(&self) -> TransportProtocol {
+        self.protocol
+    }
+
+    pub fn handshake(&self) -> &HandshakeData {
+        &self.handshake
+    }
+
+    pub fn send(&self, payload: &[u8]) -> Result<(), TransportError> {
+        self.outbound
+            .send(payload.to_vec())
+            .map_err(|_| TransportError::ChannelClosed)
+    }
+
+    pub fn recv(&self) -> Result<Option<Vec<u8>>, TransportError> {
+        let guard = self.inbound.lock().expect("receiver mutex poisoned");
+        match guard.try_recv() {
+            Ok(data) => Ok(Some(data)),
+            Err(TryRecvError::Empty) => Ok(None),
+            Err(TryRecvError::Disconnected) => Err(TransportError::ChannelClosed),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Multiaddr(String);
+
+impl Multiaddr {
+    pub fn new(addr: impl Into<String>) -> Self {
+        Self(addr.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for Multiaddr {
+    fn from(value: &str) -> Self {
+        Multiaddr::new(value)
+    }
+}
+
+impl From<String> for Multiaddr {
+    fn from(value: String) -> Self {
+        Multiaddr::new(value)
+    }
+}
+
+impl fmt::Display for Multiaddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq for Multiaddr {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for Multiaddr {}
+
+impl Hash for Multiaddr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+#[derive(Debug)]
+struct TransportState {
+    peer_id: String,
+    config: TransportConfig,
+    incoming: Mutex<VecDeque<Connection>>,
+}
+
+impl TransportState {
+    fn new(peer_id: String, config: TransportConfig) -> Self {
+        Self {
+            peer_id,
+            config,
+            incoming: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    fn enqueue(&self, connection: Connection) {
+        self.incoming
+            .lock()
+            .expect("incoming queue poisoned")
+            .push_back(connection);
+    }
+
+    fn dequeue(&self) -> Option<Connection> {
+        self.incoming
+            .lock()
+            .expect("incoming queue poisoned")
+            .pop_front()
+    }
+}
+
+struct Router {
+    listeners: Mutex<HashMap<Multiaddr, Weak<TransportState>>>,
+}
+
+impl Router {
+    fn new() -> Self {
+        Self {
+            listeners: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn register(&self, addr: Multiaddr, transport: &Arc<TransportState>) -> Result<(), TransportError> {
+        let mut listeners = self.listeners.lock().expect("router mutex poisoned");
+        if let Some(existing) = listeners.get(&addr) {
+            if existing.upgrade().is_some() {
+                return Err(TransportError::AlreadyListening(addr));
+            }
+        }
+        listeners.insert(addr, Arc::downgrade(transport));
+        Ok(())
+    }
+
+    fn resolve(&self, addr: &Multiaddr) -> Option<Arc<TransportState>> {
+        let mut listeners = self.listeners.lock().expect("router mutex poisoned");
+        if let Some(state) = listeners.get(addr) {
+            if let Some(transport) = state.upgrade() {
+                return Some(transport);
+            }
+        }
+        listeners.remove(addr);
+        None
+    }
+}
+
+fn router() -> &'static Arc<Router> {
+    static ROUTER: OnceLock<Arc<Router>> = OnceLock::new();
+    ROUTER.get_or_init(|| Arc::new(Router::new()))
+}
+
+#[derive(Debug, Clone)]
+pub struct Transport {
+    inner: Arc<TransportState>,
+}
+
+impl Transport {
+    pub fn new_transport(local_id: impl Into<String>) -> Self {
+        Self::with_config(local_id, TransportConfig::default())
+    }
+
+    pub fn with_config(local_id: impl Into<String>, config: TransportConfig) -> Self {
+        let state = Arc::new(TransportState::new(local_id.into(), config));
+        Self { inner: state }
+    }
+
+    pub fn listen(&self, addr: Multiaddr) -> Result<(), TransportError> {
+        if self.inner.peer_id.is_empty() {
+            return Err(TransportError::Unreachable);
+        }
+        router().register(addr, &self.inner)
+    }
+
+    pub fn dial(&self, addr: Multiaddr) -> Result<Connection, TransportError> {
+        let remote = router()
+            .resolve(&addr)
+            .ok_or_else(|| TransportError::UnknownMultiaddr(addr.clone()))?;
+        if Arc::ptr_eq(&remote, &self.inner) {
+            return Err(TransportError::SelfDial);
+        }
+
+        let (to_remote_tx, to_remote_rx) = mpsc::channel();
+        let (to_local_tx, to_local_rx) = mpsc::channel();
+
+        let local_handshake = HandshakeData::new(self.inner.config.vrf_tag);
+        let remote_handshake = HandshakeData::new(remote.config.vrf_tag);
+
+        let local_protocol = if self.inner.config.preferred() == remote.config.preferred() {
+            self.inner.config.preferred()
+        } else {
+            self.inner.config.fallback()
+        };
+        let remote_protocol = if remote.config.preferred() == self.inner.config.preferred() {
+            remote.config.preferred()
+        } else {
+            remote.config.fallback()
+        };
+
+        let local_connection = Connection::new(
+            self.inner.peer_id.clone(),
+            remote.peer_id.clone(),
+            local_protocol,
+            local_handshake,
+            to_local_tx,
+            to_remote_rx,
+        );
+
+        let remote_connection = Connection::new(
+            remote.peer_id.clone(),
+            self.inner.peer_id.clone(),
+            remote_protocol,
+            remote_handshake,
+            to_remote_tx,
+            to_local_rx,
+        );
+
+        remote.enqueue(remote_connection);
+        Ok(local_connection)
+    }
+
+    pub fn accept(&self) -> Option<Connection> {
+        self.inner.dequeue()
+    }
+
+    pub fn local_peer(&self) -> &str {
+        &self.inner.peer_id
+    }
+
+    pub fn tier(&self) -> TierLevel {
+        self.inner.config.tier
+    }
+
+    pub fn vrf_tag(&self) -> [u8; 32] {
+        self.inner.config.vrf_tag
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn establishes_loopback_connection() {
+        let transport_a = Transport::new_transport("node-a");
+        let transport_b = Transport::new_transport("node-b");
+        let addr = Multiaddr::from("/ip4/127.0.0.1/quic/7000");
+        transport_b.listen(addr.clone()).expect("listen");
+
+        let conn = transport_a.dial(addr.clone()).expect("dial");
+        assert_eq!(conn.remote_peer(), "node-b");
+        assert_eq!(conn.local_peer(), "node-a");
+        assert_eq!(conn.protocol(), TransportProtocol::Quic);
+
+        let inbound = transport_b.accept().expect("incoming");
+        assert_eq!(inbound.remote_peer(), "node-a");
+        assert_eq!(inbound.local_peer(), "node-b");
+        assert_eq!(inbound.protocol(), TransportProtocol::Quic);
+    }
+
+    #[test]
+    fn prevents_self_dial() {
+        let transport = Transport::new_transport("node-self");
+        let addr = Multiaddr::from("/ip4/127.0.0.1/tcp/8000");
+        transport.listen(addr.clone()).expect("listen");
+        assert!(matches!(transport.dial(addr), Err(TransportError::SelfDial)));
+    }
+}


### PR DESCRIPTION
## Summary
- add the new `rpp-p2p` crate with transport, gossip, admission, discovery, and protocol layers that mirror the requested libp2p blueprint while staying self-contained
- hook the workspace up to the new crate so other modules can depend on the local implementation

## Testing
- `cargo test` *(hangs on long-running integration tests after unit-suite success)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fd695ddc8326a764cd2d43b436e0