### PR TITLE
Integrate peer-authenticated votes into consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,6 +3154,7 @@ name = "rpp-consensus"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "libp2p",
  "serde",
  "serde_json",
  "tokio",

--- a/rpp/consensus/Cargo.toml
+++ b/rpp/consensus/Cargo.toml
@@ -8,3 +8,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["sync", "time", "rt", "macros"] }
 blake3 = "1.5"
+libp2p = { version = "0.54", default-features = false }

--- a/rpp/consensus/src/tests.rs
+++ b/rpp/consensus/src/tests.rs
@@ -1,11 +1,14 @@
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
-use super::bft_loop::{run_bft_loop, shutdown, submit_prevote, submit_proposal};
-use super::messages::{Block, ConsensusProof, PreVote, Proposal};
+use libp2p::PeerId;
+
+use super::bft_loop::{run_bft_loop, shutdown, submit_precommit, submit_prevote, submit_proposal};
+use super::evidence::EvidenceType;
+use super::messages::{Block, BlockId, ConsensusProof, PreCommit, PreVote, Proposal};
 use super::state::{ConsensusConfig, GenesisConfig};
-use std::collections::BTreeMap;
 
 use super::validator::{
     select_leader, select_validators, StakeInfo, VRFOutput, Validator, ValidatorLedgerEntry,
@@ -78,6 +81,58 @@ fn build_ledger(entries: &[(&str, u64, u8, f64)]) -> BTreeMap<String, ValidatorL
         .collect()
 }
 
+fn make_vote_signature(
+    peer: &PeerId,
+    block_hash: &BlockId,
+    round: u64,
+    height: u64,
+    phase: &str,
+) -> Vec<u8> {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&peer.to_bytes());
+    hasher.update(block_hash.0.as_bytes());
+    hasher.update(&round.to_le_bytes());
+    hasher.update(&height.to_le_bytes());
+    hasher.update(phase.as_bytes());
+    hasher.finalize().as_bytes().to_vec()
+}
+
+fn build_prevote(
+    validator: &Validator,
+    peer: &PeerId,
+    block_hash: &BlockId,
+    round: u64,
+    height: u64,
+    proof_valid: bool,
+) -> PreVote {
+    PreVote {
+        block_hash: block_hash.clone(),
+        proof_valid,
+        validator_id: validator.id.clone(),
+        peer_id: peer.clone(),
+        signature: make_vote_signature(peer, block_hash, round, height, "prevote"),
+        height,
+        round,
+    }
+}
+
+fn build_precommit(
+    validator: &Validator,
+    peer: &PeerId,
+    block_hash: &BlockId,
+    round: u64,
+    height: u64,
+) -> PreCommit {
+    PreCommit {
+        block_hash: block_hash.clone(),
+        validator_id: validator.id.clone(),
+        peer_id: peer.clone(),
+        signature: make_vote_signature(peer, block_hash, round, height, "precommit"),
+        height,
+        round,
+    }
+}
+
 fn acquire_test_lock() -> std::sync::MutexGuard<'static, ()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -138,17 +193,22 @@ fn bft_flow_reaches_commit() {
     submit_proposal(proposal.clone()).expect("proposal");
     thread::sleep(Duration::from_millis(25));
 
+    let mut peers: HashMap<_, _> = HashMap::new();
     for validator in &validator_set.validators {
-        let vote = PreVote {
-            block_hash: proposal.block_hash(),
-            proof_valid: true,
-            validator_id: validator.id.clone(),
-            round: 0,
-        };
-        submit_prevote(vote).expect("prevote");
+        peers.insert(validator.id.clone(), PeerId::random());
     }
 
-    thread::sleep(Duration::from_millis(100));
+    for validator in &validator_set.validators {
+        let peer = peers.get(&validator.id).expect("peer id");
+        let block_hash = proposal.block_hash();
+        let height = proposal.block.height;
+        let prevote = build_prevote(validator, peer, &block_hash, 0, height, true);
+        submit_prevote(prevote).expect("prevote");
+        let precommit = build_precommit(validator, peer, &block_hash, 0, height);
+        submit_precommit(precommit).expect("precommit");
+    }
+
+    thread::sleep(Duration::from_millis(150));
 
     shutdown().expect("shutdown");
     let final_state = handle.join().expect("join");
