### PR TITLE
Hydrate wallet UTXO snapshots

### DIFF
--- a/rpp/runtime/node.rs
+++ b/rpp/runtime/node.rs
@@ -330,7 +330,8 @@ impl Node {
             for account in &accounts {
                 storage.persist_account(account)?;
             }
-            let ledger = Ledger::load(accounts.clone(), config.epoch_length);
+            let utxo_snapshot = storage.load_utxo_snapshot()?.unwrap_or_default();
+            let ledger = Ledger::load(accounts.clone(), utxo_snapshot, config.epoch_length);
             let module_witnesses = ledger.drain_module_witnesses();
             let module_artifacts = ledger.stage_module_witnesses(&module_witnesses)?;
             let mut tx_hashes: Vec<[u8; 32]> = Vec::new();
@@ -431,7 +432,8 @@ impl Node {
             accounts = storage.load_accounts()?;
         }
 
-        let ledger = Ledger::load(accounts, config.epoch_length);
+        let utxo_snapshot = storage.load_utxo_snapshot()?.unwrap_or_default();
+        let ledger = Ledger::load(accounts, utxo_snapshot, config.epoch_length);
 
         let node_pk_hex = hex::encode(keypair.public.to_bytes());
         if ledger.get_account(&address).is_none() {

--- a/rpp/storage/ledger.rs
+++ b/rpp/storage/ledger.rs
@@ -154,7 +154,11 @@ impl Ledger {
         ledger
     }
 
-    pub fn load(initial: Vec<Account>, epoch_length: u64) -> Self {
+    pub fn load(
+        initial: Vec<Account>,
+        utxo_snapshots: Vec<(UtxoOutpoint, StoredUtxo)>,
+        epoch_length: u64,
+    ) -> Self {
         let ledger = Ledger::new(epoch_length);
         let mut tree = ledger.identity_tree.write();
         for account in initial {
@@ -167,6 +171,9 @@ impl Ledger {
             ledger.index_account_modules(&account);
         }
         drop(tree);
+        for (outpoint, stored) in utxo_snapshots {
+            ledger.utxo_state.insert(outpoint, stored);
+        }
         ledger.sync_epoch_for_height(0);
         ledger
     }


### PR DESCRIPTION
## Summary
- load Firewood UTXO snapshots into the in-memory ledger so wallet queries surface real outputs
- persist and read UTXO snapshot blobs in storage and expose wallet helpers that favor real data before synthetic fallbacks
- update wallet workflows and tests to exercise the hydrated UTXO path while keeping synthetic records as a legacy fallback

## Testing
- cargo test wallet::workflows::tests:: -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d7e56cdd248326b9b11e82f19309fe