### PR TITLE
Refine STWO exports and proof digest helpers

### DIFF
--- a/rpp/runtime/types/proofs.rs
+++ b/rpp/runtime/types/proofs.rs
@@ -95,6 +95,64 @@ impl BlockProofBundle {
 
 #[cfg(test)]
 mod tests {
+    mod stwo {
+        use super::super::ChainProof;
+        use crate::stwo::circuit::ExecutionTrace;
+        use crate::stwo::circuit::recursive::RecursiveWitness;
+        use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+
+        fn sample_stwo_proof() -> StarkProof {
+            let witness = RecursiveWitness {
+                previous_commitment: Some("aa".repeat(32)),
+                aggregated_commitment: "bb".repeat(32),
+                identity_commitments: vec!["cc".repeat(32)],
+                tx_commitments: vec!["dd".repeat(32)],
+                uptime_commitments: vec!["ee".repeat(32)],
+                consensus_commitments: vec!["ff".repeat(32)],
+                state_commitment: "11".repeat(32),
+                global_state_root: "22".repeat(32),
+                utxo_root: "33".repeat(32),
+                reputation_root: "44".repeat(32),
+                timetoke_root: "55".repeat(32),
+                zsi_root: "66".repeat(32),
+                proof_root: "77".repeat(32),
+                pruning_commitment: "88".repeat(32),
+                block_height: 1,
+            };
+            StarkProof {
+                kind: ProofKind::Recursive,
+                commitment: "99".repeat(32),
+                public_inputs: vec!["aa".repeat(32)],
+                payload: ProofPayload::Recursive(witness),
+                trace: ExecutionTrace {
+                    segments: Vec::new(),
+                },
+                fri_proof: FriProof::empty(),
+            }
+        }
+
+        #[test]
+        fn json_roundtrip_preserves_stwo_proof() {
+            let proof = ChainProof::Stwo(sample_stwo_proof());
+            let json = serde_json::to_string(&proof).expect("serialize chain proof");
+            let decoded: ChainProof = serde_json::from_str(&json).expect("deserialize chain proof");
+            let original = serde_json::to_value(&proof).expect("encode original");
+            let recovered = serde_json::to_value(&decoded).expect("encode decoded");
+            assert_eq!(recovered, original);
+        }
+
+        #[test]
+        fn binary_roundtrip_preserves_stwo_proof() {
+            let proof = ChainProof::Stwo(sample_stwo_proof());
+            let bytes = bincode::serialize(&proof).expect("serialize chain proof");
+            let decoded: ChainProof =
+                bincode::deserialize(&bytes).expect("deserialize chain proof");
+            let original = serde_json::to_value(&proof).expect("encode original");
+            let recovered = serde_json::to_value(&decoded).expect("encode decoded");
+            assert_eq!(recovered, original);
+        }
+    }
+
     #[cfg(feature = "backend-plonky3")]
     mod plonky3 {
         use super::super::{ChainProof, ProofSystemKind};

--- a/rpp/zk/stwo/Cargo.toml
+++ b/rpp/zk/stwo/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 official = ["dep:stwo-official"]
 prover = ["official", "stwo-official/prover"]
 fri = ["prover"]
+scaffold = []
 
 [dependencies]
 blake2 = "0.10"

--- a/rpp/zk/stwo/src/lib.rs
+++ b/rpp/zk/stwo/src/lib.rs
@@ -6,16 +6,30 @@
 //! offers simple, pure-Rust stand-ins for the original StarkWare components so
 //! that tests and local development can run without external dependencies.
 
+#[cfg(any(test, feature = "scaffold"))]
 pub mod circuits;
 pub mod core;
 pub mod params;
-pub mod prover;
-pub mod recursion;
 pub mod utils;
+
+pub use core::vcs::blake2_hash::{Blake2sHash, Blake2sHasher};
+pub use params::{FieldElement, StwoConfig};
+pub use utils::fri::{compress_proof, FriProof, FriProver, FriQuery};
+pub use utils::merkle::merkle_root;
+pub use utils::poseidon::hash_elements as poseidon_hash;
+
+#[cfg(any(test, feature = "scaffold"))]
+pub mod prover;
+#[cfg(any(test, feature = "scaffold"))]
+pub mod recursion;
+#[cfg(any(test, feature = "scaffold"))]
 pub mod verifier;
 
+#[cfg(any(test, feature = "scaffold"))]
 pub use prover::{prove_block, prove_identity, prove_reputation, prove_tx, Proof, ProofFormat};
+#[cfg(any(test, feature = "scaffold"))]
 pub use recursion::{link_proofs, RecursiveProof};
+#[cfg(any(test, feature = "scaffold"))]
 pub use verifier::{
     verify_block, verify_identity, verify_reputation, verify_tx, VerificationError,
     VerificationResult,


### PR DESCRIPTION
## Summary
- gate the local STWO scaffold modules behind a new `scaffold` feature and re-export hashing/Fri helpers for consumers
- update placeholder proof digests to fold in commitment and Fri compression so recursive links track canonical hashes
- add regression tests that serialize and deserialize `ChainProof::Stwo` artifacts through JSON and bincode

## Testing
- `cargo test types::proofs::tests::stwo::json_roundtrip_preserves_stwo_proof`
- `cargo test types::proofs::tests::stwo::binary_roundtrip_preserves_stwo_proof`


------
https://chatgpt.com/codex/tasks/task_e_68d95826d974832699938fafc468cd5b