### PR TITLE
Add stored UTXO snapshot format

### DIFF
--- a/rpp/storage/ledger.rs
+++ b/rpp/storage/ledger.rs
@@ -199,6 +199,10 @@ impl Ledger {
         self.utxo_state.unspent_outputs_for_owner(address)
     }
 
+    pub fn utxo_for_account(&self, address: &Address) -> Option<UtxoRecord> {
+        self.utxo_state.get_for_account(address)
+    }
+
     pub fn validator_public_key(&self, address: &str) -> ChainResult<PublicKey> {
         let account = self.get_account(address).ok_or_else(|| {
             ChainError::Crypto("validator account missing for signature verification".into())

--- a/rpp/storage/state/mod.rs
+++ b/rpp/storage/state/mod.rs
@@ -12,5 +12,5 @@ pub use lifecycle::StateLifecycle;
 pub use proof_registry::ProofRegistry;
 pub use reputation::ReputationState;
 pub use timetoke::TimetokeState;
-pub use utxo::{BlueprintTransferPolicy, UtxoState};
+pub use utxo::{BlueprintTransferPolicy, StoredUtxo, UtxoState};
 pub use zsi::ZsiRegistry;


### PR DESCRIPTION
## Summary
- add a serializable `StoredUtxo` representation and expose richer UTXO snapshots
- hash outpoint/value pairs for the UTXO Merkle commitment
- update ledger and wallet helpers to consume the new snapshot shape

## Testing
- cargo test *(terminated after running for several minutes due to long-running ledger tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f3a45488326b33623838fcd1d19