### PR TITLE
Seed P2P handshake with ledger identity and add update path

### DIFF
--- a/rpp/p2p/src/swarm.rs
+++ b/rpp/p2p/src/swarm.rs
@@ -242,6 +242,19 @@ impl Network {
         Ok(())
     }
 
+    pub fn update_identity(
+        &mut self,
+        zsi_id: String,
+        tier: TierLevel,
+        vrf_proof: Vec<u8>,
+    ) -> Result<(), NetworkError> {
+        self.handshake = HandshakePayload::new(zsi_id, Some(vrf_proof), tier);
+        let signed = self.sign_handshake()?;
+        let peer_id = self.local_peer_id();
+        self.peerstore.record_handshake(peer_id, &signed)?;
+        Ok(())
+    }
+
     pub fn local_peer_id(&self) -> PeerId {
         *self.swarm.local_peer_id()
     }


### PR DESCRIPTION
## Summary
- expose a ledger-derived network identity profile from the node so the P2P layer can advertise the current ZSI identifier, tier, and handshake proof
- extend the P2P runtime configuration and command surface to install and refresh handshake identity data, wiring it through the network resources and libp2p swarm
- bootstrap the CLI node startup with the ledger-backed profile before spawning the P2P runtime so initial handshakes reflect on-chain state

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d6845ee238832687fb76a483527b15