### PR TITLE
Add configurable reputation tier thresholds

### DIFF
--- a/config/node.toml
+++ b/config/node.toml
@@ -36,6 +36,12 @@ consensus_enforcement = true
 enabled = false
 sample_interval_secs = 30
 
+[reputation.tier_thresholds]
+tier2_min_uptime_hours = 24
+tier3_min_consensus_success = 10
+tier4_min_consensus_success = 100
+tier5_min_score = 0.75
+
 [genesis]
 chain_id = "rpp-local"
 

--- a/docs/cross_cutting_concerns.md
+++ b/docs/cross_cutting_concerns.md
@@ -15,7 +15,9 @@ Dieses Dokument fasst übergreifende Anforderungen für die vollständige Umsetz
    * `vrf_threshold_curve` – Funktionsdefinition zur Ableitung der Schwelle aus der Timetoke-Balance.
    * `epoch_duration`, `round_timeout`, `max_round_extensions` – Steuerung des Konsens-Tempos.
 2. **Reputation & Timetoke**
-   * `tier_thresholds` – Score-Grenzen für Tier 3+.
+   * `tier_thresholds` – Score-Grenzen für Tier 3+, konfigurierbar via
+     `reputation.tier_thresholds` in `config/node.toml` für operatorseitige
+     Anpassungen.【F:config/node.toml†L39-L43】
    * `timetoke_decay_rate`, `timetoke_accrual_rate`, `timetoke_cap` – Stabilisierung der Uptime-Gewichtung.
    * `snapshot_interval`, `max_snapshot_age` – Synchronisationsfenster.
 3. **Rewards & Slashing**

--- a/docs/deployment_observability.md
+++ b/docs/deployment_observability.md
@@ -13,7 +13,7 @@ production.
 2. **Toggle blueprint capabilities with feature gates.** Keep pruning,
    recursive proofs, reconstruction, and consensus enforcement disabled until
    the deployment reaches the appropriate phase; these gates are controlled by
-   the shared `rollout.feature_gates` map in node configuration.【F:config/node.toml†L15-L23】
+   the shared `rollout.feature_gates` map in node configuration.【F:config/node.toml†L29-L33】
 3. **Protect RPC and proof limits.** Bound incoming proof artifacts with the
    `max_proof_size_bytes` limit and size mempool/identity queues to match the
    target environment before opening endpoints to the public.【F:config/node.toml†L3-L13】
@@ -25,8 +25,11 @@ production.
    recursive proofs survive restarts.【F:config/node.toml†L3-L7】
 2. **Distribute genesis state.** Ensure the same genesis accounts, balances,
    and stakes are shipped to every validator; mismatches will prevent
-   state-transition proofs from verifying.【F:config/node.toml†L28-L34】
-3. **Run storage migrations prior to rollout.** Execute `cargo run -- migrate`
+    state-transition proofs from verifying.【F:config/node.toml†L45-L51】
+3. **Calibrate reputation tiers.** Tune `reputation.tier_thresholds` to match
+   the promotion/demotion policy for your environment; higher values slow tier
+   ascension while lower values welcome new validators faster.【F:config/node.toml†L39-L43】【F:rpp/runtime/config.rs†L40-L204】
+4. **Run storage migrations prior to rollout.** Execute `cargo run -- migrate`
    against production data before switching binaries to guarantee the RocksDB
    schema matches the proof bundle format.【F:README.md†L96-L107】
 
@@ -34,7 +37,7 @@ production.
 
 1. **Enable telemetry sampling.** Flip `rollout.telemetry.enabled` and tune the
    sampling interval to emit snapshots with node, consensus, and mempool
-   metrics.【F:config/node.toml†L24-L26】【F:src/config.rs†L141-L171】
+   metrics.【F:config/node.toml†L35-L37】【F:src/config.rs†L141-L171】
 2. **Stream snapshots to your collector.** Set `rollout.telemetry.endpoint`
    (empty means log-only) and confirm the async telemetry task is running; the
    node spawns a background loop that periodically publishes encoded telemetry

--- a/rpp/runtime/config.rs
+++ b/rpp/runtime/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{ChainError, ChainResult};
 use crate::ledger::DEFAULT_EPOCH_LENGTH;
+use crate::reputation::{ReputationParams, TierThresholds};
 use crate::types::Stake;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -62,6 +63,8 @@ pub struct NodeConfig {
     #[serde(default)]
     pub p2p: P2pConfig,
     pub genesis: GenesisConfig,
+    #[serde(default)]
+    pub reputation: ReputationConfig,
 }
 
 fn default_max_block_identity_registrations() -> usize {
@@ -143,6 +146,10 @@ impl NodeConfig {
         }
         Ok(())
     }
+
+    pub fn reputation_params(&self) -> ReputationParams {
+        self.reputation.reputation_params()
+    }
 }
 
 impl Default for NodeConfig {
@@ -168,6 +175,30 @@ impl Default for NodeConfig {
             rollout: RolloutConfig::default(),
             p2p,
             genesis: GenesisConfig::default(),
+            reputation: ReputationConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ReputationConfig {
+    pub tier_thresholds: TierThresholds,
+}
+
+impl ReputationConfig {
+    pub fn reputation_params(&self) -> ReputationParams {
+        ReputationParams {
+            tier_thresholds: self.tier_thresholds.clone(),
+            ..ReputationParams::default()
+        }
+    }
+}
+
+impl Default for ReputationConfig {
+    fn default() -> Self {
+        Self {
+            tier_thresholds: TierThresholds::default(),
         }
     }
 }

--- a/rpp/storage/ledger.rs
+++ b/rpp/storage/ledger.rs
@@ -154,6 +154,10 @@ impl Ledger {
         ledger
     }
 
+    pub fn set_reputation_params(&mut self, params: ReputationParams) {
+        self.reputation_params = params;
+    }
+
     pub fn load(
         initial: Vec<Account>,
         utxo_snapshots: Vec<(UtxoOutpoint, StoredUtxo)>,


### PR DESCRIPTION
## Summary
- allow operators to configure reputation tier thresholds through node configuration and propagate the overrides into runtime parameters
- cover promotion and demotion boundaries in `update_tier_with` with dedicated unit tests
- document the new reputation configuration knobs and update the example `node.toml`

## Testing
- cargo test reputation::tests::

------
https://chatgpt.com/codex/tasks/task_e_68d83ac975d48326882256daaf671a5e