### PR TITLE
Enforce VRF key usage for identity workflows

### DIFF
--- a/rpp/proofs/stwo/prover/mod.rs
+++ b/rpp/proofs/stwo/prover/mod.rs
@@ -79,7 +79,7 @@ impl<'a> WalletProver<'a> {
         Ok(IdentityWitness {
             wallet_pk: genesis.wallet_pk.clone(),
             wallet_addr: genesis.wallet_addr.clone(),
-            vrf_tag: genesis.vrf_tag.clone(),
+            vrf_tag: genesis.vrf_tag().to_string(),
             epoch_nonce: genesis.epoch_nonce.clone(),
             state_root: genesis.state_root.clone(),
             identity_root: genesis.identity_root.clone(),

--- a/rpp/runtime/sync.rs
+++ b/rpp/runtime/sync.rs
@@ -618,7 +618,8 @@ mod tests {
         let keypair = Keypair::generate(&mut rng);
         let address = address_from_public_key(&keypair.public);
         let vrf_keypair = generate_vrf_keypair().expect("generate vrf keypair");
-        let vrf = evaluate_vrf(&seed, height, &address, height, Some(&vrf_keypair.secret));
+        let vrf = evaluate_vrf(&seed, height, &address, height, Some(&vrf_keypair.secret))
+            .expect("evaluate vrf");
         let header = BlockHeader::new(
             height,
             previous_hash,

--- a/rpp/wallet/ui/workflows.rs
+++ b/rpp/wallet/ui/workflows.rs
@@ -166,7 +166,7 @@ impl<'a> WalletWorkflows<'a> {
                 ChainError::Config(format!("unable to persist identity workflow state: {err}"))
             })?;
         Ok(IdentityWorkflow {
-            vrf_tag: declaration.genesis.vrf_tag.clone(),
+            vrf_tag: declaration.genesis.vrf_tag().to_string(),
             epoch_nonce: declaration.genesis.epoch_nonce.clone(),
             state_root: declaration.genesis.state_root.clone(),
             identity_root: declaration.genesis.identity_root.clone(),


### PR DESCRIPTION
## Summary
- require a VRF secret key when generating proofs and propagate errors instead of synthesizing fallback tags
- extend identity genesis data with VRF public key and proof verification, and persist wallet-side VRF key material when constructing declarations
- update identity-related tests and helpers to use real VRF keypairs and proofs

## Testing
- cargo test --package rpp-chain crypto::tests::load_or_generate_vrf_keypair_reuses_existing_material -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d70ae7e1548326b3aa5a16d0efccb4