### PR TITLE
Integrate gossip pipelines with validation and storage

### DIFF
--- a/rpp/p2p/src/lib.rs
+++ b/rpp/p2p/src/lib.rs
@@ -19,9 +19,9 @@ pub use identity::{IdentityError, NodeIdentity};
 pub use peerstore::{PeerRecord, Peerstore, PeerstoreConfig, PeerstoreError};
 pub use persistence::{GossipStateError, GossipStateStore};
 pub use pipeline::{
-    BlockProposal, ConsensusPipeline, LightClientSync, MetaTelemetry, PersistentProofStorage,
-    PipelineError, ProofMempool, ProofRecord, ProofStorage, SnapshotChunk, SnapshotStore,
-    TelemetryEvent, VoteOutcome,
+    BasicRecursiveProofVerifier, BlockProposal, ConsensusPipeline, JsonProofValidator,
+    LightClientSync, MetaTelemetry, PersistentProofStorage, PipelineError, ProofMempool,
+    ProofRecord, ProofStorage, SnapshotChunk, SnapshotStore, TelemetryEvent, VoteOutcome,
 };
 pub use roadmap::{Deliverable, Milestone, Phase, Plan, WorkItem, libp2p_backbone_plan};
 pub use security::{RateLimiter, ReplayProtector};


### PR DESCRIPTION
## Summary
- replace the noop proof and recursive verifiers with JSON-aware validation helpers in the P2P pipeline
- wire ProofMempool and LightClientSync into the node runtime so gossip is validated and persisted
- add a runtime test ensuring proof gossip is written to the configured storage path

## Testing
- cargo test proof_gossip_persists_to_storage

------
https://chatgpt.com/codex/tasks/task_e_68d7e0b07a38832686b8e97f618c2874