### PR TITLE
Add feature-aware build/test scripts and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,32 @@ Ensure Rust (1.79+) is installed. Firewood sources (KV engine, WAL, pruner) are 
 
 ### Build & Test
 
+Use the helper scripts to keep build and test invocations consistent across
+the workspace.
+
 ```bash
-cargo test
+# Build the default debug artifacts
+scripts/build.sh
+
+# Build in release mode
+scripts/build.sh --release
+
+# Build the minimal feature surface (disables default features)
+scripts/build.sh --feature-set minimal
+```
+
+Run targeted test suites via `scripts/test.sh` – it enforces `-D warnings` and
+supports backend-specific feature matrices.
+
+```bash
+# Run unit and integration tests (default behaviour)
+scripts/test.sh
+
+# Run only the integration tests using the Plonky3 backend
+scripts/test.sh --integration --backend plonky3
+
+# Execute documentation tests with the release profile
+scripts/test.sh --doc --release
 ```
 
 ### Generate configuration and keys

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,127 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cargo build "$@"
+usage() {
+  cat <<'USAGE'
+Usage: scripts/build.sh [options] [-- <cargo build args>]
+
+A thin wrapper around `cargo build` that standardises common build
+profiles and feature combinations used in the project.
+
+Options:
+  --release                 Build artifacts in release mode (alias for --profile release)
+  --profile <name>          Build with the named cargo profile
+  --feature-set <name>      Use a predefined feature matrix (default|minimal|full)
+  --features <features>     Pass a custom feature list to cargo
+  --no-default-features     Disable default features
+  --all-features            Enable all features
+  --target <triple>         Build for a specific target triple
+  --package <name>          Build only the specified package
+  --bin <name>              Build only the specified binary
+  --example <name>          Build only the specified example
+  --help                    Show this help message and exit
+  --                        Pass the remaining arguments directly to cargo
+
+Feature sets:
+  default   Use the workspace default features (current cargo behaviour)
+  minimal   Disable default features (`--no-default-features`)
+  full      Enable all features (`--all-features`)
+USAGE
+}
+
+PROFILE_ARGS=()
+FEATURE_ARGS=()
+PASSTHROUGH_ARGS=()
+FEATURE_SET_SELECTED=""
+CUSTOM_FEATURES=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release)
+      if [[ ${#PROFILE_ARGS[@]} -ne 0 ]]; then
+        echo "error: --release/--profile specified multiple times" >&2
+        exit 1
+      fi
+      PROFILE_ARGS=("--release")
+      shift
+      ;;
+    --profile)
+      if [[ ${#PROFILE_ARGS[@]} -ne 0 ]]; then
+        echo "error: --profile specified multiple times" >&2
+        exit 1
+      fi
+      if [[ $# -lt 2 ]]; then
+        echo "error: --profile requires a value" >&2
+        exit 1
+      fi
+      PROFILE_ARGS=("--profile" "$2")
+      shift 2
+      ;;
+    --feature-set)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --feature-set requires a value" >&2
+        exit 1
+      fi
+      if [[ -n "$FEATURE_SET_SELECTED" || $CUSTOM_FEATURES == true ]]; then
+        echo "error: feature set already specified" >&2
+        exit 1
+      fi
+      case "$2" in
+        default)
+          FEATURE_ARGS=()
+          FEATURE_SET_SELECTED="default"
+          ;;
+        minimal)
+          FEATURE_ARGS=("--no-default-features")
+          FEATURE_SET_SELECTED="minimal"
+          ;;
+        full)
+          FEATURE_ARGS=("--all-features")
+          FEATURE_SET_SELECTED="full"
+          ;;
+        *)
+          echo "error: unknown feature set '$2'" >&2
+          exit 1
+          ;;
+      esac
+      shift 2
+      ;;
+    --features)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --features requires a value" >&2
+        exit 1
+      fi
+      FEATURE_ARGS+=("--features" "$2")
+      CUSTOM_FEATURES=true
+      shift 2
+      ;;
+    --no-default-features|--all-features)
+      FEATURE_ARGS+=("$1")
+      CUSTOM_FEATURES=true
+      shift
+      ;;
+    --target|--package|--bin|--example)
+      if [[ $# -lt 2 ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+      fi
+      PASSTHROUGH_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      PASSTHROUGH_ARGS+=("$@")
+      break
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+cargo build "${PROFILE_ARGS[@]}" "${FEATURE_ARGS[@]}" "${PASSTHROUGH_ARGS[@]}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,241 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cargo test "$@"
+usage() {
+  cat <<'USAGE'
+Usage: scripts/test.sh [options] [-- <cargo test args>]
+
+Run the project's automated test suites with consistent settings.
+
+Test selection:
+  --unit                    Run unit tests (`cargo test --lib --bins`)
+  --integration             Run integration tests (`cargo test --tests`)
+  --doc                     Run documentation tests
+  --all                     Run all test suites (default if none selected)
+  --backend <name>          Run the suites for a specific backend (default|stwo|plonky3)
+
+Build options:
+  --release                 Test using the release profile
+  --profile <name>          Test using the specified cargo profile
+  --feature-set <name>      Use a predefined feature matrix (default|minimal|full)
+  --features <features>     Pass a custom feature list to cargo
+  --no-default-features     Disable default features
+  --all-features            Enable all features
+  --target <triple>         Run tests for the specified target
+  --package <name>          Run tests for only the given package
+  --help                    Show this help message and exit
+  --                        Pass the remaining arguments directly to cargo
+
+Backends:
+  default   Use the workspace default backend configuration
+  stwo      Force the `backend-stwo` feature only
+  plonky3   Force the `backend-plonky3` feature only
+USAGE
+}
+
+export RUSTFLAGS="${RUSTFLAGS:-} -D warnings"
+
+PROFILE_ARGS=()
+FEATURE_ARGS=()
+PASSTHROUGH_ARGS=()
+FEATURE_SET_SELECTED=""
+CUSTOM_FEATURES=false
+SUITES_SELECTED=()
+BACKENDS=()
+
+add_suite() {
+  local suite="$1"
+  for existing in "${SUITES_SELECTED[@]:-}"; do
+    [[ "$existing" == "$suite" ]] && return 0
+  done
+  SUITES_SELECTED+=("$suite")
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --unit)
+      add_suite unit
+      shift
+      ;;
+    --integration)
+      add_suite integration
+      shift
+      ;;
+    --doc)
+      add_suite doc
+      shift
+      ;;
+    --all)
+      SUITES_SELECTED=(unit integration doc)
+      shift
+      ;;
+    --backend)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --backend requires a value" >&2
+        exit 1
+      fi
+      case "$2" in
+        default|stwo|plonky3)
+          BACKENDS+=("$2")
+          ;;
+        *)
+          echo "error: unknown backend '$2'" >&2
+          exit 1
+          ;;
+      esac
+      shift 2
+      ;;
+    --release)
+      if [[ ${#PROFILE_ARGS[@]} -ne 0 ]]; then
+        echo "error: --release/--profile specified multiple times" >&2
+        exit 1
+      fi
+      PROFILE_ARGS=("--release")
+      shift
+      ;;
+    --profile)
+      if [[ ${#PROFILE_ARGS[@]} -ne 0 ]]; then
+        echo "error: --profile specified multiple times" >&2
+        exit 1
+      fi
+      if [[ $# -lt 2 ]]; then
+        echo "error: --profile requires a value" >&2
+        exit 1
+      fi
+      PROFILE_ARGS=("--profile" "$2")
+      shift 2
+      ;;
+    --feature-set)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --feature-set requires a value" >&2
+        exit 1
+      fi
+      if [[ -n "$FEATURE_SET_SELECTED" || $CUSTOM_FEATURES == true ]]; then
+        echo "error: feature set already specified" >&2
+        exit 1
+      fi
+      case "$2" in
+        default)
+          FEATURE_ARGS=()
+          FEATURE_SET_SELECTED="default"
+          ;;
+        minimal)
+          FEATURE_ARGS=("--no-default-features")
+          FEATURE_SET_SELECTED="minimal"
+          ;;
+        full)
+          FEATURE_ARGS=("--all-features")
+          FEATURE_SET_SELECTED="full"
+          ;;
+        *)
+          echo "error: unknown feature set '$2'" >&2
+          exit 1
+          ;;
+      esac
+      shift 2
+      ;;
+    --features)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --features requires a value" >&2
+        exit 1
+      fi
+      FEATURE_ARGS+=("--features" "$2")
+      CUSTOM_FEATURES=true
+      shift 2
+      ;;
+    --no-default-features|--all-features)
+      FEATURE_ARGS+=("$1")
+      CUSTOM_FEATURES=true
+      shift
+      ;;
+    --target|--package|--bin|--example|--test|--bench)
+      if [[ $# -lt 2 ]]; then
+        echo "error: $1 requires a value" >&2
+        exit 1
+      fi
+      PASSTHROUGH_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      PASSTHROUGH_ARGS+=("$@")
+      break
+      ;;
+    *)
+      PASSTHROUGH_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#SUITES_SELECTED[@]} -eq 0 ]]; then
+  SUITES_SELECTED=(unit integration)
+fi
+
+if [[ ${#BACKENDS[@]} -eq 0 ]]; then
+  BACKENDS=(default)
+fi
+
+if [[ $CUSTOM_FEATURES == true && ${#BACKENDS[@]} -gt 1 ]]; then
+  echo "error: custom feature flags cannot be combined with multiple backends" >&2
+  exit 1
+fi
+
+run_suite() {
+  local suite="$1"
+  local backend="$2"
+  local -a backend_args=()
+
+  case "$backend" in
+    default)
+      backend_args=()
+      ;;
+    stwo)
+      backend_args=("--no-default-features" "--features" "backend-stwo")
+      ;;
+    plonky3)
+      backend_args=("--no-default-features" "--features" "backend-plonky3")
+      ;;
+    *)
+      echo "error: unsupported backend '$backend'" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ $CUSTOM_FEATURES == true ]]; then
+    backend_args=("${FEATURE_ARGS[@]}")
+  else
+    backend_args+=("${FEATURE_ARGS[@]}")
+  fi
+
+  local -a command=(cargo test "${PROFILE_ARGS[@]}" "${backend_args[@]}" "${PASSTHROUGH_ARGS[@]}")
+
+  case "$suite" in
+    unit)
+      command+=(--lib --bins)
+      ;;
+    integration)
+      command+=(--tests)
+      ;;
+    doc)
+      command+=(--doc)
+      ;;
+    *)
+      echo "error: unknown suite '$suite'" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "==> Running $suite tests (${backend})"
+  "${command[@]}"
+}
+
+for backend in "${BACKENDS[@]}"; do
+  for suite in "${SUITES_SELECTED[@]}"; do
+    run_suite "$suite" "$backend"
+  done
+done


### PR DESCRIPTION
## Summary
- expand scripts/build.sh with profile switches, reusable feature matrices, and usage guidance
- add suite selection, backend awareness, and -D warnings enforcement to scripts/test.sh
- document the standard build/test entrypoints for contributors in the README

## Testing
- scripts/build.sh --help
- scripts/test.sh --help

------
https://chatgpt.com/codex/tasks/task_e_68d84e5803c4832685e23b435d53cf86