### PR TITLE
Align STWO verifier with official proof layout

### DIFF
--- a/rpp/zk/stwo/src/lib.rs
+++ b/rpp/zk/stwo/src/lib.rs
@@ -16,7 +16,10 @@ pub mod verifier;
 
 pub use prover::{prove_block, prove_identity, prove_reputation, prove_tx, Proof, ProofFormat};
 pub use recursion::{link_proofs, RecursiveProof};
-pub use verifier::{verify_block, verify_identity, verify_reputation, verify_tx};
+pub use verifier::{
+    verify_block, verify_identity, verify_reputation, verify_tx, VerificationError,
+    VerificationResult,
+};
 
 #[cfg(feature = "official")]
 pub use stwo_official;


### PR DESCRIPTION
## Summary
- wrap FriProof around the official STWO proof structure and expose bytes through JSON encoding
- migrate the lightweight Proof format to raw field elements and Poseidon commitments
- rework verifier helpers to return structured VerificationError results and cover failure cases with new tests

## Testing
- cargo test -p stwo --features official

------
https://chatgpt.com/codex/tasks/task_e_68d95529846883268914f8d701e94d27