### PR TITLE
Refine light client sync ingestion pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
+ "blake2",
  "blake3",
  "futures",
  "hex",

--- a/rpp/p2p/Cargo.toml
+++ b/rpp/p2p/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.8"
 tracing = "0.1"
 blake3 = "1.5"
+blake2 = "0.10"
 rand = { version = "0.8", features = ["std"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- add network-facing state sync plan, chunk, and light client update structs for gossip payloads
- redesign LightClientSync to track plan metadata, verify recursive proofs via a pluggable verifier, and validate chunk commitments with deterministic merkle roots
- extend snapshot pipeline tests to cover plan ingestion, chunk verification, and proof acceptance

## Testing
- cargo test --manifest-path rpp/p2p/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d5b1033a508326a1bde5d77ff7dafa