### PR TITLE
Add telemetry worker and libp2p-backed node runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,8 @@ dependencies = [
  "hex",
  "hex-literal",
  "hyper 1.7.0",
+ "libp2p",
+ "log",
  "malachite",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ blake3 = "1.5"
 once_cell = "1.19"
 base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+log = "0.4"
+libp2p = { version = "0.54", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/rpp/p2p/src/swarm.rs
+++ b/rpp/p2p/src/swarm.rs
@@ -158,6 +158,9 @@ pub enum NetworkEvent {
         topic: GossipTopic,
         data: Vec<u8>,
     },
+    PeerDisconnected {
+        peer: PeerId,
+    },
     ReputationUpdated {
         peer: PeerId,
         tier: TierLevel,
@@ -319,7 +322,10 @@ impl Network {
                     self.handle_identify_event(event);
                 }
                 SwarmEvent::Behaviour(RppBehaviourEvent::Ping(_)) => {}
-                SwarmEvent::Dialing { .. } | SwarmEvent::ConnectionClosed { .. } => {}
+                SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                    return Ok(NetworkEvent::PeerDisconnected { peer: peer_id });
+                }
+                SwarmEvent::Dialing { .. } => {}
                 other => {
                     tracing::trace!(?other, "swarm event ignored");
                 }

--- a/rpp/runtime/config.rs
+++ b/rpp/runtime/config.rs
@@ -9,6 +9,26 @@ use crate::ledger::DEFAULT_EPOCH_LENGTH;
 use crate::types::Stake;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct P2pConfig {
+    pub listen_addr: String,
+    pub bootstrap_peers: Vec<String>,
+    pub heartbeat_interval_ms: u64,
+    pub gossip_enabled: bool,
+}
+
+impl Default for P2pConfig {
+    fn default() -> Self {
+        Self {
+            listen_addr: "/ip4/0.0.0.0/tcp/7600".to_string(),
+            bootstrap_peers: Vec::new(),
+            heartbeat_interval_ms: 5_000,
+            gossip_enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeConfig {
     pub data_dir: PathBuf,
     pub key_path: PathBuf,
@@ -33,6 +53,8 @@ pub struct NodeConfig {
     pub max_proof_size_bytes: usize,
     #[serde(default)]
     pub rollout: RolloutConfig,
+    #[serde(default)]
+    pub p2p: P2pConfig,
     pub genesis: GenesisConfig,
 }
 
@@ -115,6 +137,7 @@ impl Default for NodeConfig {
             target_validator_count: default_target_validator_count(),
             max_proof_size_bytes: default_max_proof_size_bytes(),
             rollout: RolloutConfig::default(),
+            p2p: P2pConfig::default(),
             genesis: GenesisConfig::default(),
         }
     }
@@ -211,6 +234,12 @@ impl Default for FeatureGates {
 pub struct TelemetryConfig {
     pub enabled: bool,
     pub endpoint: Option<String>,
+    pub auth_token: Option<String>,
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_retry_max")]
+    pub retry_max: u64,
+    #[serde(default = "default_sample_interval_secs")]
     pub sample_interval_secs: u64,
 }
 
@@ -219,9 +248,24 @@ impl Default for TelemetryConfig {
         Self {
             enabled: false,
             endpoint: None,
-            sample_interval_secs: 30,
+            auth_token: None,
+            timeout_ms: default_timeout_ms(),
+            retry_max: default_retry_max(),
+            sample_interval_secs: default_sample_interval_secs(),
         }
     }
+}
+
+fn default_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_retry_max() -> u64 {
+    3
+}
+
+fn default_sample_interval_secs() -> u64 {
+    30
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/rpp/runtime/mod.rs
+++ b/rpp/runtime/mod.rs
@@ -118,6 +118,9 @@ impl RuntimeProfile {
     }
 }
 
+pub mod node_runtime;
+pub mod telemetry;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rpp/runtime/node.rs
+++ b/rpp/runtime/node.rs
@@ -2411,6 +2411,9 @@ mod telemetry_tests {
         let config = TelemetryConfig {
             enabled: true,
             endpoint: Some(endpoint),
+            auth_token: None,
+            timeout_ms: 5_000,
+            retry_max: 3,
             sample_interval_secs: 1,
         };
         let client = Client::new();
@@ -2434,6 +2437,9 @@ mod telemetry_tests {
         let config = TelemetryConfig {
             enabled: true,
             endpoint: Some(endpoint),
+            auth_token: None,
+            timeout_ms: 5_000,
+            retry_max: 3,
             sample_interval_secs: 1,
         };
         let client = Client::new();
@@ -2455,6 +2461,9 @@ mod telemetry_tests {
         let config = TelemetryConfig {
             enabled: true,
             endpoint: None,
+            auth_token: None,
+            timeout_ms: 5_000,
+            retry_max: 3,
             sample_interval_secs: 1,
         };
         let client = Client::new();

--- a/rpp/runtime/node_runtime/mod.rs
+++ b/rpp/runtime/node_runtime/mod.rs
@@ -1,0 +1,7 @@
+pub mod network;
+pub mod node;
+
+pub use network::{NetworkConfig, NetworkResources, NetworkSetupError};
+pub use node::{
+    Heartbeat, MetaTelemetryReport, NodeEvent, NodeHandle, NodeInner, NodeMetrics, PeerTelemetry,
+};

--- a/rpp/runtime/node_runtime/network.rs
+++ b/rpp/runtime/node_runtime/network.rs
@@ -1,0 +1,120 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use libp2p::Multiaddr;
+use log::warn;
+use rpp_p2p::{
+    HandshakePayload, IdentityError, Network, NetworkError, NodeIdentity, Peerstore,
+    PeerstoreConfig, PeerstoreError, TierLevel,
+};
+use thiserror::Error;
+
+use crate::config::P2pConfig;
+
+/// Resolved libp2p networking configuration used by the runtime.
+#[derive(Clone, Debug)]
+pub struct NetworkConfig {
+    listen_addr: Multiaddr,
+    bootstrap_peers: Vec<Multiaddr>,
+    heartbeat_interval: Duration,
+    gossip_enabled: bool,
+}
+
+impl NetworkConfig {
+    /// Builds a [`NetworkConfig`] from the user-provided [`P2pConfig`].
+    pub fn from_config(config: &P2pConfig) -> Result<Self, NetworkSetupError> {
+        let listen_addr = config.listen_addr.parse::<Multiaddr>().map_err(|source| {
+            NetworkSetupError::InvalidMultiaddr {
+                addr: config.listen_addr.clone(),
+                source,
+            }
+        })?;
+        let mut bootstrap_peers = Vec::with_capacity(config.bootstrap_peers.len());
+        for addr in &config.bootstrap_peers {
+            let multiaddr = addr.parse::<Multiaddr>().map_err(|source| {
+                NetworkSetupError::InvalidMultiaddr {
+                    addr: addr.clone(),
+                    source,
+                }
+            })?;
+            bootstrap_peers.push(multiaddr);
+        }
+        let heartbeat_interval = Duration::from_millis(config.heartbeat_interval_ms.max(1));
+        Ok(Self {
+            listen_addr,
+            bootstrap_peers,
+            heartbeat_interval,
+            gossip_enabled: config.gossip_enabled,
+        })
+    }
+
+    /// Returns the listen address for the libp2p swarm.
+    pub fn listen_addr(&self) -> &Multiaddr {
+        &self.listen_addr
+    }
+
+    /// Returns bootstrap peers that should be dialled on start-up.
+    pub fn bootstrap_peers(&self) -> &[Multiaddr] {
+        &self.bootstrap_peers
+    }
+
+    /// Interval used to emit heartbeat events.
+    pub fn heartbeat_interval(&self) -> Duration {
+        self.heartbeat_interval
+    }
+
+    /// Whether gossip propagation is enabled for this node.
+    pub fn gossip_enabled(&self) -> bool {
+        self.gossip_enabled
+    }
+}
+
+/// Helper struct bundling libp2p primitives required by the node runtime.
+pub struct NetworkResources {
+    network: Network,
+    identity: Arc<NodeIdentity>,
+}
+
+impl NetworkResources {
+    /// Initialises the libp2p networking stack from the resolved configuration.
+    pub fn initialise(
+        identity_path: &Path,
+        config: &NetworkConfig,
+    ) -> Result<Self, NetworkSetupError> {
+        let identity = Arc::new(NodeIdentity::load_or_generate(identity_path)?);
+        let peerstore = Arc::new(Peerstore::open(PeerstoreConfig::memory())?);
+        let node_label = identity.peer_id().to_base58();
+        let handshake = HandshakePayload::new(node_label, None, TierLevel::Tl0);
+        let mut network = Network::new(identity.clone(), peerstore, handshake, None)?;
+        network.listen_on(config.listen_addr().clone())?;
+        for addr in config.bootstrap_peers() {
+            if let Err(err) = network.dial(addr.clone()) {
+                warn!(target: "network", "failed to dial bootstrap peer {addr}: {err}");
+            }
+        }
+        Ok(Self { network, identity })
+    }
+
+    /// Consumes the resources and returns ownership of the network and identity.
+    pub fn into_parts(self) -> (Network, Arc<NodeIdentity>) {
+        (self.network, self.identity)
+    }
+}
+
+/// Errors that can arise while setting up the libp2p networking stack.
+#[derive(Debug, Error)]
+pub enum NetworkSetupError {
+    #[error("invalid multiaddr {addr}: {source}")]
+    InvalidMultiaddr {
+        addr: String,
+        #[source]
+        source: libp2p::multiaddr::Error,
+    },
+    #[error("identity error: {0}")]
+    Identity(#[from] IdentityError),
+    #[error("peerstore error: {0}")]
+    Peerstore(#[from] PeerstoreError),
+    #[error("network error: {0}")]
+    Network(#[from] NetworkError),
+}

--- a/rpp/runtime/node_runtime/node.rs
+++ b/rpp/runtime/node_runtime/node.rs
@@ -1,0 +1,586 @@
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use libp2p::PeerId;
+use log::{debug, info, warn};
+use parking_lot::RwLock;
+use rpp_p2p::{
+    GossipTopic, HandshakePayload, MetaTelemetry, NetworkError, NetworkEvent, NodeIdentity,
+};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::time;
+
+use crate::config::{NodeConfig, P2pConfig, TelemetryConfig};
+use crate::runtime::telemetry::{TelemetryHandle, TelemetrySnapshot};
+
+use super::network::{NetworkConfig, NetworkResources, NetworkSetupError};
+
+/// Commands issued to the node runtime.
+#[derive(Debug)]
+enum NodeCommand {
+    Publish {
+        topic: GossipTopic,
+        data: Vec<u8>,
+        response: oneshot::Sender<Result<(), NodeError>>,
+    },
+    Shutdown,
+}
+
+/// In-memory metrics that are periodically forwarded to the telemetry worker.
+#[derive(Clone, Debug, Default)]
+pub struct NodeMetrics {
+    pub block_height: u64,
+    pub block_hash: String,
+    pub transaction_count: usize,
+    pub reputation_score: f64,
+}
+
+/// Summary of peer activity that is emitted via heartbeat and meta telemetry events.
+#[derive(Clone, Debug)]
+pub struct PeerTelemetry {
+    pub peer: PeerId,
+    pub version: String,
+    pub latency_ms: u64,
+    pub last_seen: SystemTime,
+}
+
+/// Aggregate telemetry information for all known peers.
+#[derive(Clone, Debug)]
+pub struct MetaTelemetryReport {
+    pub local_peer_id: PeerId,
+    pub peer_count: usize,
+    pub peers: Vec<PeerTelemetry>,
+}
+
+/// Periodic heartbeat message emitted by the node runtime.
+#[derive(Clone, Debug)]
+pub struct Heartbeat {
+    pub peer_count: usize,
+    pub block_height: u64,
+    pub block_hash: String,
+    pub transaction_count: usize,
+    pub reputation_score: f64,
+}
+
+/// Public configuration wrapper used by the node runtime.
+#[derive(Clone, Debug)]
+pub struct NodeRuntimeConfig {
+    pub identity_path: PathBuf,
+    pub p2p: P2pConfig,
+    pub telemetry: TelemetryConfig,
+}
+
+impl From<&NodeConfig> for NodeRuntimeConfig {
+    fn from(config: &NodeConfig) -> Self {
+        Self {
+            identity_path: config.p2p_key_path.clone(),
+            p2p: config.p2p.clone(),
+            telemetry: config.rollout.telemetry.clone(),
+        }
+    }
+}
+
+/// Events emitted by the node runtime for consumption by higher layers.
+#[derive(Clone, Debug)]
+pub enum NodeEvent {
+    Gossip {
+        peer: PeerId,
+        topic: GossipTopic,
+        data: Vec<u8>,
+    },
+    PeerConnected {
+        peer: PeerId,
+        payload: HandshakePayload,
+    },
+    PeerDisconnected {
+        peer: PeerId,
+    },
+    Heartbeat(Heartbeat),
+    MetaTelemetry(MetaTelemetryReport),
+}
+
+/// Errors raised by the node runtime.
+#[derive(Debug, thiserror::Error)]
+pub enum NodeError {
+    #[error("network setup error: {0}")]
+    NetworkSetup(#[from] NetworkSetupError),
+    #[error("network error: {0}")]
+    Network(#[from] NetworkError),
+    #[error("command channel closed")]
+    CommandChannelClosed,
+    #[error("gossip propagation disabled")]
+    GossipDisabled,
+}
+
+/// Node runtime internals responsible for coordinating networking and telemetry.
+pub struct NodeInner {
+    network: rpp_p2p::Network,
+    identity: Arc<NodeIdentity>,
+    commands: mpsc::Receiver<NodeCommand>,
+    events: broadcast::Sender<NodeEvent>,
+    metrics: Arc<RwLock<NodeMetrics>>,
+    telemetry: TelemetryHandle,
+    connected_peers: HashSet<PeerId>,
+    known_versions: HashMap<PeerId, String>,
+    meta_telemetry: MetaTelemetry,
+    heartbeat_interval: Duration,
+    gossip_enabled: bool,
+}
+
+impl NodeInner {
+    /// Builds a new [`NodeInner`] alongside its corresponding [`NodeHandle`].
+    pub fn new(config: NodeRuntimeConfig) -> Result<(Self, NodeHandle), NodeError> {
+        let network_config = NetworkConfig::from_config(&config.p2p)?;
+        let telemetry = TelemetryHandle::spawn(config.telemetry.clone());
+        let resources = NetworkResources::initialise(&config.identity_path, &network_config)?;
+        let (network, identity) = resources.into_parts();
+        let (command_tx, command_rx) = mpsc::channel(64);
+        let (event_tx, _) = broadcast::channel(256);
+        let metrics = Arc::new(RwLock::new(NodeMetrics::default()));
+        let handle = NodeHandle {
+            commands: command_tx.clone(),
+            metrics: metrics.clone(),
+            events: event_tx.clone(),
+            local_peer_id: identity.peer_id(),
+        };
+        let inner = Self {
+            network,
+            identity,
+            commands: command_rx,
+            events: event_tx,
+            metrics,
+            telemetry,
+            connected_peers: HashSet::new(),
+            known_versions: HashMap::new(),
+            meta_telemetry: MetaTelemetry::new(),
+            heartbeat_interval: network_config.heartbeat_interval(),
+            gossip_enabled: network_config.gossip_enabled(),
+        };
+        Ok((inner, handle))
+    }
+
+    /// Main async loop that drives network events and periodic telemetry.
+    pub async fn run(mut self) -> Result<(), NodeError> {
+        let mut heartbeat = time::interval(self.heartbeat_interval);
+        loop {
+            tokio::select! {
+                Some(command) = self.commands.recv() => {
+                    if self.handle_command(command).await? {
+                        break;
+                    }
+                }
+                event = self.network.next_event() => {
+                    let event = event?;
+                    self.handle_network_event(event);
+                }
+                _ = heartbeat.tick() => {
+                    self.emit_heartbeat().await;
+                }
+            }
+        }
+        let _ = self.telemetry.shutdown().await;
+        Ok(())
+    }
+
+    async fn handle_command(&mut self, command: NodeCommand) -> Result<bool, NodeError> {
+        match command {
+            NodeCommand::Publish {
+                topic,
+                data,
+                response,
+            } => {
+                let result = if self.gossip_enabled {
+                    self.network
+                        .publish(topic, data)
+                        .map(|_| ())
+                        .map_err(NodeError::from)
+                } else {
+                    Err(NodeError::GossipDisabled)
+                };
+                let _ = response.send(result);
+                Ok(false)
+            }
+            NodeCommand::Shutdown => Ok(true),
+        }
+    }
+
+    fn handle_network_event(&mut self, event: NetworkEvent) {
+        match event {
+            NetworkEvent::NewListenAddr(addr) => {
+                info!(target: "node", "listening on {addr}");
+            }
+            NetworkEvent::HandshakeCompleted { peer, payload } => {
+                info!(target: "node", "peer connected: {peer}");
+                self.connected_peers.insert(peer);
+                self.known_versions.insert(peer, payload.zsi_id.clone());
+                self.meta_telemetry
+                    .record(peer, payload.zsi_id.clone(), Duration::from_millis(0));
+                let _ = self.events.send(NodeEvent::PeerConnected { peer, payload });
+            }
+            NetworkEvent::PeerDisconnected { peer } => {
+                info!(target: "node", "peer disconnected: {peer}");
+                self.connected_peers.remove(&peer);
+                self.known_versions.remove(&peer);
+                let _ = self.events.send(NodeEvent::PeerDisconnected { peer });
+            }
+            NetworkEvent::GossipMessage { peer, topic, data } => {
+                if self.gossip_enabled {
+                    if let Some(version) = self.known_versions.get(&peer) {
+                        self.meta_telemetry
+                            .record(peer, version.clone(), Duration::from_millis(0));
+                    }
+                    let _ = self.events.send(NodeEvent::Gossip { peer, topic, data });
+                }
+            }
+            NetworkEvent::ReputationUpdated {
+                peer,
+                tier,
+                score,
+                label,
+            } => {
+                debug!(
+                    target: "node",
+                    "reputation updated for {peer}: tier={tier:?} score={score} label={label}"
+                );
+            }
+            NetworkEvent::PeerBanned { peer, until } => {
+                warn!(target: "node", "peer {peer} banned until {until:?}");
+            }
+            NetworkEvent::AdmissionRejected {
+                peer,
+                topic,
+                reason,
+            } => {
+                warn!(
+                    target: "node",
+                    "peer {peer} rejected on topic {topic:?}: {reason}"
+                );
+            }
+        }
+    }
+
+    async fn emit_heartbeat(&self) {
+        let metrics = self.metrics.read().clone();
+        let peer_count = self.connected_peers.len();
+        let heartbeat = Heartbeat {
+            peer_count,
+            block_height: metrics.block_height,
+            block_hash: metrics.block_hash.clone(),
+            transaction_count: metrics.transaction_count,
+            reputation_score: metrics.reputation_score,
+        };
+        let _ = self.events.send(NodeEvent::Heartbeat(heartbeat));
+
+        let meta = self.build_meta_report(peer_count);
+        let _ = self.events.send(NodeEvent::MetaTelemetry(meta.clone()));
+
+        let snapshot = TelemetrySnapshot {
+            block_height: metrics.block_height,
+            block_hash: metrics.block_hash,
+            transaction_count: metrics.transaction_count,
+            peer_count,
+            node_id: self.identity.peer_id().to_base58(),
+            reputation_score: metrics.reputation_score,
+            timestamp: SystemTime::now(),
+        };
+        if let Err(err) = self.telemetry.send(snapshot).await {
+            warn!(target: "telemetry", "failed to enqueue telemetry snapshot: {err}");
+        }
+    }
+
+    fn build_meta_report(&self, peer_count: usize) -> MetaTelemetryReport {
+        let mut peers = Vec::new();
+        for peer in &self.connected_peers {
+            if let Some(event) = self.meta_telemetry.latest(peer) {
+                peers.push(PeerTelemetry {
+                    peer: event.peer,
+                    version: event.version.clone(),
+                    latency_ms: event.latency.as_millis() as u64,
+                    last_seen: event.received_at,
+                });
+            }
+        }
+        MetaTelemetryReport {
+            local_peer_id: self.identity.peer_id(),
+            peer_count,
+            peers,
+        }
+    }
+}
+
+/// Handle used to interact with the asynchronous node runtime.
+#[derive(Clone)]
+pub struct NodeHandle {
+    commands: mpsc::Sender<NodeCommand>,
+    metrics: Arc<RwLock<NodeMetrics>>,
+    events: broadcast::Sender<NodeEvent>,
+    local_peer_id: PeerId,
+}
+
+impl NodeHandle {
+    /// Returns a broadcast receiver for node events.
+    pub fn subscribe(&self) -> broadcast::Receiver<NodeEvent> {
+        self.events.subscribe()
+    }
+
+    /// Updates the metrics that will be forwarded to telemetry.
+    pub fn update_metrics(&self, metrics: NodeMetrics) {
+        *self.metrics.write() = metrics;
+    }
+
+    /// Publishes a gossip message via the libp2p network.
+    pub async fn publish_gossip(&self, topic: GossipTopic, data: Vec<u8>) -> Result<(), NodeError> {
+        let (tx, rx) = oneshot::channel();
+        self.commands
+            .send(NodeCommand::Publish {
+                topic,
+                data,
+                response: tx,
+            })
+            .await
+            .map_err(|_| NodeError::CommandChannelClosed)?;
+        let result = rx.await.map_err(|_| NodeError::CommandChannelClosed)?;
+        result
+    }
+
+    /// Signals the runtime to shut down.
+    pub async fn shutdown(&self) -> Result<(), NodeError> {
+        self.commands
+            .send(NodeCommand::Shutdown)
+            .await
+            .map_err(|_| NodeError::CommandChannelClosed)
+    }
+
+    /// Returns the local libp2p peer identifier.
+    pub fn local_peer_id(&self) -> PeerId {
+        self.local_peer_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration as StdDuration;
+    use tempfile::tempdir;
+    use tokio::task::{self, LocalSet};
+    use tokio::time::timeout;
+
+    fn test_config(
+        identity_path: PathBuf,
+        listen: String,
+        bootstrap: Vec<String>,
+    ) -> NodeRuntimeConfig {
+        let mut p2p = P2pConfig::default();
+        p2p.listen_addr = listen;
+        p2p.bootstrap_peers = bootstrap;
+        p2p.heartbeat_interval_ms = 200;
+        p2p.gossip_enabled = true;
+        NodeRuntimeConfig {
+            identity_path,
+            p2p,
+            telemetry: TelemetryConfig {
+                enabled: false,
+                endpoint: None,
+                auth_token: None,
+                timeout_ms: 50,
+                retry_max: 0,
+                sample_interval_secs: 1,
+            },
+        }
+    }
+
+    fn random_listen_addr() -> (String, u16) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind random port");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+        (format!("/ip4/127.0.0.1/tcp/{port}"), port)
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn nodes_exchange_gossip() {
+        let local = LocalSet::new();
+        local
+            .run_until(async {
+                let dir_one = tempdir().expect("tempdir");
+                let dir_two = tempdir().expect("tempdir");
+                let (addr_one, _) = random_listen_addr();
+                let (addr_two, _) = random_listen_addr();
+
+                let config_one = test_config(
+                    dir_one.path().join("node1.key"),
+                    addr_one.clone(),
+                    Vec::new(),
+                );
+                let config_two = test_config(
+                    dir_two.path().join("node2.key"),
+                    addr_two.clone(),
+                    vec![addr_one.clone()],
+                );
+
+                let (node_one, handle_one) = NodeInner::new(config_one).expect("node1");
+                let (node_two, handle_two) = NodeInner::new(config_two).expect("node2");
+                let mut events_two = handle_two.subscribe();
+
+                let task_one = task::spawn_local(async move {
+                    node_one.run().await.expect("run node1");
+                });
+                let task_two = task::spawn_local(async move {
+                    node_two.run().await.expect("run node2");
+                });
+
+                wait_for_peer_connected(&mut events_two).await;
+
+                handle_one
+                    .publish_gossip(GossipTopic::Blocks, b"hello".to_vec())
+                    .await
+                    .expect("publish");
+
+                let received = timeout(StdDuration::from_secs(5), async {
+                    loop {
+                        match events_two.recv().await {
+                            Ok(NodeEvent::Gossip { topic, data, .. }) => {
+                                if topic == GossipTopic::Blocks && data == b"hello".to_vec() {
+                                    break;
+                                }
+                            }
+                            Ok(_) => continue,
+                            Err(err) => panic!("event channel closed: {err}"),
+                        }
+                    }
+                })
+                .await;
+                assert!(received.is_ok(), "gossip message not received");
+
+                handle_one.shutdown().await.expect("shutdown1");
+                handle_two.shutdown().await.expect("shutdown2");
+                let _ = task_one.await;
+                let _ = task_two.await;
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disconnect_produces_event() {
+        let local = LocalSet::new();
+        local
+            .run_until(async {
+                let dir_one = tempdir().expect("tempdir");
+                let dir_two = tempdir().expect("tempdir");
+                let (addr_one, _) = random_listen_addr();
+                let (addr_two, _) = random_listen_addr();
+
+                let config_one = test_config(
+                    dir_one.path().join("node1.key"),
+                    addr_one.clone(),
+                    Vec::new(),
+                );
+                let config_two = test_config(
+                    dir_two.path().join("node2.key"),
+                    addr_two.clone(),
+                    vec![addr_one.clone()],
+                );
+
+                let (node_one, handle_one) = NodeInner::new(config_one).expect("node1");
+                let (node_two, handle_two) = NodeInner::new(config_two).expect("node2");
+                let mut events_two = handle_two.subscribe();
+
+                let task_one = task::spawn_local(async move {
+                    node_one.run().await.expect("run node1");
+                });
+                let task_two = task::spawn_local(async move {
+                    node_two.run().await.expect("run node2");
+                });
+
+                wait_for_peer_connected(&mut events_two).await;
+                handle_one.shutdown().await.expect("shutdown1");
+
+                let disconnected = timeout(StdDuration::from_secs(5), async {
+                    loop {
+                        match events_two.recv().await {
+                            Ok(NodeEvent::PeerDisconnected { .. }) => break,
+                            Ok(_) => continue,
+                            Err(err) => panic!("event channel closed: {err}"),
+                        }
+                    }
+                })
+                .await;
+                assert!(disconnected.is_ok(), "disconnect event not observed");
+
+                handle_two.shutdown().await.expect("shutdown2");
+                let _ = task_one.await;
+                let _ = task_two.await;
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn heartbeat_emits_events_and_telemetry() {
+        let local = LocalSet::new();
+        local
+            .run_until(async {
+                let dir = tempdir().expect("tempdir");
+                let (addr, _) = random_listen_addr();
+                let config = test_config(dir.path().join("node.key"), addr, Vec::new());
+                let (node, handle) = NodeInner::new(config).expect("node");
+                let mut events = handle.subscribe();
+
+                handle.update_metrics(NodeMetrics {
+                    block_height: 12,
+                    block_hash: "0xabc".into(),
+                    transaction_count: 4,
+                    reputation_score: 0.9,
+                });
+
+                let task = task::spawn_local(async move {
+                    node.run().await.expect("run node");
+                });
+
+                let heartbeat = timeout(StdDuration::from_secs(5), async {
+                    loop {
+                        match events.recv().await {
+                            Ok(NodeEvent::Heartbeat(hb)) => break hb,
+                            Ok(_) => continue,
+                            Err(err) => panic!("event channel closed: {err}"),
+                        }
+                    }
+                })
+                .await
+                .expect("heartbeat event");
+                assert_eq!(heartbeat.block_height, 12);
+                assert_eq!(heartbeat.peer_count, 0);
+
+                let meta = timeout(StdDuration::from_secs(5), async {
+                    loop {
+                        match events.recv().await {
+                            Ok(NodeEvent::MetaTelemetry(report)) => break report,
+                            Ok(_) => continue,
+                            Err(err) => panic!("event channel closed: {err}"),
+                        }
+                    }
+                })
+                .await
+                .expect("meta telemetry");
+                assert_eq!(meta.peer_count, 0);
+
+                handle.shutdown().await.expect("shutdown");
+                let _ = task.await;
+            })
+            .await;
+    }
+
+    async fn wait_for_peer_connected(events: &mut broadcast::Receiver<NodeEvent>) {
+        timeout(StdDuration::from_secs(5), async {
+            loop {
+                match events.recv().await {
+                    Ok(NodeEvent::PeerConnected { .. }) => break,
+                    Ok(_) => continue,
+                    Err(err) => panic!("event channel closed: {err}"),
+                }
+            }
+        })
+        .await
+        .expect("peer connected");
+    }
+}

--- a/rpp/runtime/telemetry.rs
+++ b/rpp/runtime/telemetry.rs
@@ -1,0 +1,393 @@
+use std::time::{Duration, SystemTime};
+
+use log::{error, info, warn};
+use reqwest::{Client, StatusCode};
+use serde::Serialize;
+use tokio::sync::mpsc;
+
+use crate::config::TelemetryConfig;
+
+const TELEMETRY_CHANNEL_CAPACITY: usize = 128;
+
+/// Snapshot of runtime telemetry data that is exported to remote collectors.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct TelemetrySnapshot {
+    /// Current block height of the node.
+    pub block_height: u64,
+    /// Hash of the latest block.
+    pub block_hash: String,
+    /// Total number of transactions seen within the current reporting window.
+    pub transaction_count: usize,
+    /// Number of currently connected peers.
+    pub peer_count: usize,
+    /// Identifier of the node emitting the snapshot (usually the libp2p peer id).
+    pub node_id: String,
+    /// Reputation score of the node as calculated by the local reputation subsystem.
+    pub reputation_score: f64,
+    /// Timestamp of the snapshot on the local node.
+    pub timestamp: SystemTime,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TelemetryError {
+    #[error("telemetry channel closed")]
+    ChannelClosed,
+}
+
+#[derive(Debug)]
+enum TelemetryMessage {
+    Snapshot(TelemetrySnapshot),
+    Shutdown,
+}
+
+/// Handle that allows producers to submit telemetry snapshots.
+#[derive(Clone)]
+pub struct TelemetryHandle {
+    sender: mpsc::Sender<TelemetryMessage>,
+}
+
+impl TelemetryHandle {
+    /// Spawns a telemetry worker and returns a handle for submitting snapshots.
+    pub fn spawn(config: TelemetryConfig) -> Self {
+        let (sender, receiver) = mpsc::channel(TELEMETRY_CHANNEL_CAPACITY);
+        let worker = TelemetryWorker::new(config, receiver);
+        tokio::spawn(async move {
+            worker.run().await;
+        });
+        Self { sender }
+    }
+
+    /// Sends a snapshot to the telemetry worker.
+    pub async fn send(&self, snapshot: TelemetrySnapshot) -> Result<(), TelemetryError> {
+        self.sender
+            .send(TelemetryMessage::Snapshot(snapshot))
+            .await
+            .map_err(|_| TelemetryError::ChannelClosed)
+    }
+
+    /// Gracefully shuts down the telemetry worker.
+    pub async fn shutdown(&self) -> Result<(), TelemetryError> {
+        self.sender
+            .send(TelemetryMessage::Shutdown)
+            .await
+            .map_err(|_| TelemetryError::ChannelClosed)
+    }
+}
+
+struct TelemetryWorker {
+    config: TelemetryConfig,
+    client: Client,
+    receiver: mpsc::Receiver<TelemetryMessage>,
+}
+
+impl TelemetryWorker {
+    fn new(config: TelemetryConfig, receiver: mpsc::Receiver<TelemetryMessage>) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_millis(config.timeout_ms.max(1)))
+            .build()
+            .expect("reqwest client");
+        Self {
+            config,
+            client,
+            receiver,
+        }
+    }
+
+    async fn run(mut self) {
+        while let Some(message) = self.receiver.recv().await {
+            match message {
+                TelemetryMessage::Snapshot(snapshot) => {
+                    self.process_snapshot(snapshot).await;
+                }
+                TelemetryMessage::Shutdown => break,
+            }
+        }
+    }
+
+    async fn process_snapshot(&self, snapshot: TelemetrySnapshot) {
+        if !self.config.enabled {
+            self.log_snapshot("telemetry disabled", &snapshot);
+            return;
+        }
+
+        match self.config.endpoint.as_deref() {
+            Some(endpoint) if !endpoint.is_empty() => {
+                if let Err(err) = self.dispatch_http(endpoint, &snapshot).await {
+                    warn!(
+                        target: "telemetry",
+                        "telemetry HTTP dispatch failed: {err}"
+                    );
+                    self.log_snapshot("http dispatch failed", &snapshot);
+                }
+            }
+            _ => {
+                self.log_snapshot("no endpoint configured", &snapshot);
+            }
+        }
+    }
+
+    fn log_snapshot(&self, reason: &str, snapshot: &TelemetrySnapshot) {
+        match serde_json::to_string(snapshot) {
+            Ok(payload) => {
+                info!(
+                    target: "telemetry",
+                    "{reason}: {payload}"
+                );
+            }
+            Err(err) => {
+                error!(target: "telemetry", "failed to encode telemetry snapshot: {err}");
+            }
+        }
+    }
+
+    async fn dispatch_http(
+        &self,
+        endpoint: &str,
+        snapshot: &TelemetrySnapshot,
+    ) -> Result<(), TelemetryDispatchError> {
+        let mut last_err = None;
+        for attempt in 0..=self.config.retry_max {
+            let mut request = self.client.post(endpoint).json(snapshot);
+            if let Some(token) = &self.config.auth_token {
+                request = request.header("Authorization", format!("Bearer {token}"));
+            }
+            match request.send().await {
+                Ok(response) => {
+                    if response.status().is_success() {
+                        return Ok(());
+                    }
+                    let status = response.status();
+                    let body = response
+                        .text()
+                        .await
+                        .unwrap_or_else(|_| "<body unavailable>".to_string());
+                    last_err = Some(TelemetryDispatchError::Status(status, body));
+                }
+                Err(err) => last_err = Some(TelemetryDispatchError::Request(err)),
+            }
+
+            if attempt < self.config.retry_max {
+                let exponent = attempt.min(16); // prevent overflow on very high retry counts
+                let multiplier = 1u64 << exponent;
+                let delay_ms = self.config.timeout_ms.saturating_mul(multiplier).max(1);
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            TelemetryDispatchError::Status(StatusCode::INTERNAL_SERVER_ERROR, "unknown".into())
+        }))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TelemetryDispatchError {
+    #[error("request error: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("endpoint responded with {0}: {1}")]
+    Status(StatusCode, String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::routing::post;
+    use axum::{Json, Router};
+    use serde_json::Value;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::OnceLock;
+    use tokio::sync::oneshot;
+    use tokio::time::{Duration as TokioDuration, sleep};
+
+    #[tokio::test]
+    async fn disabled_configuration_only_logs() {
+        let (addr, counter, shutdown) = spawn_test_server().await;
+        let config = TelemetryConfig {
+            enabled: false,
+            endpoint: Some(format!("http://{addr}")),
+            auth_token: None,
+            timeout_ms: 50,
+            retry_max: 2,
+            sample_interval_secs: 1,
+        };
+        let handle = TelemetryHandle::spawn(config);
+        let snapshot = sample_snapshot();
+
+        handle.send(snapshot).await.expect("snapshot queued");
+        sleep(TokioDuration::from_millis(200)).await;
+
+        assert_eq!(counter.lock().unwrap().len(), 0);
+        handle.shutdown().await.expect("shutdown");
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn enabled_configuration_posts_json_payload() {
+        let (addr, counter, shutdown) = spawn_test_server().await;
+        let endpoint = format!("http://{addr}");
+        let config = TelemetryConfig {
+            enabled: true,
+            endpoint: Some(endpoint.clone()),
+            auth_token: Some("token-123".into()),
+            timeout_ms: 100,
+            retry_max: 1,
+            sample_interval_secs: 1,
+        };
+        let handle = TelemetryHandle::spawn(config);
+        let snapshot = sample_snapshot();
+
+        handle
+            .send(snapshot.clone())
+            .await
+            .expect("snapshot queued");
+
+        tokio::time::timeout(TokioDuration::from_secs(2), async {
+            loop {
+                if !counter.lock().unwrap().is_empty() {
+                    break;
+                }
+                sleep(TokioDuration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("received payload");
+
+        let payloads = counter.lock().unwrap().clone();
+        assert_eq!(payloads.len(), 1);
+        let json: Value = serde_json::from_str(&payloads[0]).expect("json payload");
+        assert_eq!(json["block_height"], 42);
+        assert_eq!(json["node_id"], "node-1");
+        handle.shutdown().await.expect("shutdown");
+        let _ = shutdown.send(());
+    }
+
+    #[tokio::test]
+    async fn failed_endpoint_retries_and_logs() {
+        let logger = init_test_logger();
+        let port = find_unused_port();
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let config = TelemetryConfig {
+            enabled: true,
+            endpoint: Some(endpoint),
+            auth_token: None,
+            timeout_ms: 50,
+            retry_max: 2,
+            sample_interval_secs: 1,
+        };
+        let handle = TelemetryHandle::spawn(config);
+        let snapshot = sample_snapshot();
+
+        handle.send(snapshot).await.expect("snapshot queued");
+        sleep(TokioDuration::from_millis(400)).await;
+
+        let logs = logger.drain();
+        assert!(
+            logs.iter()
+                .any(|entry| entry.contains("telemetry HTTP dispatch failed"))
+        );
+        handle.shutdown().await.expect("shutdown");
+    }
+
+    fn sample_snapshot() -> TelemetrySnapshot {
+        TelemetrySnapshot {
+            block_height: 42,
+            block_hash: "0xdeadbeef".into(),
+            transaction_count: 7,
+            peer_count: 3,
+            node_id: "node-1".into(),
+            reputation_score: 0.75,
+            timestamp: SystemTime::now(),
+        }
+    }
+
+    async fn spawn_test_server() -> (
+        std::net::SocketAddr,
+        Arc<Mutex<VecDeque<String>>>,
+        oneshot::Sender<()>,
+    ) {
+        let storage = Arc::new(Mutex::new(VecDeque::new()));
+        let storage_clone = storage.clone();
+        let app = Router::new()
+            .route(
+                "/",
+                post(
+                    move |State(state): State<Arc<Mutex<VecDeque<String>>>>,
+                          Json(payload): Json<Value>| async move {
+                        state.lock().unwrap().push_back(payload.to_string());
+                        Result::<(), axum::http::StatusCode>::Ok(())
+                    },
+                ),
+            )
+            .with_state(storage_clone);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let state = storage.clone();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        (addr, state, shutdown_tx)
+    }
+
+    fn find_unused_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("bind random port")
+            .local_addr()
+            .expect("local addr")
+            .port()
+    }
+
+    #[derive(Default)]
+    struct TestLogger {
+        records: Mutex<Vec<String>>,
+    }
+
+    impl TestLogger {
+        fn drain(&self) -> Vec<String> {
+            std::mem::take(&mut *self.records.lock().unwrap())
+        }
+    }
+
+    impl log::Log for TestLogger {
+        fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            if self.enabled(record.metadata()) {
+                self.records
+                    .lock()
+                    .unwrap()
+                    .push(format!("{}", record.args()));
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    static LOGGER: OnceLock<Arc<TestLogger>> = OnceLock::new();
+
+    fn init_test_logger() -> Arc<TestLogger> {
+        LOGGER
+            .get_or_init(|| {
+                let logger = Arc::new(TestLogger::default());
+                log::set_boxed_logger(Box::new(logger.clone())).ok();
+                log::set_max_level(log::LevelFilter::Trace);
+                logger
+            })
+            .clone()
+    }
+}


### PR DESCRIPTION
## Summary
- add an asynchronous telemetry worker that accepts snapshots over a channel and optionally posts JSON payloads with retries
- implement a libp2p-backed node runtime that wires networking, heartbeats, and telemetry emission together
- expand runtime configuration and surface peer disconnect events from the networking layer

## Testing
- `cargo test telemetry::tests::disabled_configuration_only_logs`
- `cargo test telemetry::tests::enabled_configuration_posts_json_payload`
- `cargo test telemetry::tests::failed_endpoint_retries_and_logs`
- `cargo test node_runtime::node::tests::nodes_exchange_gossip -- --nocapture` *(fails: Network(Admission(TierInsufficient { required: Tl3, actual: Tl0 })))*
- `cargo test node_runtime::node::tests::disconnect_produces_event -- --nocapture`
- `cargo test node_runtime::node::tests::heartbeat_emits_events_and_telemetry -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68d6766808fc8326b0555adda43f8b94