### PR TITLE
Refactor FRI scaffolding to use official proof types

### DIFF
--- a/rpp/proofs/stwo/aggregation/mod.rs
+++ b/rpp/proofs/stwo/aggregation/mod.rs
@@ -277,10 +277,7 @@ mod tests {
     }
 
     fn dummy_fri_proof() -> FriProof {
-        FriProof {
-            commitments: Vec::new(),
-            challenges: Vec::new(),
-        }
+        FriProof::empty()
     }
 
     fn make_proof(

--- a/rpp/proofs/stwo/fri.rs
+++ b/rpp/proofs/stwo/fri.rs
@@ -3,28 +3,18 @@
 //! This module provides a lightweight polynomial commitment builder that
 //! emulates the structure of a FRI prover. While it does not implement the
 //! full low-level cryptographic primitives of a production STARK backend, the
-//! scaffolding computes deterministic folding challenges, evaluation queries,
-//! and Poseidon-backed Merkle commitments so that verifiers can faithfully
-//! reproduce the prover's output. The resulting artifacts are embedded in
-//! [`StarkProof`](crate::stwo::proof::StarkProof) instances.
-
-use std::collections::HashSet;
-
-use num_bigint::BigUint;
-use num_traits::ToPrimitive;
+//! scaffolding produces deterministic field-element transcripts that can be
+//! wrapped into the official STWO FRI proof structures. The resulting artifacts
+//! are embedded in [`StarkProof`](crate::stwo::proof::StarkProof) instances.
 
 use crate::stwo::circuit::ExecutionTrace;
 use crate::stwo::params::{FieldElement, PoseidonHasher, StarkParameters};
-use crate::stwo::proof::{FriProof, FriQuery, PolynomialCommitment};
-
-/// Number of queries collected for every column commitment.
-const DEFAULT_QUERY_COUNT: usize = 4;
+use crate::stwo::proof::FriProof;
 
 /// Helper encapsulating the deterministic FRI-style commitment process.
 pub struct FriProver<'a> {
     parameters: &'a StarkParameters,
     hasher: PoseidonHasher,
-    query_count: usize,
 }
 
 impl<'a> FriProver<'a> {
@@ -33,61 +23,33 @@ impl<'a> FriProver<'a> {
         Self {
             parameters,
             hasher: parameters.poseidon_hasher(),
-            query_count: DEFAULT_QUERY_COUNT,
         }
-    }
-
-    /// Override the number of queries collected for every column commitment.
-    #[allow(dead_code)]
-    pub fn with_query_count(mut self, queries: usize) -> Self {
-        self.query_count = queries.max(1);
-        self
     }
 
     /// Generate a deterministic FRI-style commitment proof for the supplied
     /// execution trace and public inputs.
     pub fn prove(&self, trace: &ExecutionTrace, public_inputs: &[FieldElement]) -> FriProof {
+        let mut elements = Vec::new();
+        elements.extend_from_slice(public_inputs);
+
         let challenges = self.derive_challenges(trace, public_inputs);
-        let mut commitments = Vec::new();
+        elements.extend(challenges.iter().cloned());
+
         for segment in &trace.segments {
-            let domain_size = next_power_of_two(segment.rows.len());
-            for (column_index, column_name) in segment.columns.iter().enumerate() {
-                let mut evaluations = Vec::with_capacity(domain_size);
-                for row in &segment.rows {
-                    evaluations.push(row[column_index].clone());
-                }
-                while evaluations.len() < domain_size {
-                    evaluations.push(FieldElement::zero(self.parameters.modulus()));
-                }
-                let leaf_hashes = self.hash_leaves(&evaluations);
-                let tree = build_merkle_tree(&self.hasher, leaf_hashes);
-                let root = tree
-                    .last()
-                    .and_then(|level| level.first())
-                    .cloned()
-                    .unwrap_or_else(|| FieldElement::zero(self.parameters.modulus()));
-                let label = format!("{}::{}", segment.name, column_name);
-                let queries = self.build_queries(
-                    &label,
-                    domain_size,
-                    &evaluations,
-                    &tree,
-                    public_inputs,
-                    &challenges,
-                );
-                commitments.push(PolynomialCommitment {
-                    segment: segment.name.clone(),
-                    column: column_name.clone(),
-                    domain_size,
-                    merkle_root: root,
-                    queries,
-                });
+            let name_element =
+                FieldElement::from_bytes(segment.name.as_bytes(), self.parameters.modulus());
+            elements.push(name_element);
+            for column in &segment.columns {
+                let column_element =
+                    FieldElement::from_bytes(column.as_bytes(), self.parameters.modulus());
+                elements.push(column_element);
+            }
+            for row in &segment.rows {
+                elements.extend(row.iter().cloned());
             }
         }
-        FriProof {
-            commitments,
-            challenges,
-        }
+
+        FriProof::from_elements(&elements)
     }
 
     fn derive_challenges(
@@ -110,132 +72,4 @@ impl<'a> FriProver<'a> {
         sponge.finish_absorbing();
         sponge.squeeze_many(2)
     }
-
-    fn build_queries(
-        &self,
-        label: &str,
-        domain_size: usize,
-        evaluations: &[FieldElement],
-        tree: &[Vec<FieldElement>],
-        public_inputs: &[FieldElement],
-        challenges: &[FieldElement],
-    ) -> Vec<FriQuery> {
-        let indices = self.derive_query_indices(label, domain_size, public_inputs, challenges);
-        indices
-            .into_iter()
-            .map(|index| {
-                let evaluation = evaluations[index].clone();
-                let auth_path = build_authentication_path(tree, index);
-                FriQuery {
-                    index,
-                    evaluation,
-                    auth_path,
-                }
-            })
-            .collect()
-    }
-
-    fn derive_query_indices(
-        &self,
-        label: &str,
-        domain_size: usize,
-        public_inputs: &[FieldElement],
-        challenges: &[FieldElement],
-    ) -> Vec<usize> {
-        if domain_size == 0 {
-            return vec![];
-        }
-        let mut sponge = self.hasher.sponge();
-        sponge.absorb_elements(public_inputs);
-        sponge.absorb_elements(challenges);
-        sponge.absorb_bytes(&[label.as_bytes().to_vec()]);
-        sponge.finish_absorbing();
-        let modulus = BigUint::from(domain_size);
-        let unique_target = domain_size.min(self.query_count);
-        let mut indices = Vec::with_capacity(self.query_count);
-        let mut seen = HashSet::new();
-        while seen.len() < unique_target {
-            let element = sponge.squeeze();
-            let value = element.value() % &modulus;
-            let index = value
-                .to_usize()
-                .unwrap_or_else(|| (value % &modulus).to_usize().unwrap_or(0));
-            if seen.insert(index) {
-                indices.push(index);
-            }
-        }
-        if indices.is_empty() {
-            indices.push(0);
-        }
-        let unique_count = indices.len();
-        while indices.len() < self.query_count {
-            let next = indices[indices.len() % unique_count];
-            indices.push(next);
-        }
-        indices.sort_unstable();
-        indices
-    }
-
-    fn hash_leaves(&self, evaluations: &[FieldElement]) -> Vec<FieldElement> {
-        evaluations
-            .iter()
-            .enumerate()
-            .map(|(index, value)| {
-                let index_element = FieldElement::from_u64(index as u64, self.parameters.modulus());
-                self.hasher.hash(&[value.clone(), index_element])
-            })
-            .collect()
-    }
-}
-
-fn next_power_of_two(value: usize) -> usize {
-    match value {
-        0 => 1,
-        1 => 1,
-        _ => value.next_power_of_two(),
-    }
-}
-
-fn build_merkle_tree(hasher: &PoseidonHasher, leaves: Vec<FieldElement>) -> Vec<Vec<FieldElement>> {
-    let mut levels = Vec::new();
-    if leaves.is_empty() {
-        return levels;
-    }
-    let mut current = leaves;
-    levels.push(current.clone());
-    while current.len() > 1 {
-        if current.len() % 2 == 1 {
-            let last = current.last().cloned().unwrap();
-            current.push(last);
-        }
-        let mut next = Vec::with_capacity(current.len() / 2);
-        for chunk in current.chunks(2) {
-            let left = chunk[0].clone();
-            let right = chunk[1].clone();
-            next.push(hasher.hash(&[left, right]));
-        }
-        levels.push(next.clone());
-        current = next;
-    }
-    levels
-}
-
-fn build_authentication_path(tree: &[Vec<FieldElement>], mut index: usize) -> Vec<FieldElement> {
-    let mut path = Vec::new();
-    if tree.is_empty() {
-        return path;
-    }
-    for level in tree.iter() {
-        if level.len() == 1 {
-            break;
-        }
-        let sibling_index = if index % 2 == 0 { index + 1 } else { index - 1 };
-        let sibling = level
-            .get(sibling_index)
-            .cloned()
-            .unwrap_or_else(|| level[index].clone());
-        path.push(sibling);
-        index /= 2;
-    }
-    path
 }

--- a/rpp/runtime/sync.rs
+++ b/rpp/runtime/sync.rs
@@ -533,10 +533,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 
@@ -554,10 +551,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 
@@ -592,10 +586,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 

--- a/rpp/runtime/types/block.rs
+++ b/rpp/runtime/types/block.rs
@@ -1549,10 +1549,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         })
     }
 
