### PR TITLE
Ensure warnings fail builds in CI and scripts

### DIFF
--- a/.github/workflows/sim-smoke.yml
+++ b/.github/workflows/sim-smoke.yml
@@ -1,5 +1,9 @@
 name: sim-smoke
 
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
 on:
   push:
     branches: [ main ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${RUSTFLAGS:-}" ]]; then
+  export RUSTFLAGS="-D warnings"
+elif [[ " ${RUSTFLAGS} " != *" -D warnings "* ]]; then
+  export RUSTFLAGS="${RUSTFLAGS} -D warnings"
+fi
+
+: "${CARGO_TERM_COLOR:=always}"
+export CARGO_TERM_COLOR
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/build.sh [options] [-- <cargo build args>]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${RUSTFLAGS:-}" ]]; then
+  export RUSTFLAGS="-D warnings"
+elif [[ " ${RUSTFLAGS} " != *" -D warnings "* ]]; then
+  export RUSTFLAGS="${RUSTFLAGS} -D warnings"
+fi
+
+: "${CARGO_TERM_COLOR:=always}"
+export CARGO_TERM_COLOR
+
 usage() {
   cat <<'USAGE'
 Usage: scripts/test.sh [options] [-- <cargo test args>]
@@ -32,8 +41,6 @@ Backends:
   plonky3   Force the `backend-plonky3` feature only
 USAGE
 }
-
-export RUSTFLAGS="${RUSTFLAGS:-} -D warnings"
 
 PROFILE_ARGS=()
 FEATURE_ARGS=()


### PR DESCRIPTION
## Summary
- set default RUSTFLAGS and terminal color for the sim-smoke workflow jobs
- update the build and test wrapper scripts to ensure `-D warnings` is included while respecting existing environment overrides

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d8597906d883268e2bfe2ffdd0fc65