### PR TITLE
Ensure Plonky3 commitments use canonical JSON encoding

### DIFF
--- a/docs/test_validation_strategy.md
+++ b/docs/test_validation_strategy.md
@@ -8,6 +8,7 @@ Diese Strategie beschreibt, wie die STWO/Plonky3-Integration vollständig überp
 - **Kern-Circuits**: Für jeden Circuit (`transaction`, `identity`, `state`, `pruning`, `uptime`, `consensus`, `recursive`) werden Constraints und Witness-Generatoren mit gezielten Testfällen abgedeckt. Spezialfälle (z. B. doppelte Votes im Consensus-Circuit oder negative Gebühren in Transaktionen) erhalten dedizierte Regressionstests.
 - **Aggregations- und Snapshot-Helfer**: Die Hash-Pfade und StateCommitment-Snapshots in `stwo::aggregation` werden gegen deterministische Referenzvektoren getestet.
 - **Hilfsstrukturen**: Parser für Witness-Daten (`types::proofs`, `plonky3::proof`) und das Serialisierungsformat `ChainProof` erhalten Roundtrip-Tests.
+- **Hilfsstrukturen**: Parser für Witness-Daten (`types::proofs`, `plonky3::proof`) und das Serialisierungsformat `ChainProof` erhalten Roundtrip-Tests. Commitments für Plonky3 prüfen zusätzlich eine kanonische JSON-Kodierung, bei der Objekt-Schlüssel vor der Serialisierung sortiert werden.
 
 ### 1.2 Integrationstests
 - **Wallet-Prover**: Szenarien vom Bau eines Blocks bis zum Generieren aller Teilbeweise. Enthält Varianten für Identitäts-Genesis, normale Transaktionen, Uptime- und Konsensus-Proofs sowie den rekursiven Block-Proof. Für Plonky3 werden die gleichen Szenarien mit aktiviertem Feature `backend-plonky3` ausgeführt.


### PR DESCRIPTION
## Summary
- canonicalize JSON serialization for Plonky3 public inputs so commitments and proof transcripts are order independent
- add a regression test that exercises different map orderings while expecting equal commitments
- document the new canonical JSON encoding requirement in the validation strategy

## Testing
- cargo test --features backend-plonky3 compute_commitment_is_stable_for_map_ordering

------
https://chatgpt.com/codex/tasks/task_e_68d8694b674c8326a28e754f3d0d18bd