@@ -1688,10 +1685,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 

--- a/rpp/storage/migration.rs
+++ b/rpp/storage/migration.rs
@@ -294,10 +294,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         })
     }
 
@@ -383,10 +380,7 @@ mod tests {
                 TraceSegment::new("dummy", vec!["column".to_string()], Vec::new()).unwrap(),
             )
             .unwrap(),
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 

--- a/rpp/storage/mod.rs
+++ b/rpp/storage/mod.rs
@@ -512,10 +512,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 
@@ -533,10 +530,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 
@@ -571,10 +565,7 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof {
-                commitments: Vec::new(),
-                challenges: Vec::new(),
-            },
+            fri_proof: FriProof::empty(),
         }
     }
 

--- a/rpp/zk/stwo/src/lib.rs
+++ b/rpp/zk/stwo/src/lib.rs
@@ -17,3 +17,6 @@ pub mod verifier;
 pub use prover::{prove_block, prove_identity, prove_reputation, prove_tx, Proof, ProofFormat};
 pub use recursion::{link_proofs, RecursiveProof};
 pub use verifier::{verify_block, verify_identity, verify_reputation, verify_tx};
+
+#[cfg(feature = "official")]
+pub use stwo_official;

--- a/tests/end_to_end_rpc.rs
+++ b/tests/end_to_end_rpc.rs
@@ -160,10 +160,7 @@ fn sample_transaction_bundle(to: &str) -> TransactionProofBundle {
         trace: ExecutionTrace {
             segments: Vec::new(),
         },
-        fri_proof: FriProof {
-            commitments: Vec::new(),
-            challenges: Vec::new(),
-        },
+        fri_proof: FriProof::empty(),
     };
 
     TransactionProofBundle::new(signed_tx, ChainProof::Stwo(proof))


### PR DESCRIPTION
## Summary
- wrap the local FRI query and proof helpers around the official STWO types with deterministic serialization
- simplify the placeholder FRI prover to emit element transcripts and update callers to use `FriProof::empty()`
- add a round-trip unit test that serializes and restores an official proof using the new wrappers

## Testing
- `cargo test -p stwo official_proof_roundtrip --features official -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68d9467586c08326877fb9a1993a427a