### PR TITLE
Persist peer networking state

### DIFF
--- a/config/node.toml
+++ b/config/node.toml
@@ -15,6 +15,14 @@ epoch_length = 1440
 target_validator_count = 100
 max_proof_size_bytes = 4194304
 
+[p2p]
+listen_addr = "/ip4/0.0.0.0/tcp/7600"
+bootstrap_peers = []
+heartbeat_interval_ms = 5000
+gossip_enabled = true
+peerstore_path = "./data/p2p/peerstore.json"
+gossip_path = "./data/p2p/gossip.json"
+
 [rollout]
 release_channel = "development"
 

--- a/rpp/runtime/node_runtime/node.rs
+++ b/rpp/runtime/node_runtime/node.rs
@@ -162,6 +162,7 @@ impl NodeInner {
         let resources = NetworkResources::initialise(
             &config.identity_path,
             &network_config,
+            &config.p2p,
             config.identity.clone(),
         )?;
         let (network, identity) = resources.into_parts();

--- a/tests/end_to_end_pipeline.rs
+++ b/tests/end_to_end_pipeline.rs
@@ -27,6 +27,8 @@ async fn orchestrated_pipeline_finalises_transaction() {
     node_config.vrf_key_path = key_dir.join("vrf.toml");
     node_config.snapshot_dir = node_data.join("snapshots");
     node_config.proof_cache_dir = node_data.join("proofs");
+    node_config.p2p.peerstore_path = node_data.join("p2p/peerstore.json");
+    node_config.p2p.gossip_path = Some(node_data.join("p2p/gossip.json"));
     node_config.block_time_ms = 200;
     node_config.mempool_limit = 64;
 

--- a/tests/pipeline_orchestrator.rs
+++ b/tests/pipeline_orchestrator.rs
@@ -35,6 +35,8 @@ impl OrchestratorFixture {
         node_config.vrf_key_path = key_dir.join("vrf.toml");
         node_config.snapshot_dir = node_data.join("snapshots");
         node_config.proof_cache_dir = node_data.join("proofs");
+        node_config.p2p.peerstore_path = node_data.join("p2p/peerstore.json");
+        node_config.p2p.gossip_path = Some(node_data.join("p2p/gossip.json"));
         node_config.block_time_ms = 200;
         node_config.mempool_limit = 64;
         node_config.rollout.feature_gates.pruning = false;


### PR DESCRIPTION
## Summary
- add peerstore and gossip persistence paths to the P2P configuration with defaults and directory setup
- initialise network resources with a persistent peerstore and optional gossip state store
- update the sample node configuration and tests to cover persistence across restarts

## Testing
- cargo test (aborted due to long runtime)
- cargo test updates_reputation_and_ban_state_across_restart

------
https://chatgpt.com/codex/tasks/task_e_68d692a2599c8326b6863f7faf2ffd95