### PR TITLE
docs: refresh README with Firewood storage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ It integrates:
 
 - **Stwo** for Blake2-based hashing and Merkle root construction.
 - **Malachite** for high precision arithmetic in stake-weighted consensus.
-- **RocksDB** as the persistent storage engine for blocks, accounts, and chain metadata.
+- **Firewood** as the append-only storage stack with integrated WAL, Merkle commitments, and pruning proofs.
 
 ## Features
 
 - Deterministic stake-weighted proposer selection backed by Malachite `Natural` arithmetic plus Poseidon-based VRF proofs for validator fairness.
-- RocksDB-backed storage with column families for blocks, accounts, and metadata.
+- Firewood-backed storage with append-only WAL, column families, and pruning proofs for blocks, accounts, and metadata.
 - Ed25519 transaction signing and verification with Stwo hashing for all payload commitments.
 - HTTP/JSON API powered by Axum for transaction submission and state inspection.
 - Configurable block cadence, mempool sizing, and genesis allocation via TOML configuration.
@@ -21,7 +21,7 @@ It integrates:
 
 ### Prerequisites
 
-Ensure Rust (1.79+) is installed. All external dependencies (RocksDB sources, etc.) are fetched and built by Cargo automatically.
+Ensure Rust (1.79+) is installed. Firewood sources (KV engine, WAL, pruner) are built automatically by Cargo during the first compile.
 
 ### Build & Test
 
@@ -32,8 +32,9 @@ cargo test
 ### Generate configuration and keys
 
 ```bash
-# Create a default configuration file
+# Create default configuration templates
 cargo run -- generate-config --path config/node.toml
+cargo run -- generate-wallet-config --path config/wallet.toml
 
 # Generate new Ed25519 + VRF keypairs for the node
 cargo run -- keygen --path keys/node.toml --vrf-path keys/vrf.toml
@@ -52,10 +53,46 @@ cargo run -- migrate --config config/node.toml
 ### Launch the node
 
 ```bash
-cargo run -- start --config config/node.toml
+cargo run -- start --mode node --node-config config/node.toml
 ```
 
-The node will open a RocksDB instance under the configured `data_dir`, start block production, and expose an HTTP API (default `127.0.0.1:7070`).
+The node opens a Firewood store under the configured `data_dir` (creating `db`, `wal`, and pruning checkpoints), starts block production, and exposes an HTTP API (default `127.0.0.1:7070`).
+Firewood automatically prunes historical state once checkpoints are verified, keeping the working set lean while preserving proofs.
+
+### Modern quickstart workflows
+
+**Use curated runtime profiles**
+
+```bash
+# Launch a node using the bundled profile (resolves config paths automatically)
+cargo run -- start --profile node
+
+# Spawn a validator-oriented runtime (node + wallet + validator daemons)
+cargo run -- start --profile validator
+```
+
+**Select proof backends**
+
+```bash
+# Run with the default STWO backend
+cargo run -- start --mode node --node-config config/node.toml
+
+# Switch to the experimental Plonky3 backend
+cargo run --no-default-features --features backend-plonky3 -- start --mode node --node-config config/node.toml
+```
+
+**Toggle rollout feature gates**
+
+```toml
+# config/node.toml
+[rollout.feature_gates]
+pruning = true
+recursive_proofs = true
+reconstruction = true
+consensus_enforcement = true
+```
+
+After adjusting gates, restart the node and inspect `GET /status/rollout` to confirm the active feature set.
 
 ## HTTP API
 
@@ -70,7 +107,7 @@ The node will open a RocksDB instance under the configured `data_dir`, start blo
 
 `config/node.toml` includes:
 
-- `data_dir`: persistent storage directory (RocksDB is stored in `data_dir/db`).
+- `data_dir`: persistent storage directory (Firewood stores KV pages in `data_dir/db` plus `data_dir/wal`).
 - `key_path`: location of the node's Ed25519 keypair file.
 - `p2p_key_path`: persistent libp2p Ed25519 identity used for Noise handshakes.
 - `vrf_key_path`: path to the node's Poseidon VRF keypair (auto-created on first launch).
@@ -93,10 +130,9 @@ The node will open a RocksDB instance under the configured `data_dir`, start blo
 
 ## Development Notes
 
-- Run `cargo run -- migrate` when deploying a new binary against an existing data directory to ensure the RocksDB schema is upgraded in-place.
-
+- Run `cargo run -- migrate` when deploying a new binary against an existing data directory to ensure the Firewood schema is upgraded in-place.
+- Firewood compilation (KV core, pruning engine) happens on the first build; subsequent builds reuse the generated artifacts.
 - Run `cargo fmt` to keep formatting consistent.
-- The RocksDB build may take a few minutes the first time. Subsequent builds reuse the compiled artifacts.
-- Consensus selection and Merkle commitments are unit test friendly and live in `src/consensus.rs` and `src/ledger.rs` respectively.
+- Consensus selection logic lives in `rpp/consensus/src/lib.rs`, while ledger state management sits in `rpp/storage/ledger.rs`.
 
 Enjoy experimenting with the Digital Value Network!


### PR DESCRIPTION
## Summary
- replace RocksDB references with the Firewood storage stack and updated config notes
- update module paths and add modern quickstart steps covering profiles, feature gates, and proof backends

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d84d17e3e88326945e1c90d4986a9d