### PR TITLE
Simplify UTXO state storage

### DIFF
--- a/rpp/storage/state/mod.rs
+++ b/rpp/storage/state/mod.rs
@@ -12,5 +12,5 @@ pub use lifecycle::StateLifecycle;
 pub use proof_registry::ProofRegistry;
 pub use reputation::ReputationState;
 pub use timetoke::TimetokeState;
-pub use utxo::{BlueprintTransferPolicy, StoredUtxo, UtxoState};
+pub use utxo::{StoredUtxo, UtxoState};
 pub use zsi::ZsiRegistry;

--- a/rpp/storage/state/utxo.rs
+++ b/rpp/storage/state/utxo.rs
@@ -1,120 +1,15 @@
-use std::cmp::Ordering;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 
-use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use tokio::sync::RwLock;
 
-use crate::errors::{ChainError, ChainResult};
-use crate::reputation::{ReputationParams, Tier, TimetokeParams};
 use crate::rpp::{AssetType, UtxoOutpoint, UtxoRecord};
 use crate::state::merkle::compute_merkle_root;
-use crate::types::{Account, AccountId, Address};
+use crate::types::{Account, Address};
 
-#[derive(Clone, Debug)]
-pub struct StoredUtxo {
-    pub owner: AccountId,
-    pub amount: u64,
-    pub spent: bool,
-}
-
-impl StoredUtxo {
-    fn new(owner: AccountId, amount: u64) -> Self {
-        Self {
-            owner,
-            amount,
-            spent: false,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-struct AccountProfile {
-    tier: Tier,
-    reputation_score: f64,
-    timetoke_hours: u64,
-}
-
-impl From<&Account> for AccountProfile {
-    fn from(account: &Account) -> Self {
-        Self {
-            tier: account.reputation.tier.clone(),
-            reputation_score: account.reputation.score,
-            timetoke_hours: account.reputation.timetokes.hours_online,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BlueprintTransferPolicy {
-    pub min_tier: Tier,
-    pub min_score: f64,
-    pub min_timetoke_hours: u64,
-    pub max_inputs: usize,
-    pub preferred_fragment_value: u128,
-    pub max_fragments_per_account: usize,
-}
-
-impl BlueprintTransferPolicy {
-    pub fn blueprint_default() -> Self {
-        let reputation_params = ReputationParams::default();
-        let timetoke_params = TimetokeParams::default();
-        Self {
-            min_tier: Tier::Tl2,
-            min_score: reputation_params.tier_thresholds.tier5_min_score / 3.0,
-            min_timetoke_hours: timetoke_params.decay_step_hours.saturating_mul(6),
-            max_inputs: 4,
-            preferred_fragment_value: 25_000,
-            max_fragments_per_account: 8,
-        }
-    }
-
-    fn fragment_values(&self, balance: u128) -> Vec<u128> {
-        if balance == 0 {
-            return Vec::new();
-        }
-        let mut remaining = balance;
-        let mut fragments = Vec::new();
-        while remaining > 0 && fragments.len() < self.max_fragments_per_account {
-            let next = remaining.min(self.preferred_fragment_value);
-            fragments.push(next);
-            remaining = remaining.saturating_sub(next);
-        }
-        if remaining > 0 {
-            if let Some(last) = fragments.last_mut() {
-                *last = last.saturating_add(remaining);
-            }
-        }
-        fragments
-    }
-
-    pub fn ensure_account_allowed(&self, account: &Account) -> ChainResult<()> {
-        if account.reputation.tier < self.min_tier {
-            return Err(ChainError::Transaction(
-                "wallet tier insufficient for requested policy".into(),
-            ));
-        }
-        if account.reputation.score < self.min_score {
-            return Err(ChainError::Transaction(
-                "wallet reputation score below blueprint minimum".into(),
-            ));
-        }
-        if account.reputation.timetokes.hours_online < self.min_timetoke_hours {
-            return Err(ChainError::Transaction(
-                "wallet timetoke hours below blueprint minimum".into(),
-            ));
-        }
-        Ok(())
-    }
-}
-
-impl Default for BlueprintTransferPolicy {
-    fn default() -> Self {
-        Self::blueprint_default()
-    }
-}
-
-#[derive(Clone, Debug)]
+/// Wrapper around a [`UtxoRecord`] that is stored inside the ledger state.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StoredUtxo {
     pub record: UtxoRecord,
 }
@@ -128,25 +23,40 @@ impl StoredUtxo {
 #[derive(Default)]
 pub struct UtxoState {
     entries: RwLock<BTreeMap<UtxoOutpoint, StoredUtxo>>,
-    account_profiles: RwLock<BTreeMap<Address, AccountProfile>>,
-    policy: BlueprintTransferPolicy,
 }
 
 impl UtxoState {
     pub fn new() -> Self {
-        Self::with_policy(BlueprintTransferPolicy::blueprint_default())
+        Self::default()
     }
 
-    pub fn with_policy(policy: BlueprintTransferPolicy) -> Self {
-        Self {
-            entries: RwLock::new(BTreeMap::new()),
-            account_profiles: RwLock::new(BTreeMap::new()),
-            policy,
-        }
+    /// Insert or replace a UTXO inside the state.
+    pub fn insert(&self, stored: StoredUtxo) {
+        let outpoint = stored.record.outpoint.clone();
+        self.entries.blocking_write().insert(outpoint, stored);
     }
 
-    pub fn policy(&self) -> BlueprintTransferPolicy {
-        self.policy.clone()
+    /// Remove a spent UTXO. Returns `true` if an entry was removed.
+    pub fn remove_spent(&self, outpoint: &UtxoOutpoint) -> bool {
+        self.entries.blocking_write().remove(outpoint).is_some()
+    }
+
+    /// Fetch a UTXO by its outpoint.
+    pub fn get(&self, outpoint: &UtxoOutpoint) -> Option<UtxoRecord> {
+        self.entries
+            .blocking_read()
+            .get(outpoint)
+            .map(|stored| stored.record.clone())
+    }
+
+    /// Return the canonical UTXO associated with the provided account.
+    pub fn get_for_account(&self, address: &Address) -> Option<UtxoRecord> {
+        self.entries
+            .blocking_read()
+            .values()
+            .filter(|stored| stored.record.owner == *address)
+            .min_by_key(|stored| stored.record.outpoint.index)
+            .map(|stored| stored.record.clone())
     }
 
     pub fn upsert_from_account(&self, account: &Account) {
@@ -158,254 +68,61 @@ impl UtxoState {
     }
 
     fn upsert_from_account_with_tx(&self, account: &Account, tx_id: Option<[u8; 32]>) {
-        let mut entries = self.entries.write();
+        let mut entries = self.entries.blocking_write();
         let existing_tx_id = entries
             .iter()
-            .find(|(outpoint, stored)| stored.owner == account.address && outpoint.index == 0)
+            .find(|(outpoint, stored)| {
+                stored.record.owner == account.address && outpoint.index == 0
+            })
             .map(|(outpoint, _)| outpoint.tx_id);
         let tx_id = tx_id.or(existing_tx_id).unwrap_or([0u8; 32]);
 
-        entries.retain(|_, stored| stored.owner != account.address);
+        entries.retain(|_, stored| stored.record.owner != account.address);
 
-        let aggregated_outpoint = make_outpoint(tx_id, 0);
-        entries.insert(
-            aggregated_outpoint,
-            StoredUtxo::new(account.address.clone(), to_amount(account.balance)),
+        let aggregated_outpoint = UtxoOutpoint { tx_id, index: 0 };
+        let record = build_record(
+            &account.address,
+            account.balance,
+            aggregated_outpoint.clone(),
+            aggregated_outpoint.index,
         );
-
-        for (index, value) in self
-            .policy
-            .fragment_values(account.balance)
-            .into_iter()
-            .enumerate()
-        {
-            let fragment_index = u32::try_from(index + 1).unwrap_or(u32::MAX);
-            let outpoint = make_outpoint(tx_id, fragment_index);
-            entries.insert(
-                outpoint,
-                StoredUtxo::new(account.address.clone(), to_amount(value)),
-            );
-        }
-        drop(entries);
-
-        let mut profiles = self.account_profiles.write();
-        profiles.insert(account.address.clone(), AccountProfile::from(account));
-    }
-
-    pub fn get_for_account(&self, address: &Address) -> Option<UtxoRecord> {
-        self.entries
-            .read()
-            .iter()
-            .find(|(outpoint, stored)| {
-                stored.owner == *address && outpoint.index == 0 && !stored.spent
-            })
-            .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
-    }
-
-    pub fn fragments_for_account(&self, address: &Address) -> Vec<UtxoRecord> {
-        let entries = self.entries.read();
-        entries
-            .iter()
-            .filter(|(outpoint, stored)| {
-                stored.owner == *address && outpoint.index > 0 && !stored.spent
-            })
-            .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
-            .collect()
+        entries.insert(aggregated_outpoint, StoredUtxo::new(record));
     }
 
     pub fn unspent_outputs_for_owner(&self, owner: &Address) -> Vec<UtxoRecord> {
-        let entries = self.entries.read();
-        let mut outputs: Vec<UtxoRecord> = entries
+        let mut outputs: Vec<UtxoRecord> = self
+            .entries
+            .blocking_read()
             .iter()
-            .filter(|(outpoint, stored)| {
-                stored.owner == *owner && outpoint.index > 0 && !stored.spent
-            })
-            .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
+            .filter(|(_, stored)| stored.record.owner == *owner)
+            .map(|(_, stored)| stored.record.clone())
             .collect();
         outputs.sort_by(|a, b| a.outpoint.cmp(&b.outpoint));
         outputs
     }
 
-    pub fn select_inputs_for_owner(
-        &self,
-        owner: &Address,
-        target: u128,
-        policy: &BlueprintTransferPolicy,
-    ) -> ChainResult<Vec<UtxoRecord>> {
-        let profiles = self.account_profiles.read();
-        let profile = profiles.get(owner).ok_or_else(|| {
-            ChainError::Transaction("wallet inputs unavailable for requested owner".into())
-        })?;
-        if profile.tier < policy.min_tier {
-            return Err(ChainError::Transaction(
-                "owner tier below blueprint requirement".into(),
-            ));
-        }
-        if profile.reputation_score < policy.min_score {
-            return Err(ChainError::Transaction(
-                "owner reputation score below blueprint requirement".into(),
-            ));
-        }
-        if profile.timetoke_hours < policy.min_timetoke_hours {
-            return Err(ChainError::Transaction(
-                "owner timetoke hours below blueprint requirement".into(),
-            ));
-        }
-        drop(profiles);
-
-        let entries = self.entries.read();
-        let mut fragments: Vec<UtxoRecord> = entries
-            .iter()
-            .filter(|(outpoint, stored)| {
-                stored.owner == *owner && outpoint.index > 0 && !stored.spent
-            })
-            .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
-            .collect();
-        fragments.sort_by(|a, b| match b.value.cmp(&a.value) {
-            Ordering::Equal => a.outpoint.cmp(&b.outpoint),
-            other => other,
-        });
-        let mut selected = Vec::new();
-        let mut total = 0u128;
-        for fragment in fragments {
-            if total >= target {
-                break;
-            }
-            total = total
-                .checked_add(fragment.value)
-                .ok_or_else(|| ChainError::Transaction("input value overflow".into()))?;
-            selected.push(fragment);
-            if selected.len() > policy.max_inputs {
-                return Err(ChainError::Transaction(
-                    "required inputs exceed blueprint maximum".into(),
-                ));
-            }
-        }
-        if total < target {
-            return Err(ChainError::Transaction(
-                "insufficient input liquidity for requested amount".into(),
-            ));
-        }
-        selected.sort_by(|a, b| a.outpoint.cmp(&b.outpoint));
-        Ok(selected)
-    }
-
-    pub fn owners_by_tier(&self, min_tier: Tier) -> Vec<UtxoRecord> {
-        let entries = self.entries.read();
-        let profiles = self.account_profiles.read();
-        profiles
-            .iter()
-            .filter(|(_, profile)| profile.tier >= min_tier)
-            .filter_map(|(owner, _)| aggregated_for_owner(&entries, owner))
-            .collect()
-    }
-
-    pub fn owners_by_reputation(&self, min_score: f64) -> Vec<UtxoRecord> {
-        let entries = self.entries.read();
-        let profiles = self.account_profiles.read();
-        profiles
-            .iter()
-            .filter(|(_, profile)| profile.reputation_score >= min_score)
-            .filter_map(|(owner, _)| aggregated_for_owner(&entries, owner))
-            .collect()
-    }
-
-    pub fn insert(&self, stored: StoredUtxo) {
-        let record = stored.record.clone();
-        let mut entries = self.entries.write();
-        entries.insert(
-            record.outpoint.clone(),
-            StoredUtxo::new(record.owner.clone(), to_amount(record.value)),
-        );
-        drop(entries);
-
-        let mut profiles = self.account_profiles.write();
-        profiles
-            .entry(record.owner.clone())
-            .or_insert(AccountProfile {
-                tier: Tier::Tl0,
-                reputation_score: 0.0,
-                timetoke_hours: 0,
-            });
-    }
-
-    pub fn remove_spent(&self, outpoint: &UtxoOutpoint) -> bool {
-        self.remove(outpoint).is_some()
-    }
-
-    pub fn remove(&self, outpoint: &UtxoOutpoint) -> Option<UtxoRecord> {
-        let mut entries = self.entries.write();
-        let removed = entries.remove(outpoint)?;
-        let owner = removed.owner.clone();
-        if outpoint.index == 0 {
-            entries.retain(|_, stored| stored.owner != owner);
-        }
-        drop(entries);
-
-        if outpoint.index == 0 {
-            self.account_profiles.write().remove(&owner);
-        }
-
-        Some(stored_to_record(outpoint, &removed))
-    }
-
-    pub fn get(&self, outpoint: &UtxoOutpoint) -> Option<UtxoRecord> {
-        self.entries
-            .read()
-            .get(outpoint)
-            .map(|stored| stored_to_record(outpoint, stored))
-    }
-
     pub fn snapshot(&self) -> Vec<UtxoRecord> {
         self.entries
-            .read()
+            .blocking_read()
             .iter()
-            .filter(|(outpoint, stored)| outpoint.index == 0 && !stored.spent)
-            .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
+            .filter(|(outpoint, _)| outpoint.index == 0)
+            .map(|(_, stored)| stored.record.clone())
             .collect()
     }
 
     pub fn commitment(&self) -> [u8; 32] {
         let mut leaves: Vec<[u8; 32]> = self
             .entries
-            .read()
+            .blocking_read()
             .iter()
-            .filter(|(outpoint, stored)| outpoint.index == 0 && !stored.spent)
-            .map(|(outpoint, stored)| {
-                let record = stored_to_record(outpoint, stored);
-                let payload = serde_json::to_vec(&record).expect("serialize utxo record");
+            .filter(|(outpoint, _)| outpoint.index == 0)
+            .map(|(_, stored)| {
+                let payload = serde_json::to_vec(&stored.record).expect("serialize utxo record");
                 Blake2sHasher::hash(&payload).into()
             })
             .collect();
         compute_merkle_root(&mut leaves)
     }
-}
-
-fn to_amount(value: u128) -> u64 {
-    value.min(u64::MAX as u128) as u64
-}
-
-fn stored_to_record(outpoint: &UtxoOutpoint, stored: &StoredUtxo) -> UtxoRecord {
-    build_record(
-        &stored.owner,
-        stored.amount as u128,
-        outpoint.clone(),
-        outpoint.index,
-    )
-}
-
-fn aggregated_for_owner(
-    entries: &BTreeMap<UtxoOutpoint, StoredUtxo>,
-    owner: &Address,
-) -> Option<UtxoRecord> {
-    entries
-        .iter()
-        .find(|(outpoint, stored)| stored.owner == *owner && outpoint.index == 0 && !stored.spent)
-        .map(|(outpoint, stored)| stored_to_record(outpoint, stored))
-}
-
-fn make_outpoint(tx_id: [u8; 32], index: u32) -> UtxoOutpoint {
-    UtxoOutpoint { tx_id, index }
 }
 
 fn build_record(owner: &Address, value: u128, outpoint: UtxoOutpoint, salt: u32) -> UtxoRecord {
@@ -424,58 +141,75 @@ fn build_record(owner: &Address, value: u128, outpoint: UtxoOutpoint, salt: u32)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::reputation::{ReputationProfile, TimetokeBalance};
     use crate::types::Stake;
 
-    fn sample_account(address: &str, balance: u128, tier: Tier, score: f64, hours: u64) -> Account {
-        let mut account = Account::new(address.to_string(), balance, Stake::default());
-        account.reputation = ReputationProfile::new(address);
-        account.reputation.tier = tier;
-        account.reputation.score = score;
-        account.reputation.timetokes = TimetokeBalance {
-            hours_online: hours,
-            ..TimetokeBalance::default()
-        };
-        account
+    fn sample_account(address: &str, balance: u128) -> Account {
+        Account::new(address.to_string(), balance, Stake::default())
+    }
+
+    fn sample_record(owner: &str, tx_id: [u8; 32], index: u32, value: u128) -> UtxoRecord {
+        UtxoRecord {
+            outpoint: UtxoOutpoint { tx_id, index },
+            owner: owner.to_string(),
+            value,
+            asset_type: AssetType::Native,
+            script_hash: [index as u8; 32],
+            timelock: None,
+        }
     }
 
     #[test]
-    fn policy_blocks_tier_violation() {
-        let policy = BlueprintTransferPolicy {
-            min_tier: Tier::Tl2,
-            min_score: 0.1,
-            min_timetoke_hours: 1,
-            max_inputs: 4,
-            preferred_fragment_value: 10,
-            max_fragments_per_account: 4,
+    fn insert_and_get_round_trip() {
+        let state = UtxoState::new();
+        let outpoint = UtxoOutpoint {
+            tx_id: [1u8; 32],
+            index: 0,
         };
-        let state = UtxoState::with_policy(policy.clone());
-        let account = sample_account("addr-tier", 40, Tier::Tl1, 0.5, 10);
-        state.upsert_from_account(&account);
-        let result = state.select_inputs_for_owner(&account.address, 20, &policy);
-        assert!(matches!(
-            result,
-            Err(ChainError::Transaction(message)) if message.contains("tier")
-        ));
+        let record = sample_record("alice", outpoint.tx_id, outpoint.index, 42);
+        state.insert(StoredUtxo::new(record.clone()));
+        let fetched = state.get(&outpoint).expect("utxo fetched");
+        assert_eq!(fetched.outpoint, record.outpoint);
+        assert_eq!(fetched.owner, record.owner);
+        assert_eq!(fetched.value, record.value);
     }
 
     #[test]
-    fn policy_blocks_low_reputation() {
-        let policy = BlueprintTransferPolicy {
-            min_tier: Tier::Tl1,
-            min_score: 0.6,
-            min_timetoke_hours: 1,
-            max_inputs: 4,
-            preferred_fragment_value: 10,
-            max_fragments_per_account: 4,
+    fn remove_spent_removes_entry() {
+        let state = UtxoState::new();
+        let outpoint = UtxoOutpoint {
+            tx_id: [2u8; 32],
+            index: 0,
         };
-        let state = UtxoState::with_policy(policy.clone());
-        let account = sample_account("addr-rep", 40, Tier::Tl3, 0.2, 10);
+        let record = sample_record("bob", outpoint.tx_id, outpoint.index, 7);
+        state.insert(StoredUtxo::new(record));
+        assert!(state.remove_spent(&outpoint));
+        assert!(state.get(&outpoint).is_none());
+    }
+
+    #[test]
+    fn get_for_account_prefers_lowest_index() {
+        let state = UtxoState::new();
+        let first = sample_record("carol", [3u8; 32], 1, 10);
+        let second = sample_record("carol", [4u8; 32], 0, 20);
+        state.insert(StoredUtxo::new(first.clone()));
+        state.insert(StoredUtxo::new(second.clone()));
+        let fetched = state
+            .get_for_account(&"carol".to_string())
+            .expect("carol utxo");
+        assert_eq!(fetched.outpoint, second.outpoint);
+        assert_eq!(fetched.value, second.value);
+    }
+
+    #[test]
+    fn upsert_from_account_rebuilds_record() {
+        let state = UtxoState::new();
+        let account = sample_account("dave", 100);
         state.upsert_from_account(&account);
-        let result = state.select_inputs_for_owner(&account.address, 20, &policy);
-        assert!(matches!(
-            result,
-            Err(ChainError::Transaction(message)) if message.contains("reputation")
-        ));
+        let record = state
+            .get_for_account(&account.address)
+            .expect("utxo record");
+        assert_eq!(record.owner, account.address);
+        assert_eq!(record.value, account.balance);
+        assert_eq!(record.outpoint.index, 0);
     }
 }


### PR DESCRIPTION
## Summary
- replace the UTXO state store with a tokio RwLock-backed BTreeMap of StoredUtxo records and drop blueprint policy handling
- update the wallet workflow helper to consume the simplified UTXO state API
- adjust state re-exports to reflect the streamlined types

## Testing
- cargo test rpp::storage::state::utxo -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d6ee1103d88326ada0df72e204a75d