### PR TITLE
Support multi-output ledger snapshots in wallet workflows

### DIFF
--- a/rpp/runtime/orchestration.rs
+++ b/rpp/runtime/orchestration.rs
@@ -269,10 +269,15 @@ impl PipelineOrchestrator {
             ));
         }
         let hash = workflow.bundle.hash();
+        let expected_balance = workflow
+            .sender_post_utxos
+            .iter()
+            .map(|utxo| utxo.value)
+            .sum();
         let metrics = FlowMetrics::new(
             sender.clone(),
             workflow.nonce,
-            workflow.sender_post_utxo.value,
+            expected_balance,
             Instant::now(),
         );
         self.metrics.register(hash.clone(), metrics).await;


### PR DESCRIPTION
## Summary
- update wallet transaction workflow to surface deterministic UTXO collections for sender and recipient snapshots
- reuse the ledger-backed helper for post-transaction balance projections and adjust orchestrator metrics to sum the updated outputs

## Testing
- `cargo test wallet_utxo_view_matches_ledger`


------
https://chatgpt.com/codex/tasks/task_e_68d7c41f9fb08326b1dcc174b15e0518