### PR TITLE
Validate configurable reputation weights

### DIFF
--- a/config/node.toml
+++ b/config/node.toml
@@ -42,6 +42,14 @@ tier3_min_consensus_success = 10
 tier4_min_consensus_success = 100
 tier5_min_score = 0.75
 
+[reputation.weights]
+# All reputation weights must be between 0.0 and 1.0 and sum to 1.0.
+validation = 0.4
+uptime = 0.2
+consensus = 0.2
+peer_feedback = 0.15
+decay = 0.05
+
 [genesis]
 chain_id = "rpp-local"
 

--- a/docs/cross_cutting_concerns.md
+++ b/docs/cross_cutting_concerns.md
@@ -18,6 +18,10 @@ Dieses Dokument fasst übergreifende Anforderungen für die vollständige Umsetz
    * `tier_thresholds` – Score-Grenzen für Tier 3+, konfigurierbar via
      `reputation.tier_thresholds` in `config/node.toml` für operatorseitige
      Anpassungen.【F:config/node.toml†L39-L43】
+   * `weights` – Gewichtung der Bewertungsquellen (Validierung, Uptime,
+     Konsens, Peer-Feedback, Decay). Alle Werte müssen im Bereich `[0.0, 1.0]`
+     liegen und sich zu `1.0` normalisieren; anpassbar per
+     `[reputation.weights]` im Node-/Governance-Config.【F:config/node.toml†L45-L51】
    * `timetoke_decay_rate`, `timetoke_accrual_rate`, `timetoke_cap` – Stabilisierung der Uptime-Gewichtung.
    * `snapshot_interval`, `max_snapshot_age` – Synchronisationsfenster.
 3. **Rewards & Slashing**


### PR DESCRIPTION
## Summary
- add validation and error handling for reputation weights along with deserialization aliases
- update scoring to use accessor helpers and add unit tests for invalid and extreme weight mixes
- expose weight overrides via configuration and document allowed ranges

## Testing
- cargo test reputation_weights_reject_negative_components

------
https://chatgpt.com/codex/tasks/task_e_68d83efa79cc8326aae01341c5b9d453