### PR TITLE
Remove unused libp2p handle from API context

### DIFF
--- a/docs/libp2p_network_plan.md
+++ b/docs/libp2p_network_plan.md
@@ -2,6 +2,8 @@
 
 Dieser Plan gliedert die Umsetzung des Blueprint 2.3 in klar umrissene Liefergegenstände mit definierten Abhängigkeiten, Qualitätskriterien und Tests. Jeder Abschnitt endet mit „Definition of Done“ (DoD), damit Fortschritt messbar bleibt.
 
+> **Aktueller Stand:** Die öffentliche RPC-Schnittstelle verwaltet keinen Libp2p-Knoten. Runtime-Handles werden ausschließlich innerhalb der Runtime verwendet und nicht via `ApiContext` exponiert. Operator-Steuerung des Netzwerks bleibt damit ausdrücklich Teil der nachstehenden Deliverables.
+
 ## Phase 0 – Grundlagen & Infrastruktur
 1. **Libp2p-Abhängigkeiten und Runtime integrieren**
    - `libp2p`-, `tokio`- und `futures`-Versionen wählen, die mit dem bestehenden Async-Stack kompatibel sind.

--- a/rpp/rpc/api.rs
+++ b/rpp/rpc/api.rs
@@ -21,7 +21,6 @@ use crate::orchestration::{PipelineDashboardSnapshot, PipelineOrchestrator, Pipe
 use crate::reputation::Tier;
 use crate::rpp::TimetokeRecord;
 use crate::runtime::RuntimeMode;
-use crate::runtime::node_runtime::NodeHandle as P2pHandle;
 use crate::sync::ReconstructionPlan;
 use crate::types::{
     Account, Address, AttestedIdentityRequest, Block, SignedTransaction, Transaction,
@@ -37,8 +36,6 @@ use parking_lot::RwLock;
 pub struct ApiContext {
     mode: Arc<RwLock<RuntimeMode>>,
     node: Option<NodeHandle>,
-    #[allow(dead_code)]
-    p2p: Option<P2pHandle>,
     wallet: Option<Arc<Wallet>>,
     orchestrator: Option<Arc<PipelineOrchestrator>>,
 }
@@ -47,14 +44,12 @@ impl ApiContext {
     pub fn new(
         mode: Arc<RwLock<RuntimeMode>>,
         node: Option<NodeHandle>,
-        p2p: Option<P2pHandle>,
         wallet: Option<Arc<Wallet>>,
         orchestrator: Option<Arc<PipelineOrchestrator>>,
     ) -> Self {
         Self {
             mode,
             node,
-            p2p,
             wallet,
             orchestrator,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,6 @@ async fn start_runtime(args: StartArgs) -> Result<()> {
     let context = api::ApiContext::new(
         runtime_mode.clone(),
         node_handle.clone(),
-        p2p_handle.clone(),
         wallet_instance.clone(),
         orchestrator_instance.clone(),
     );

--- a/tests/end_to_end_rpc.rs
+++ b/tests/end_to_end_rpc.rs
@@ -49,7 +49,6 @@ impl RpcTestHarness {
         let addr = primary.config.rpc_listen;
         let node_handle = primary.node_handle.clone();
         let runtime_handle = node_handle.clone();
-        let p2p_handle = primary.p2p_handle.clone();
         let wallet = primary.wallet.clone();
         let orchestrator = primary.orchestrator.clone();
 
@@ -57,7 +56,6 @@ impl RpcTestHarness {
         let context = api::ApiContext::new(
             runtime_mode,
             Some(runtime_handle),
-            Some(p2p_handle),
             Some(wallet),
             Some(orchestrator),
         );


### PR DESCRIPTION
## Summary
- drop the unused libp2p handle from `ApiContext` and all callers
- refresh the libp2p implementation plan to clarify that RPC currently leaves libp2p control to the runtime

## Testing
- cargo test end_to_end_rpc -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d7ea0203888326a5d33aa18f1466aa