### PR TITLE
Add wallet-controlled node lifecycle management

### DIFF
--- a/rpp/wallet/ui/mod.rs
+++ b/rpp/wallet/ui/mod.rs
@@ -3,6 +3,12 @@ pub mod tabs;
 pub mod wallet;
 pub mod workflows;
 
+use tokio::task::JoinHandle;
+
+use crate::config::NodeConfig;
+use crate::errors::{ChainError, ChainResult};
+use crate::node::{NodeHandle, NodeInner};
+
 pub use crate::types::UptimeProof;
 pub use proofs::{ProofGenerator, TxProof};
 pub use tabs::{HistoryEntry, HistoryStatus, NodeTabMetrics, ReceiveTabAddress, SendPreview};
@@ -12,3 +18,30 @@ pub use workflows::{
     IdentityWorkflowState, ReputationStatus, TransactionPolicy, TransactionWorkflow,
     UptimeWorkflow, WalletWorkflows,
 };
+
+/// Handle returned by [`start_node`] encapsulating the running node task.
+pub struct WalletNodeRuntime {
+    handle: NodeHandle,
+    join: JoinHandle<()>,
+}
+
+impl WalletNodeRuntime {
+    pub fn handle(&self) -> &NodeHandle {
+        &self.handle
+    }
+}
+
+/// Start a node runtime using the wallet configuration surface.
+pub async fn start_node(config: NodeConfig) -> ChainResult<WalletNodeRuntime> {
+    let (handle, join) = NodeInner::start(config).await?;
+    Ok(WalletNodeRuntime { handle, join })
+}
+
+/// Stop a running node runtime previously started via [`start_node`].
+pub async fn stop_node(runtime: WalletNodeRuntime) -> ChainResult<()> {
+    runtime.handle.stop().await?;
+    runtime
+        .join
+        .await
+        .map_err(|err| ChainError::Config(format!("node runtime join error: {err}")))
+}

--- a/tests/rpc_endpoints.rs
+++ b/tests/rpc_endpoints.rs
@@ -1,14 +1,14 @@
 use std::sync::Arc;
 
 use axum::{
+    Json, Router,
     body::Body,
     extract::{Path, State},
-    http::{header::CONTENT_TYPE, Method, Request, StatusCode},
+    http::{Method, Request, StatusCode, header::CONTENT_TYPE},
     routing::{get, post},
-    Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -35,10 +35,7 @@ async fn status_returns_node_status() {
 
     assert_eq!(payload["role"].as_str(), Some("node"));
     assert_eq!(payload["height"].as_u64(), Some(2));
-    assert_eq!(
-        payload["latest_commitment"].as_str(),
-        Some("state-root-2"),
-    );
+    assert_eq!(payload["latest_commitment"].as_str(), Some("state-root-2"),);
 }
 
 #[tokio::test]

--- a/tests/wallet_node_control.rs
+++ b/tests/wallet_node_control.rs
@@ -1,0 +1,83 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener};
+use std::time::Duration;
+
+use anyhow::Result;
+use tempfile::TempDir;
+use tokio::time::sleep;
+
+use rpp_chain::config::NodeConfig;
+use rpp_chain::wallet::{start_node, stop_node};
+
+fn available_port() -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+fn configure_node(temp: &TempDir) -> Result<NodeConfig> {
+    let mut config = NodeConfig::default();
+    let data_dir = temp.path().join("data");
+    let keys_dir = temp.path().join("keys");
+
+    config.data_dir = data_dir.clone();
+    config.snapshot_dir = data_dir.join("snapshots");
+    config.proof_cache_dir = data_dir.join("proofs");
+    config.key_path = keys_dir.join("node.toml");
+    config.p2p_key_path = keys_dir.join("p2p.toml");
+    config.vrf_key_path = keys_dir.join("vrf.toml");
+    config.p2p.peerstore_path = data_dir.join("p2p/peerstore.json");
+    config.p2p.gossip_path = Some(data_dir.join("p2p/gossip.json"));
+
+    let rpc_port = available_port()?;
+    config.rpc_listen = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port);
+    let p2p_port = available_port()?;
+    config.p2p.listen_addr = format!("/ip4/127.0.0.1/tcp/{p2p_port}");
+    config.block_time_ms = 200;
+    config.mempool_limit = 128;
+
+    Ok(config)
+}
+
+fn p2p_port(config: &NodeConfig) -> u16 {
+    config
+        .p2p
+        .listen_addr
+        .rsplit('/')
+        .next()
+        .expect("multiaddr port segment")
+        .parse()
+        .expect("valid port number")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wallet_node_can_start_and_stop_multiple_times() -> Result<()> {
+    let temp = TempDir::new()?;
+    let mut config = configure_node(&temp)?;
+
+    // Ensure deterministic genesis chain id for repeated startups.
+    config.genesis.chain_id = "wallet-node-control".to_string();
+
+    let port = p2p_port(&config);
+
+    for cycle in 0..3 {
+        let runtime = start_node(config.clone()).await?;
+        // Allow the runtime to produce at least one block.
+        sleep(Duration::from_millis(500)).await;
+
+        let status = runtime.handle().node_status()?;
+        assert_eq!(
+            status.last_hash.len(),
+            64,
+            "node status should be reachable on cycle {cycle}"
+        );
+
+        stop_node(runtime).await?;
+
+        // After shutdown, the P2P port should be available for binding again.
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        TcpListener::bind(addr)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add broadcast-driven shutdown coordination to the node runtime so it can start and stop cleanly
- expose wallet helper APIs that launch the node in the background and allow orderly shutdown
- cover the new lifecycle with an integration test that exercises repeated start/stop cycles

## Testing
- cargo test wallet_node_control -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d79caa59808326975bf48a2617c440