### PR TITLE
Handle consensus timeout with automatic proposals

### DIFF
--- a/rpp/consensus/src/bft_loop.rs
+++ b/rpp/consensus/src/bft_loop.rs
@@ -86,7 +86,11 @@ async fn run_loop(state: &mut ConsensusState) {
 
 async fn handle_timeout(state: &mut ConsensusState) {
     if state.should_timeout(Instant::now()) {
+        let _ = state.broadcast_pending_messages();
         state.next_round();
+        if let Some(proposal) = state.build_current_leader_proposal() {
+            let _ = state.broadcast_proposal(&proposal);
+        }
     }
 }
 

--- a/rpp/consensus/src/tests.rs
+++ b/rpp/consensus/src/tests.rs
@@ -1,3 +1,4 @@
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
@@ -6,8 +7,16 @@ use super::messages::{Block, ConsensusProof, PreVote, Proposal};
 use super::state::{ConsensusConfig, GenesisConfig};
 use super::validator::{select_leader, select_validators, VRFOutput};
 
+fn acquire_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("lock poisoned")
+}
+
 #[test]
 fn bft_flow_reaches_commit() {
+    let _guard = acquire_test_lock();
     let vrf_outputs = vec![
         VRFOutput {
             validator_id: "validator-1".into(),
@@ -86,4 +95,99 @@ fn bft_flow_reaches_commit() {
     assert_eq!(final_state.block_height, 1);
     assert!(final_state.pending_rewards.len() >= 1);
     assert!(final_state.pending_proofs.len() >= 1);
+}
+
+#[test]
+fn timeout_triggers_new_proposal_flow() {
+    let _guard = acquire_test_lock();
+    let vrf_outputs = vec![
+        VRFOutput {
+            validator_id: "validator-1".into(),
+            output: [1; 32],
+            proof: vec![],
+            reputation_tier: 4,
+            reputation_score: 1.5,
+            timetoken_balance: 2_000_000,
+        },
+        VRFOutput {
+            validator_id: "validator-2".into(),
+            output: [2; 32],
+            proof: vec![],
+            reputation_tier: 3,
+            reputation_score: 1.2,
+            timetoken_balance: 1_500_000,
+        },
+        VRFOutput {
+            validator_id: "validator-3".into(),
+            output: [3; 32],
+            proof: vec![],
+            reputation_tier: 3,
+            reputation_score: 1.1,
+            timetoken_balance: 1_300_000,
+        },
+    ];
+
+    let config = ConsensusConfig::new(30, 30, 10, 0.1);
+    let genesis = GenesisConfig::new(0, vrf_outputs.clone(), "root".into(), config);
+    let state = super::state::ConsensusState::new(genesis).expect("state init");
+
+    let handle = thread::spawn(move || {
+        let mut state = state;
+        run_bft_loop(&mut state);
+        state
+    });
+
+    thread::sleep(Duration::from_millis(10));
+
+    let validator_set = select_validators(0, &vrf_outputs);
+    let leader = select_leader(&validator_set).expect("leader");
+
+    let manual_proposal = Proposal {
+        block: Block {
+            height: 1,
+            epoch: 0,
+            payload: serde_json::json!({"tx": []}),
+            timestamp: 0,
+        },
+        proof: ConsensusProof {
+            commitment: "manual-commitment".into(),
+            witness_hash: "manual-witness".into(),
+            recursion_depth: 0,
+            valid: true,
+        },
+        leader_id: leader.id.clone(),
+    };
+    let manual_hash = manual_proposal.block_hash();
+
+    submit_proposal(manual_proposal).expect("manual proposal");
+    thread::sleep(Duration::from_millis(10));
+
+    let prevote = PreVote {
+        block_hash: manual_hash.clone(),
+        proof_valid: true,
+        validator_id: leader.id.clone(),
+        round: 0,
+    };
+    submit_prevote(prevote).expect("prevote");
+
+    thread::sleep(Duration::from_millis(120));
+
+    shutdown().expect("shutdown");
+    let final_state = handle.join().expect("join");
+
+    assert!(final_state.round >= 1, "timeout should advance the round");
+    assert!(
+        final_state
+            .pending_proposals
+            .iter()
+            .any(|proposal| proposal.proof.commitment.starts_with("stwo-commitment-")),
+        "expected timeout to trigger a new leader proposal",
+    );
+    assert!(
+        final_state
+            .pending_prevote_messages
+            .iter()
+            .any(|vote| vote.validator_id == leader.id && vote.block_hash == manual_hash),
+        "outstanding prevote should remain tracked for rebroadcast",
+    );
 }


### PR DESCRIPTION
## Summary
- trigger rebroadcasts of pending proposals and votes during view changes and auto-submit a new leader proposal after timeouts
- extend the consensus state with helpers to build and broadcast proposals while tracking outstanding vote messages
- cover the timeout path with a unit test that synchronizes suite execution to avoid shared channel interference

## Testing
- cargo test -p rpp-consensus


------
https://chatgpt.com/codex/tasks/task_e_68d862110c608326a9d9d282974c1232