### PR TITLE
Document runtime architecture and enforce doc builds

### DIFF
--- a/.github/workflows/sim-smoke.yml
+++ b/.github/workflows/sim-smoke.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Ensure documentation builds
+        run: cargo doc --no-deps --workspace
       - name: Run deterministic smoke scenario
         run: |
           cargo test -p rpp-sim --test sim_smoke -- --ignored

--- a/rpp/consensus/node.rs
+++ b/rpp/consensus/node.rs
@@ -1,3 +1,14 @@
+//! Consensus node logic responsible for VRF leader election and BFT voting.
+//!
+//! This module encapsulates proposer selection, vote validation, and
+//! misbehavior evidence tracking. Core invariants:
+//!
+//! * [`EvidencePool`] de-duplicates votes by `(height, round, kind, voter)` to
+//!   detect equivocation.
+//! * All [`BftVote`] values must carry signatures that validate against the
+//!   submitter's public key prior to acceptance.
+//! * VRF submissions are filtered through [`VrfSubmissionPool`] so that
+//!   proposer randomness is both unbiased and replay-safe across epochs.
 use std::collections::{HashMap, HashSet};
 
 use malachite::Natural;

--- a/rpp/runtime/node.rs
+++ b/rpp/runtime/node.rs
@@ -1,3 +1,18 @@
+//! Stateful runtime node coordinating consensus, storage, and external services.
+//!
+//! The [`Node`] type wraps the chain runtime, orchestrating mempool management,
+//! block production, and proof generation. Invariants maintained here include:
+//!
+//! * The in-memory tip (`ChainTip`) always reflects the latest committed block
+//!   stored in [`Storage`].
+//! * VRF submissions are validated against the current epoch before they are
+//!   admitted to consensus queues.
+//! * Side-effectful subsystems (telemetry, gossip, prover tasks) are spawned and
+//!   owned by [`NodeHandle`], which ensures graceful shutdown via the async
+//!   join handles it tracks.
+//!
+//! Public status/reporting structs are defined alongside the runtime to expose
+//! snapshot views without leaking internal locks.
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::str::FromStr;
 use std::sync::Arc;

--- a/rpp/runtime/orchestration.rs
+++ b/rpp/runtime/orchestration.rs
@@ -1,3 +1,12 @@
+//! High-level orchestrator connecting the runtime node with wallet workflows and
+//! gossip interfaces.
+//!
+//! [`PipelineOrchestrator`] supervises asynchronous tasks that bridge the
+//! consensus engine, mempool, and external clients. It is responsible for
+//! coordinating transaction submission, gossip fan-out, and system health
+//! monitoring. Channels created here have bounded capacity to prevent unbounded
+//! backpressure on gossip ingress, and all spawned tasks are tracked so they can
+//! be cancelled during shutdown via [`NodeHandle`].
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,15 @@
+//! Core crate wiring together the RPP blockchain runtime.
+//!
+//! The crate re-exports modules that live in the `rpp` workspace so that
+//! consumers can interact with the system through a single entry point. The
+//! `runtime`, `consensus`, and `node` modules compose the node lifecycle, while
+//! `storage` and `ledger` encapsulate persistent state management. Proof system
+//! integrations are exposed under `proof_system`, `stwo`, and `plonky3`, and
+//! wallet/UI integrations live in `wallet`.
+//!
+//! Applications typically depend on [`config::NodeConfig`] to bootstrap a node,
+//! [`node::Node`] and [`node::NodeHandle`] to operate it, and the supporting modules for consensus,
+//! networking, proofs, and state synchronization.
 #[path = "../rpp/rpc/api.rs"]
 pub mod api;
 #[path = "../rpp/proofs/blueprint/mod.rs"]


### PR DESCRIPTION
## Summary
- add a crate-level overview in `src/lib.rs`
- document responsibilities and invariants for runtime and consensus nodes
- wire `cargo doc --no-deps --workspace` into CI to guard documentation coverage

## Testing
- `cargo doc --no-deps --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68d84a2a39948326be16af3caf30e3a0