### PR TITLE
Refactor STWO prover to emit library-compatible proofs

### DIFF
--- a/rpp/zk/stwo/src/verifier.rs
+++ b/rpp/zk/stwo/src/verifier.rs
@@ -1,103 +1,183 @@
-use crate::circuits::identity::{IdentityGenesis, IdentityWitness};
-use crate::circuits::pruning::{PruningInputs, PruningWitness};
-use crate::circuits::reputation::{ReputationState, ReputationWitness};
-use crate::circuits::transaction::{Transaction, TransactionWitness, UtxoState};
-use crate::params::{FieldElement, StwoConfig};
-use crate::prover::{Block, Proof, ProofCircuit, ProofFormat};
+use crate::circuits::identity::IdentityWitness;
+use crate::circuits::pruning::PruningWitness;
+use crate::circuits::reputation::ReputationWitness;
+use crate::circuits::transaction::TransactionWitness;
+use crate::circuits::CircuitWitness;
+use crate::params::FieldElement;
+use crate::prover::{Block, Proof, ProofCircuit};
 use crate::utils::fri::FriProver;
 use crate::utils::poseidon;
 
-fn fri_inputs_from_trace(trace: &crate::circuits::CircuitTrace) -> Vec<FieldElement> {
-    vec![
-        FieldElement::from_bytes(&trace.trace_commitment[..16]),
-        FieldElement::from_bytes(&trace.trace_commitment[16..]),
-        FieldElement::from_bytes(&trace.constraint_commitment[..16]),
-        FieldElement::from_bytes(&trace.constraint_commitment[16..]),
+fn commitment_from_inputs(inputs: &[FieldElement]) -> String {
+    hex::encode(poseidon::hash_elements(inputs))
+}
+
+fn decode_witness<T: serde::de::DeserializeOwned>(proof: &Proof) -> Option<T> {
+    proof.payload.decode_json()
+}
+
+fn encode_inputs(inputs: &[FieldElement]) -> Vec<String> {
+    inputs
+        .iter()
+        .map(|element| hex::encode(element.to_bytes()))
+        .collect()
+}
+
+fn commitment_elements(commitment: &[u8; 32]) -> [FieldElement; 2] {
+    [
+        FieldElement::from_bytes(&commitment[..16]),
+        FieldElement::from_bytes(&commitment[16..]),
     ]
 }
 
-fn verify_witness(
-    proof: &Proof,
-    witness_trace: crate::circuits::CircuitTrace,
-    public_inputs: serde_json::Value,
-) -> bool {
-    if proof.format != ProofFormat::Json {
-        return false;
-    }
-    if proof.config != StwoConfig::default() {
-        return false;
-    }
-    if proof.trace != witness_trace {
-        return false;
-    }
-    if proof.public_inputs != public_inputs {
-        return false;
-    }
-    let fri_inputs = fri_inputs_from_trace(&witness_trace);
-    FriProver::verify(&fri_inputs, &proof.fri_proof)
+fn fri_inputs(trace: &crate::circuits::CircuitTrace, inputs: &[FieldElement]) -> Vec<FieldElement> {
+    let mut values = inputs.to_vec();
+    values.extend(commitment_elements(&trace.trace_commitment));
+    values.extend(commitment_elements(&trace.constraint_commitment));
+    values
 }
 
-pub fn verify_tx(tx: &Transaction, proof: &Proof) -> bool {
-    if proof.circuit != ProofCircuit::Transaction {
-        return false;
+fn verify_generic<W>(proof: &Proof, expected_circuit: ProofCircuit) -> Option<W>
+where
+    W: CircuitWitness + Clone + PartialEq,
+{
+    if proof.circuit != expected_circuit {
+        return None;
     }
-    let state_root = proof
-        .public_inputs
-        .get("state_root")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let state = UtxoState {
-        root: state_root.to_owned(),
-        height: 0,
+    decode_witness::<W>(proof)
+}
+
+fn transaction_inputs(witness: &TransactionWitness) -> Vec<FieldElement> {
+    vec![
+        FieldElement::from_bytes(witness.tx.tx_id.as_bytes()),
+        FieldElement::from_bytes(witness.state.root.as_bytes()),
+        FieldElement::from(witness.tx.tier as u128),
+        FieldElement::from(witness.balance_sum),
+    ]
+}
+
+fn reputation_inputs(witness: &ReputationWitness) -> Vec<FieldElement> {
+    vec![
+        FieldElement::from_bytes(witness.state.participant.as_bytes()),
+        FieldElement::from(witness.state.score as u128),
+        FieldElement::from(witness.state.tier as u128),
+        FieldElement::from(witness.timetoken as u128),
+    ]
+}
+
+fn identity_inputs(witness: &IdentityWitness) -> Vec<FieldElement> {
+    vec![
+        FieldElement::from_bytes(witness.genesis.wallet_address.as_bytes()),
+        FieldElement::from_bytes(witness.genesis.genesis_block.as_bytes()),
+    ]
+}
+
+fn pruning_inputs(witness: &PruningWitness) -> Vec<FieldElement> {
+    vec![
+        FieldElement::from_bytes(witness.inputs.utxo_root.as_bytes()),
+        FieldElement::from_bytes(witness.inputs.reputation_root.as_bytes()),
+        FieldElement::from_bytes(&witness.inputs.previous_proof_digest[..16]),
+        FieldElement::from_bytes(&witness.inputs.previous_proof_digest[16..]),
+    ]
+}
+
+pub fn verify_tx(tx: &crate::circuits::transaction::Transaction, proof: &Proof) -> bool {
+    let witness: TransactionWitness = match verify_generic(proof, ProofCircuit::Transaction) {
+        Some(witness) => witness,
+        None => return false,
     };
-    let witness = TransactionWitness::new(tx.clone(), state);
-    verify_witness(proof, witness.trace(), witness.public_inputs())
-}
-
-pub fn verify_reputation(state: &ReputationState, proof: &Proof) -> bool {
-    if proof.circuit != ProofCircuit::Reputation {
+    if witness.tx != *tx {
         return false;
     }
-    let witness = ReputationWitness::new(state.clone(), state.epochs_participated, 0);
-    verify_witness(proof, witness.trace(), witness.public_inputs())
+    let expected_inputs = transaction_inputs(&witness);
+    if encode_inputs(&expected_inputs) != proof.public_inputs {
+        return false;
+    }
+    if commitment_from_inputs(&expected_inputs) != proof.commitment {
+        return false;
+    }
+    let expected_trace = witness.trace();
+    if proof.trace != expected_trace {
+        return false;
+    }
+    let fri_values = fri_inputs(&expected_trace, &expected_inputs);
+    FriProver::verify(&fri_values, &proof.fri_proof)
+}
+
+pub fn verify_reputation(
+    state: &crate::circuits::reputation::ReputationState,
+    proof: &Proof,
+) -> bool {
+    let witness: ReputationWitness = match verify_generic(proof, ProofCircuit::Reputation) {
+        Some(witness) => witness,
+        None => return false,
+    };
+    if witness.state != *state {
+        return false;
+    }
+    let expected_inputs = reputation_inputs(&witness);
+    if encode_inputs(&expected_inputs) != proof.public_inputs {
+        return false;
+    }
+    if commitment_from_inputs(&expected_inputs) != proof.commitment {
+        return false;
+    }
+    let expected_trace = witness.trace();
+    if proof.trace != expected_trace {
+        return false;
+    }
+    let fri_values = fri_inputs(&expected_trace, &expected_inputs);
+    FriProver::verify(&fri_values, &proof.fri_proof)
 }
 
 pub fn verify_block(block: &Block, proof: &Proof) -> bool {
-    if proof.circuit != ProofCircuit::Block {
+    let witness: PruningWitness = match verify_generic(proof, ProofCircuit::Block) {
+        Some(witness) => witness,
+        None => return false,
+    };
+    if witness.inputs.utxo_root != block.tx_root {
         return false;
     }
-    let previous_digest = proof
-        .public_inputs
-        .get("previous_digest")
-        .and_then(|value| value.as_str())
-        .unwrap_or_default();
-    let mut digest_bytes = [0u8; 32];
-    hex::decode_to_slice(previous_digest, &mut digest_bytes).ok();
-    let inputs = PruningInputs {
-        utxo_root: block.tx_root.clone(),
-        reputation_root: block.reputation_root.clone(),
-        previous_proof_digest: digest_bytes,
-    };
-    let leaves = vec![
-        digest_bytes,
-        poseidon::hash_elements(&[
-            FieldElement::from(block.height as u128),
-            FieldElement::from_bytes(block.tx_root.as_bytes()),
-        ]),
-    ];
-    let witness = PruningWitness::new(inputs, leaves);
-    verify_witness(proof, witness.trace(), witness.public_inputs())
+    if witness.inputs.reputation_root != block.reputation_root {
+        return false;
+    }
+    let expected_inputs = pruning_inputs(&witness);
+    if encode_inputs(&expected_inputs) != proof.public_inputs {
+        return false;
+    }
+    if commitment_from_inputs(&expected_inputs) != proof.commitment {
+        return false;
+    }
+    let expected_trace = witness.trace();
+    if proof.trace != expected_trace {
+        return false;
+    }
+    let fri_values = fri_inputs(&expected_trace, &expected_inputs);
+    FriProver::verify(&fri_values, &proof.fri_proof)
 }
 
-pub fn verify_identity(genesis: &IdentityGenesis, proof: &Proof) -> bool {
-    if proof.circuit != ProofCircuit::Identity {
+pub fn verify_identity(
+    genesis: &crate::circuits::identity::IdentityGenesis,
+    proof: &Proof,
+) -> bool {
+    let witness: IdentityWitness = match verify_generic(proof, ProofCircuit::Identity) {
+        Some(witness) => witness,
+        None => return false,
+    };
+    if witness.genesis != *genesis {
         return false;
     }
-    let wallet_key = proof
-        .public_inputs
-        .get("wallet")
-        .and_then(|value| value.as_str())
-        .unwrap_or_default();
-    let witness = IdentityWitness::new(genesis.clone(), wallet_key.to_owned(), "vote".into());
-    verify_witness(proof, witness.trace(), witness.public_inputs())
+    let expected_inputs = identity_inputs(&witness);
+    if encode_inputs(&expected_inputs) != proof.public_inputs {
+        return false;
+    }
+    if commitment_from_inputs(&expected_inputs) != proof.commitment {
+        return false;
+    }
+    let expected_trace = witness.trace();
+    if proof.trace != expected_trace {
+        return false;
+    }
+    let fri_values = fri_inputs(&expected_trace, &expected_inputs);
+    FriProver::verify(&fri_values, &proof.fri_proof)
 }


### PR DESCRIPTION
## Summary
- encode proofs with library-style commitments, public inputs and payload handling
- reuse witness data to feed the FRI helper and persist commitments for each circuit
- update verifier logic to decode embedded witnesses and validate proofs, adding roundtrip tests

## Testing
- cargo test -p stwo --features official

------
https://chatgpt.com/codex/tasks/task_e_68d95268daa083269e4844762f5462c1