@@ -156,6 +216,137 @@ fn bft_flow_reaches_commit() {
     assert_eq!(final_state.block_height, 1);
     assert!(final_state.pending_rewards.len() >= 1);
     assert!(final_state.pending_proofs.len() >= 1);
+}
+
+#[test]
+fn detects_conflicting_prevotes_triggers_slash() {
+    let _guard = acquire_test_lock();
+    let vrf_outputs = vec![
+        build_vrf_output(0, "validator-1", [1; 32], 4, 1.5, 2_000_000),
+        build_vrf_output(0, "validator-2", [2; 32], 3, 1.2, 1_500_000),
+        build_vrf_output(0, "validator-3", [3; 32], 3, 1.1, 1_300_000),
+    ];
+    let ledger = build_ledger(&[
+        ("validator-1", 10, 4, 1.5),
+        ("validator-2", 8, 3, 1.2),
+        ("validator-3", 6, 3, 1.1),
+    ]);
+
+    let config = ConsensusConfig::new(60, 60, 10, 0.1);
+    let genesis = GenesisConfig::new(
+        0,
+        vrf_outputs.clone(),
+        ledger.clone(),
+        "root".into(),
+        config,
+    );
+    let state = super::state::ConsensusState::new(genesis).expect("state init");
+
+    let handle = thread::spawn(move || {
+        let mut state = state;
+        run_bft_loop(&mut state);
+        state
+    });
+
+    thread::sleep(Duration::from_millis(20));
+
+    let validator_set = select_validators(0, &vrf_outputs, &ledger);
+    let leader = select_leader(&validator_set).expect("leader");
+    let conflicting = validator_set
+        .validators
+        .iter()
+        .find(|validator| validator.id == "validator-1")
+        .expect("validator-1 present")
+        .clone();
+
+    let mut peers: HashMap<_, _> = HashMap::new();
+    for validator in &validator_set.validators {
+        peers.insert(validator.id.clone(), PeerId::random());
+    }
+
+    let proposal_a = Proposal {
+        block: Block {
+            height: 1,
+            epoch: 0,
+            payload: serde_json::json!({"tx": [1]}),
+            timestamp: 10,
+        },
+        proof: ConsensusProof {
+            commitment: "commitment-a".into(),
+            witness_hash: "witness-a".into(),
+            recursion_depth: 0,
+            valid: true,
+        },
+        leader_id: leader.id.clone(),
+    };
+
+    let proposal_b = Proposal {
+        block: Block {
+            height: 1,
+            epoch: 0,
+            payload: serde_json::json!({"tx": [2]}),
+            timestamp: 20,
+        },
+        proof: ConsensusProof {
+            commitment: "commitment-b".into(),
+            witness_hash: "witness-b".into(),
+            recursion_depth: 0,
+            valid: true,
+        },
+        leader_id: leader.id.clone(),
+    };
+
+    submit_proposal(proposal_a.clone()).expect("proposal a");
+    submit_proposal(proposal_b.clone()).expect("proposal b");
+
+    thread::sleep(Duration::from_millis(25));
+
+    let peer = peers.get(&conflicting.id).expect("peer id");
+    let height = proposal_a.block.height;
+    let hash_a = proposal_a.block_hash();
+    let hash_b = proposal_b.block_hash();
+
+    let prevote_a = build_prevote(&conflicting, peer, &hash_a, 0, height, true);
+    submit_prevote(prevote_a).expect("prevote a");
+
+    thread::sleep(Duration::from_millis(10));
+
+    let prevote_b = build_prevote(&conflicting, peer, &hash_b, 0, height, true);
+    submit_prevote(prevote_b).expect("prevote b");
+
+    thread::sleep(Duration::from_millis(80));
+
+    shutdown().expect("shutdown");
+    let final_state = handle.join().expect("join");
+
+    let evidence = final_state
+        .pending_evidence
+        .iter()
+        .find(|record| {
+            record.accused == conflicting.id
+                && matches!(record.evidence, EvidenceType::DoubleSign { .. })
+        })
+        .expect("double-sign evidence recorded");
+
+    if let EvidenceType::DoubleSign {
+        height: evidence_height,
+    } = evidence.evidence
+    {
+        assert_eq!(evidence_height, 1);
+    }
+
+    let punished = final_state
+        .validator_set
+        .validators
+        .iter()
+        .find(|validator| validator.id == conflicting.id)
+        .expect("validator still present");
+
+    assert_eq!(
+        punished.timetoken_balance,
+        conflicting.timetoken_balance - 1
+    );
+    assert_eq!(punished.reputation_tier, conflicting.reputation_tier - 1);
 }
 
 #[test]
@@ -210,15 +401,12 @@ fn timeout_triggers_new_proposal_flow() {
     };
     let manual_hash = manual_proposal.block_hash();
 
-    submit_proposal(manual_proposal).expect("manual proposal");
+    submit_proposal(manual_proposal.clone()).expect("manual proposal");
     thread::sleep(Duration::from_millis(10));
 
-    let prevote = PreVote {
-        block_hash: manual_hash.clone(),
-        proof_valid: true,
-        validator_id: leader.id.clone(),
-        round: 0,
-    };
+    let leader_peer = PeerId::random();
+    let height = manual_proposal.block.height;
+    let prevote = build_prevote(&leader, &leader_peer, &manual_hash, 0, height, true);
     submit_prevote(prevote).expect("prevote");
 
     thread::sleep(Duration::from_millis(120));


### PR DESCRIPTION
## Summary
- extend consensus vote messages to carry libp2p peer identities, signatures, and heights so commits contain real attestation data
- gate quorum accounting on signed votes, persist unique vote fingerprints, and slash/record evidence on detected double-signs
- exercise the new flow with integration tests that cover conflicting votes alongside the existing timeout and commit paths

## Testing
- cargo test -p rpp-consensus

------
https://chatgpt.com/codex/tasks/task_e_68d8e3f31d088326a47fee1b4b557d9a