### PR TITLE
Add NodeConfig validation and tests

### DIFF
--- a/rpp/runtime/node.rs
+++ b/rpp/runtime/node.rs
@@ -306,6 +306,7 @@ pub struct NetworkIdentityProfile {
 
 impl Node {
     pub fn new(config: NodeConfig) -> ChainResult<Self> {
+        config.validate()?;
         config.ensure_directories()?;
         let keypair = load_or_generate_keypair(&config.key_path)?;
         let vrf_keypair = load_or_generate_vrf_keypair(&config.vrf_key_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,7 +325,9 @@ fn migrate_storage(config_path: PathBuf, dry_run: bool) -> Result<()> {
 
 fn load_or_init_node_config(path: &Path) -> Result<NodeConfig> {
     if path.exists() {
-        Ok(NodeConfig::load(path)?)
+        let config = NodeConfig::load(path)?;
+        config.validate()?;
+        Ok(config)
     } else {
         let config = NodeConfig::default();
         config.save(path)?;


### PR DESCRIPTION
## Summary
- add NodeConfig::validate to enforce required numeric ranges and call it during load/save
- validate node configurations when creating nodes or loading configs through the CLI
- cover successful and failing configuration validation paths with new unit tests

## Testing
- cargo test node_config_validation

------
https://chatgpt.com/codex/tasks/task_e_68d8481c7a608326a8afdbceb1581a0c