### PR TITLE
Add peerstore VRF acceptance coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.8.5",
+ "schnorrkel",
  "serde",
  "serde_json",
  "tempfile",

--- a/rpp/p2p/Cargo.toml
+++ b/rpp/p2p/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1"
 blake3 = "1.5"
 blake2 = "0.10"
 rand = { version = "0.8", features = ["std"] }
+schnorrkel = "0.11"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/rpp/p2p/src/lib.rs
+++ b/rpp/p2p/src/lib.rs
@@ -14,7 +14,7 @@ mod tier;
 mod topics;
 
 pub use admission::{AdmissionControl, AdmissionError, ReputationEvent, ReputationOutcome};
-pub use handshake::HandshakePayload;
+pub use handshake::{HandshakePayload, VRF_HANDSHAKE_CONTEXT};
 pub use identity::{IdentityError, NodeIdentity};
 pub use peerstore::{PeerRecord, Peerstore, PeerstoreConfig, PeerstoreError};
 pub use persistence::{GossipStateError, GossipStateStore};

--- a/rpp/runtime/node_runtime/network.rs
+++ b/rpp/runtime/node_runtime/network.rs
@@ -99,6 +99,7 @@ impl NetworkResources {
             (
                 HandshakePayload::new(
                     profile.zsi_id.clone(),
+                    Some(profile.vrf_public_key.clone()),
                     Some(profile.vrf_proof.clone()),
                     profile.tier,
                 ),
@@ -106,13 +107,18 @@ impl NetworkResources {
             )
         } else {
             (
-                HandshakePayload::new(node_label, None, TierLevel::Tl0),
+                HandshakePayload::new(node_label, None, None, TierLevel::Tl0),
                 None,
             )
         };
         let mut network = Network::new(identity.clone(), peerstore, handshake, gossip_state)?;
         if let Some(profile) = profile {
-            network.update_identity(profile.zsi_id, profile.tier, profile.vrf_proof)?;
+            network.update_identity(
+                profile.zsi_id,
+                profile.tier,
+                profile.vrf_public_key,
+                profile.vrf_proof,
+            )?;
         }
         network.listen_on(config.listen_addr().clone())?;
         for addr in config.bootstrap_peers() {

--- a/rpp/runtime/node_runtime/node.rs
+++ b/rpp/runtime/node_runtime/node.rs
@@ -97,6 +97,7 @@ impl From<&NodeConfig> for NodeRuntimeConfig {
 pub struct IdentityProfile {
     pub zsi_id: String,
     pub tier: TierLevel,
+    pub vrf_public_key: Vec<u8>,
     pub vrf_proof: Vec<u8>,
 }
 
@@ -105,6 +106,7 @@ impl From<NetworkIdentityProfile> for IdentityProfile {
         Self {
             zsi_id: profile.zsi_id,
             tier: profile.tier,
+            vrf_public_key: profile.vrf_public_key,
             vrf_proof: profile.vrf_proof,
         }
     }
@@ -321,7 +323,12 @@ impl NodeInner {
             NodeCommand::UpdateIdentity { profile, response } => {
                 let result = self
                     .network
-                    .update_identity(profile.zsi_id, profile.tier, profile.vrf_proof)
+                    .update_identity(
+                        profile.zsi_id,
+                        profile.tier,
+                        profile.vrf_public_key,
+                        profile.vrf_proof,
+                    )
                     .map_err(NodeError::from);
                 let _ = response.send(result);
                 Ok(false)

--- a/storage-firewood/src/lib.rs
+++ b/storage-firewood/src/lib.rs
@@ -63,7 +63,10 @@ mod tests {
         } else {
             proof.commitment_root[0] ^= 0xFF;
         }
-        assert!(!FirewoodPruner::verify_pruned_state(commitment_root, &proof));
+        assert!(!FirewoodPruner::verify_pruned_state(
+            commitment_root,
+            &proof
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add regression tests ensuring low-tier peers without VRF material are still accepted
- cover acceptance of valid VRF proofs when no identity verifier is configured

## Testing
- cargo test -p rpp-p2p

------
https://chatgpt.com/codex/tasks/task_e_68d824b807848326afd9a9dc836cc3fa