### PR TITLE
Refactor UTXO storage layout

### DIFF
--- a/rpp/runtime/types/mod.rs
+++ b/rpp/runtime/types/mod.rs
@@ -22,3 +22,4 @@ pub use transaction::{SignedTransaction, Transaction, TransactionEnvelope};
 pub use uptime::{UptimeClaim, UptimeProof};
 
 pub type Address = String;
+pub type AccountId = Address;

--- a/rpp/storage/state/mod.rs
+++ b/rpp/storage/state/mod.rs
@@ -12,5 +12,5 @@ pub use lifecycle::StateLifecycle;
 pub use proof_registry::ProofRegistry;
 pub use reputation::ReputationState;
 pub use timetoke::TimetokeState;
-pub use utxo::{BlueprintTransferPolicy, UtxoState};
+pub use utxo::{BlueprintTransferPolicy, StoredUtxo, UtxoState};
 pub use zsi::ZsiRegistry;


### PR DESCRIPTION
## Summary
- add an `AccountId` alias and re-export the new `StoredUtxo` type so other modules can use it
- replace the UTXO state map with entries keyed by outpoints that hold `StoredUtxo` values and cache account reputation data
- update query, selection, and commitment helpers to operate on the new storage layout

## Testing
- cargo fmt
- cargo test --lib *(fails: missing `utxo_state` definition in wallet workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f3d7c5c83268827664cc3367539