### PR TITLE
Integrate P2P runtime into node startup orchestration

### DIFF
--- a/rpp/rpc/api.rs
+++ b/rpp/rpc/api.rs
@@ -21,6 +21,7 @@ use crate::orchestration::{PipelineDashboardSnapshot, PipelineOrchestrator, Pipe
 use crate::reputation::Tier;
 use crate::rpp::TimetokeRecord;
 use crate::runtime::RuntimeMode;
+use crate::runtime::node_runtime::NodeHandle as P2pHandle;
 use crate::sync::ReconstructionPlan;
 use crate::types::{
     Account, Address, AttestedIdentityRequest, Block, SignedTransaction, Transaction,
@@ -36,6 +37,8 @@ use parking_lot::RwLock;
 pub struct ApiContext {
     mode: Arc<RwLock<RuntimeMode>>,
     node: Option<NodeHandle>,
+    #[allow(dead_code)]
+    p2p: Option<P2pHandle>,
     wallet: Option<Arc<Wallet>>,
     orchestrator: Option<Arc<PipelineOrchestrator>>,
 }
@@ -44,12 +47,14 @@ impl ApiContext {
     pub fn new(
         mode: Arc<RwLock<RuntimeMode>>,
         node: Option<NodeHandle>,
+        p2p: Option<P2pHandle>,
         wallet: Option<Arc<Wallet>>,
         orchestrator: Option<Arc<PipelineOrchestrator>>,
     ) -> Self {
         Self {
             mode,
             node,
+            p2p,
             wallet,
             orchestrator,
         }

--- a/tests/end_to_end_pipeline.rs
+++ b/tests/end_to_end_pipeline.rs
@@ -34,7 +34,7 @@ async fn orchestrated_pipeline_finalises_transaction() {
     let handle = node.handle();
     let node_keypair = load_keypair(&node_config.key_path).expect("load node key");
 
-    let (orchestrator, shutdown_rx) = PipelineOrchestrator::new(handle.clone());
+    let (orchestrator, shutdown_rx) = PipelineOrchestrator::new(handle.clone(), None);
     orchestrator.spawn(shutdown_rx);
     let node_task = tokio::spawn(async move {
         let _ = node.start().await;

--- a/tests/pipeline_orchestrator.rs
+++ b/tests/pipeline_orchestrator.rs
@@ -55,7 +55,7 @@ impl OrchestratorFixture {
         let keypair = load_keypair(&node_config.key_path).expect("load node key");
         let wallet = Arc::new(Wallet::new(handle.storage(), keypair));
 
-        let (orchestrator, shutdown_rx) = PipelineOrchestrator::new(handle.clone());
+        let (orchestrator, shutdown_rx) = PipelineOrchestrator::new(handle.clone(), None);
         let orchestrator = Arc::new(orchestrator);
         let shutdown_observer = shutdown_rx.clone();
         orchestrator.spawn(shutdown_rx);


### PR DESCRIPTION
## Summary
- instantiate and run the libp2p node runtime alongside the existing node service
- propagate the P2P handle through the API context and pipeline orchestrator for future event handling
- improve coordinated shutdown so the P2P runtime receives an explicit stop signal

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6846138208326b26cfcc1fdcc87e9