### PR TITLE
Add StakeInfo interface and saturating validator weights

### DIFF
--- a/rpp/consensus/src/evidence.rs
+++ b/rpp/consensus/src/evidence.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::bft_loop::ConsensusMessage;
 use crate::state::register_message_sender;
-use crate::validator::ValidatorId;
+use crate::validator::{StakeInfo, ValidatorId};
 use crate::{ConsensusError, ConsensusResult};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -43,7 +43,7 @@ pub fn slash(accused: &ValidatorId, amount: u64, state: &mut crate::state::Conse
     {
         validator.timetoken_balance = validator.timetoken_balance.saturating_sub(amount);
         validator.reputation_tier = validator.reputation_tier.saturating_sub(1);
-        validator.update_weight();
+        validator.update_weight(StakeInfo::new(validator.stake));
         state.recompute_totals();
     }
 }

--- a/rpp/consensus/src/lib.rs
+++ b/rpp/consensus/src/lib.rs
@@ -17,8 +17,8 @@ pub use messages::{Block, Commit, ConsensusProof, PreCommit, PreVote, Proposal, 
 pub use rewards::{distribute_rewards, RewardDistribution};
 pub use state::{ConsensusConfig, ConsensusState, GenesisConfig};
 pub use validator::{
-    select_leader, select_validators, VRFOutput, Validator, ValidatorId, ValidatorLedgerEntry,
-    ValidatorSet,
+    select_leader, select_validators, StakeInfo, VRFOutput, Validator, ValidatorId,
+    ValidatorLedgerEntry, ValidatorSet,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add a StakeInfo abstraction so the consensus pipeline can pass ledger stake data into validator weight updates
- update the validator weight calculation to saturate on large multipliers and respect zero stake inputs
- extend the consensus test suite with coverage for high-stake, zero-stake, and reputation edge cases

## Testing
- cargo test -p rpp-consensus

------
https://chatgpt.com/codex/tasks/task_e_68d8e1928bf483269bf4c7cb209f2455