### PR TITLE
Add caching to sim smoke workflow

### DIFF
--- a/.github/workflows/sim-smoke.yml
+++ b/.github/workflows/sim-smoke.yml
@@ -18,6 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # Cache Cargo registry and build artifacts; updating Cargo.lock will bust the key.
+      # Keep an eye on runtime after enabling the cache and tighten the path list if size grows.
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Build rpp-chain (${{ matrix.backend }})
         run: scripts/build.sh --package rpp-chain --backend ${{ matrix.backend }}
       - name: Run rpp-chain unit tests (${{ matrix.backend }})
@@ -28,6 +40,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # Share the same cache key so registry downloads and build output can be reused across jobs.
+      # If cache misses start to dominate runtime, consider separating cargo registry vs target caches.
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: Ensure documentation builds
         run: cargo doc --no-deps --workspace
       - name: Run deterministic smoke scenario


### PR DESCRIPTION
## Summary
- add a shared cargo cache to the sim smoke workflow covering registries and target output
- document cache busting guidance and monitoring expectations in the workflow comments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d85c107f808326b627882755860a6e