### PR TITLE
Refactor UTXO snapshots to stored representation

### DIFF
--- a/rpp/proofs/rpp.rs
+++ b/rpp/proofs/rpp.rs
@@ -399,6 +399,13 @@ pub struct UtxoRecord {
     pub timelock: Option<u64>,
 }
 
+/// Snapshot of all UTXO data derived for an account.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StoredUtxo {
+    pub aggregated: UtxoRecord,
+    pub fragments: Vec<UtxoRecord>,
+}
+
 /// Asset categories supported by the chain.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AssetType {
@@ -506,10 +513,10 @@ pub struct TransactionWitness {
     pub sender_after: AccountBalanceWitness,
     pub recipient_before: Option<AccountBalanceWitness>,
     pub recipient_after: AccountBalanceWitness,
-    pub sender_utxo_before: Option<UtxoRecord>,
-    pub sender_utxo_after: Option<UtxoRecord>,
-    pub recipient_utxo_before: Option<UtxoRecord>,
-    pub recipient_utxo_after: Option<UtxoRecord>,
+    pub sender_utxo_before: Option<StoredUtxo>,
+    pub sender_utxo_after: Option<StoredUtxo>,
+    pub recipient_utxo_before: Option<StoredUtxo>,
+    pub recipient_utxo_after: Option<StoredUtxo>,
 }
 
 impl TransactionWitness {
@@ -521,10 +528,10 @@ impl TransactionWitness {
         sender_after: AccountBalanceWitness,
         recipient_before: Option<AccountBalanceWitness>,
         recipient_after: AccountBalanceWitness,
-        sender_utxo_before: Option<UtxoRecord>,
-        sender_utxo_after: Option<UtxoRecord>,
-        recipient_utxo_before: Option<UtxoRecord>,
-        recipient_utxo_after: Option<UtxoRecord>,
+        sender_utxo_before: Option<StoredUtxo>,
+        sender_utxo_after: Option<StoredUtxo>,
+        recipient_utxo_before: Option<StoredUtxo>,
+        recipient_utxo_after: Option<StoredUtxo>,
     ) -> Self {
         Self {
             tx_id,


### PR DESCRIPTION
## Summary
- introduce a StoredUtxo structure for witness data and update transaction witnesses to use it
- refactor the in-memory UtxoState to manage StoredUtxo snapshots and expose helpers for rebuilding state
- update ledger indexing and wallet workflows to derive UTXO snapshots via the new APIs

## Testing
- `cargo test` *(terminated after long-running ledger identity tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d69f522d9c8326aa6fd874939b7618