### PR TITLE
Add verifying key metadata to Plonky3 proofs

### DIFF
--- a/rpp/proofs/plonky3/proof.rs
+++ b/rpp/proofs/plonky3/proof.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -9,7 +11,10 @@ pub struct Plonky3Proof {
     pub circuit: String,
     pub commitment: String,
     pub public_inputs: Value,
-    pub proof: String,
+    #[serde(with = "serde_base64_vec")]
+    pub proof: Vec<u8>,
+    #[serde(with = "serde_hex_key")]
+    pub verifying_key: [u8; 32],
 }
 
 impl Plonky3Proof {
@@ -25,5 +30,53 @@ impl Plonky3Proof {
     pub fn into_value(self) -> ChainResult<Value> {
         serde_json::to_value(self)
             .map_err(|err| ChainError::Crypto(format!("failed to encode Plonky3 proof: {err}")))
+    }
+}
+
+mod serde_base64_vec {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&BASE64_STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        BASE64_STANDARD
+            .decode(encoded.as_bytes())
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+mod serde_hex_key {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(key: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(key))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        let bytes = hex::decode(&encoded).map_err(serde::de::Error::custom)?;
+        if bytes.len() != 32 {
+            return Err(serde::de::Error::custom("verifying key must be 32 bytes"));
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&bytes);
+        Ok(key)
     }
 }

--- a/rpp/runtime/types/proofs.rs
+++ b/rpp/runtime/types/proofs.rs
@@ -105,7 +105,10 @@ mod tests {
             let proof = ChainProof::Plonky3(serde_json::json!({"commitment": "abc"}));
             assert_eq!(proof.system(), ProofSystemKind::Plonky3);
             assert!(matches!(proof.expect_stwo(), Err(ChainError::Crypto(_))));
-            assert!(matches!(proof.clone().into_stwo(), Err(ChainError::Crypto(_))));
+            assert!(matches!(
+                proof.clone().into_stwo(),
+                Err(ChainError::Crypto(_))
+            ));
         }
     }
 }

--- a/tests/plonky3_recursion.rs
+++ b/tests/plonky3_recursion.rs
@@ -5,6 +5,7 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 use rpp_chain::crypto::address_from_public_key;
+use rpp_chain::plonky3::crypto;
 use rpp_chain::plonky3::proof::Plonky3Proof;
 use rpp_chain::plonky3::prover::Plonky3Prover;
 use rpp_chain::plonky3::verifier::Plonky3Verifier;
@@ -74,6 +75,12 @@ fn plonky3_recursive_flow_roundtrip() {
 
     // Recursive proof must reference all commitments from the bundle.
     if let ChainProof::Plonky3(value) = &bundle.recursive_proof {
+        let parsed = Plonky3Proof::from_value(value).unwrap();
+        assert_eq!(parsed.proof.len(), 32);
+        assert_eq!(
+            parsed.verifying_key,
+            crypto::verifying_key("recursive").unwrap()
+        );
         let commitments = value
             .get("public_inputs")
             .and_then(|inputs| inputs.get("commitments"))


### PR DESCRIPTION
## Summary
- include base64-encoded proof bytes and the verifying key in the Plonky3 proof artifact serialization
- update the mock crypto backend to derive proofs from keyed hashes and validate the configured verifying key during verification
- extend Plonky3 unit tests to assert verifying key propagation and reject tampered proof metadata

## Testing
- cargo test --features backend-plonky3 tests::plonky3_recursion -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d8659e6d308326b0876d7538c2e196