### PR TITLE
Add snapshot sync networking and telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,7 @@ dependencies = [
  "axum",
  "bincode",
  "blake2",
+ "blake3",
  "clap",
  "ed25519-dalek 1.0.1",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { version = "1.7", features = ["v4", "serde"] }
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 blake2 = "0.10"
+blake3 = "1.5"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/rpp/p2p/src/lib.rs
+++ b/rpp/p2p/src/lib.rs
@@ -19,8 +19,9 @@ pub use identity::{IdentityError, NodeIdentity};
 pub use peerstore::{PeerRecord, Peerstore, PeerstoreConfig, PeerstoreError};
 pub use pipeline::{
     BlockProposal, ConsensusPipeline, LightClientSync, MetaTelemetry, PersistentProofStorage,
-    PipelineError, ProofMempool, ProofRecord, ProofStorage, SnapshotChunk, SnapshotStore,
-    TelemetryEvent, VoteOutcome,
+    PipelineError, ProofMempool, ProofRecord, ProofStorage, SnapshotChunk, SnapshotChunkPayload,
+    SnapshotMessage, SnapshotPlanMetadata, SnapshotStore, TelemetryEvent, VoteOutcome,
+    decode_snapshot_message, encode_snapshot_message,
 };
 pub use persistence::{GossipStateError, GossipStateStore};
 pub use roadmap::{libp2p_backbone_plan, Deliverable, Milestone, Phase, Plan, WorkItem};


### PR DESCRIPTION
## Summary
- instantiate the libp2p network inside `Node::new`, wire light-client channels, and surface snapshot sync status through telemetry and the node handle
- add snapshot gossip message codecs and chunk payload helpers to the p2p pipeline crate
- publish reconstruction snapshot plans and chunks on a cadence while ingesting incoming snapshot gossip events

## Testing
- `cargo fmt`
- `cargo test` *(terminated after several minutes while long-running identity/sync tests continued to execute)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b11472f083269bb2743802f642b3