### PR TITLE
Integrate official STWO FRI backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +223,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -171,7 +235,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -200,7 +264,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -302,7 +366,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -343,6 +407,18 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
+name = "bigdecimal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -440,6 +516,20 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "byteorder"
@@ -541,7 +631,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -630,6 +720,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,7 +808,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -733,7 +834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -770,6 +871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,7 +909,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -856,6 +968,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd92664bf78c4d3dba9b7cdafce6fa15b13ed3ed16175218196942e99168a8"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,7 +1000,27 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1011,7 +1155,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1677,6 +1821,24 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2078,7 +2240,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2226,7 +2388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c738d3789301e957a8f7519318fcbb1b92bb95863b28f6938ae5a05be6259f34"
 dependencies = [
  "hashbrown 0.15.5",
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "ryu",
 ]
@@ -2237,7 +2399,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9446a966be7f1708c10badd6690d3094b5ad62d3accdcf2154740656d7650cfa"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
  "malachite-q",
@@ -2250,7 +2412,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1707c9a1fa36ce21749b35972bfad17bbf34cf5a7c96897c0491da321e387d3b"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "libm",
  "malachite-base",
  "serde",
@@ -2263,7 +2425,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d764801aa4e96bbb69b389dcd03b50075345131cd63ca2e380bca71cc37a3675"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "malachite-base",
  "malachite-nz",
  "serde",
@@ -2637,7 +2799,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2752,7 +2914,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3078,6 +3240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,7 +3309,7 @@ dependencies = [
  "serde",
  "serde_json",
  "storage-firewood",
- "stwo",
+ "stwo 1.0.0",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3433,7 +3605,7 @@ checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3622,6 +3794,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "starknet-crypto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e2c30c01e8eb0fc913c4ee3cf676389fffc1d1182bfe5bb9670e4e72e968064"
+dependencies = [
+ "crypto-bigint",
+ "hex",
+ "hmac",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rfc6979",
+ "sha2 0.10.9",
+ "starknet-crypto-codegen",
+ "starknet-curve",
+ "starknet-ff",
+ "zeroize",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
+dependencies = [
+ "starknet-curve",
+ "starknet-ff",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c383518bb312751e4be80f53e8644034aa99a0afb29d7ac41b89a997db875b"
+dependencies = [
+ "starknet-ff",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
+dependencies = [
+ "ark-ff",
+ "bigdecimal",
+ "crypto-bigint",
+ "getrandom 0.2.16",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,17 +3876,63 @@ version = "1.0.0"
 dependencies = [
  "blake2",
  "hex",
+ "num-traits",
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "stwo 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "stwo"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e487d011fb1370cb22142bbc7095a31ca6371424f5d1e2fc83a7d453fb69f8d"
+dependencies = [
+ "blake2",
+ "blake3",
+ "bytemuck",
+ "cfg-if",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "hex",
+ "indexmap",
+ "itertools 0.12.1",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "starknet-crypto",
+ "starknet-ff",
+ "stwo-std-shims",
+ "thiserror 2.0.16",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "stwo-std-shims"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3690,7 +3962,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3753,7 +4025,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3764,7 +4036,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3859,7 +4131,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3992,7 +4264,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4052,7 +4324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4238,7 +4510,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -4273,7 +4545,7 @@ checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4761,7 +5033,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4782,7 +5054,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4802,7 +5074,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4823,7 +5095,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4856,5 +5128,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/rpp/zk/stwo/Cargo.toml
+++ b/rpp/zk/stwo/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 hex = "0.4"
+num-traits = "0.2"
+stwo-lib = { package = "stwo", version = "1.0.0", features = ["prover"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/rpp/zk/stwo/src/lib.rs
+++ b/rpp/zk/stwo/src/lib.rs
@@ -16,4 +16,5 @@ pub mod verifier;
 
 pub use prover::{prove_block, prove_identity, prove_reputation, prove_tx, Proof, ProofFormat};
 pub use recursion::{link_proofs, RecursiveProof};
+pub use utils::fri::{FriProof, FriProver, FriWrapperError};
 pub use verifier::{verify_block, verify_identity, verify_reputation, verify_tx};

--- a/rpp/zk/stwo/src/params/stwo_config.rs
+++ b/rpp/zk/stwo/src/params/stwo_config.rs
@@ -52,6 +52,10 @@ impl FieldElement {
     pub fn to_bytes(self) -> [u8; 16] {
         self.0.to_be_bytes()
     }
+
+    pub fn as_u128(self) -> u128 {
+        self.0
+    }
 }
 
 impl From<u128> for FieldElement {

--- a/rpp/zk/stwo/src/prover.rs
+++ b/rpp/zk/stwo/src/prover.rs
@@ -95,8 +95,9 @@ where
     let config = StwoConfig::default();
     let public_inputs = witness.to_json();
     let trace = witness.trace_commitments();
-    let fri_inputs = witness.fri_values();
-    let fri_proof = FriProver::prove(&fri_inputs);
+    let fri_values = witness.fri_values();
+    let fri_proof = FriProver::prove(&fri_values, &config)
+        .expect("fri prover should generate a proof for the witness");
 
     Proof {
         circuit,

--- a/rpp/zk/stwo/src/utils/fri.rs
+++ b/rpp/zk/stwo/src/utils/fri.rs
@@ -1,65 +1,250 @@
-use rand::{Rng, SeedableRng};
+use std::collections::BTreeMap;
+
+use num_traits::identities::Zero;
 use serde::{Deserialize, Serialize};
+use stwo_lib::core::channel::{Blake2sChannel, MerkleChannel};
+use stwo_lib::core::fields::m31::{BaseField, P as M31_MODULUS};
+use stwo_lib::core::fields::qm31::SecureField;
+use stwo_lib::core::fri::{
+    CirclePolyDegreeBound, FriConfig, FriProof as StwoFriProof, FriVerifier,
+};
+use stwo_lib::core::vcs::blake2_merkle::Blake2sMerkleChannel;
+use stwo_lib::prover::backend::cpu::CpuCirclePoly;
+use stwo_lib::prover::backend::CpuBackend;
+use stwo_lib::prover::fri::FriProver as StwoFriProver;
+use stwo_lib::prover::poly::circle::{PolyOps, SecureEvaluation};
+use stwo_lib::prover::poly::twiddles::TwiddleTree;
+use stwo_lib::prover::poly::BitReversedOrder;
 
 use crate::core::vcs::blake2_hash::Blake2sHasher;
-use crate::params::FieldElement;
-use crate::utils::poseidon;
+use crate::params::{FieldElement, StwoConfig};
 
-/// Minimal representation of a FRI query.  The randomness is deterministic for
-/// repeatability during testing.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct FriQuery {
-    pub index: usize,
-    pub value: FieldElement,
+#[derive(Debug, thiserror::Error)]
+pub enum FriWrapperError {
+    #[error("fri blowup factor must be a power of two greater than one, got {blowup_factor}")]
+    InvalidBlowupFactor { blowup_factor: usize },
+    #[error("fri polynomial degree {log_degree} exceeds supported maximum {max_log_degree}")]
+    DegreeTooLarge {
+        log_degree: u32,
+        max_log_degree: u32,
+    },
+    #[error("fri column degree bounds mismatch between witness and proof")]
+    ColumnBoundsMismatch,
+    #[error("fri configuration mismatch between witness and proof")]
+    ConfigMismatch,
+    #[error("fri query evaluations mismatch")]
+    QueryMismatch,
+    #[error("fri verification failed: {0}")]
+    Verification(#[from] stwo_lib::core::fri::FriVerificationError),
 }
 
-/// Proof object returned by the simplified FRI protocol.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FriProof {
-    pub commitment: [u8; 32],
-    pub queries: Vec<FriQuery>,
+    pub config: FriConfig,
+    pub column_log_degree_bounds: Vec<u32>,
+    pub proof: StwoFriProof<<Blake2sMerkleChannel as MerkleChannel>::H>,
+    pub query_values: Vec<Vec<SecureField>>,
+}
+
+impl PartialEq for FriProof {
+    fn eq(&self, other: &Self) -> bool {
+        self.column_log_degree_bounds == other.column_log_degree_bounds
+            && self.config.log_blowup_factor == other.config.log_blowup_factor
+            && self.config.log_last_layer_degree_bound == other.config.log_last_layer_degree_bound
+            && self.config.n_queries == other.config.n_queries
+            && self.query_values == other.query_values
+            && serde_json::to_vec(&self.proof).ok() == serde_json::to_vec(&other.proof).ok()
+    }
+}
+
+impl Eq for FriProof {}
+
+struct FriInputs {
+    config: FriConfig,
+    columns: Vec<SecureEvaluation<CpuBackend, BitReversedOrder>>,
+    column_log_degree_bounds: Vec<u32>,
+    twiddles: TwiddleTree<CpuBackend>,
+}
+
+const MAX_LOG_DEGREE: u32 = 10;
+
+impl FriInputs {
+    fn new(values: &[FieldElement], config: &StwoConfig) -> Result<Self, FriWrapperError> {
+        let blowup_factor = config.blowup_factor;
+        if blowup_factor.count_ones() != 1 || blowup_factor <= 1 {
+            return Err(FriWrapperError::InvalidBlowupFactor { blowup_factor });
+        }
+
+        let log_blowup_factor = blowup_factor.ilog2() as u32;
+
+        let input_len = values.len().max(1);
+        let log_degree = (input_len.next_power_of_two().ilog2()) as u32;
+        if log_degree > MAX_LOG_DEGREE {
+            return Err(FriWrapperError::DegreeTooLarge {
+                log_degree,
+                max_log_degree: MAX_LOG_DEGREE,
+            });
+        }
+
+        let coeffs_len = 1usize << log_degree;
+        let mut coeffs = vec![BaseField::zero(); coeffs_len];
+        for (coeff, value) in coeffs.iter_mut().zip(values.iter().copied()) {
+            *coeff = field_to_base(value);
+        }
+
+        let circle_poly = CpuCirclePoly::new(coeffs);
+        let coset = stwo_lib::core::circle::Coset::half_odds(log_degree + log_blowup_factor - 1);
+        let domain = stwo_lib::core::poly::circle::CircleDomain::new(coset);
+        let evaluation = circle_poly.evaluate(domain);
+        let secure_evaluation = SecureEvaluation::new(
+            domain,
+            evaluation.into_iter().map(SecureField::from).collect(),
+        );
+        debug_assert_eq!(
+            secure_evaluation.domain.log_size(),
+            log_degree + log_blowup_factor,
+            "secure evaluation domain log size mismatch"
+        );
+
+        let twiddles = CpuBackend::precompute_twiddles(secure_evaluation.domain.half_coset);
+        let last_layer_log = log_degree.saturating_sub(2);
+        let fri_config = FriConfig::new(last_layer_log, log_blowup_factor, config.fri_repetitions);
+
+        Ok(Self {
+            config: fri_config,
+            columns: vec![secure_evaluation],
+            column_log_degree_bounds: vec![log_degree],
+            twiddles,
+        })
+    }
+
+    fn collect_query_values(
+        &self,
+        query_positions: &BTreeMap<u32, Vec<usize>>,
+    ) -> Vec<Vec<SecureField>> {
+        self.columns
+            .iter()
+            .map(|column| {
+                let log_size = column.domain.log_size();
+                query_positions
+                    .get(&log_size)
+                    .into_iter()
+                    .flat_map(|positions| positions.iter())
+                    .map(|index| column.values.at(*index))
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+fn field_to_base(value: FieldElement) -> BaseField {
+    let modulus_square = (M31_MODULUS as u128) * (M31_MODULUS as u128);
+    let reduced = value.as_u128() % modulus_square;
+    BaseField::reduce(reduced as u64)
 }
 
 pub struct FriProver;
 
 impl FriProver {
-    pub fn commit(values: &[FieldElement]) -> [u8; 32] {
-        poseidon::hash_elements(values)
-    }
+    pub fn prove(
+        values: &[FieldElement],
+        config: &StwoConfig,
+    ) -> Result<FriProof, FriWrapperError> {
+        let inputs = FriInputs::new(values, config)?;
 
-    pub fn prove(values: &[FieldElement]) -> FriProof {
-        let commitment = Self::commit(values);
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-        let queries: Vec<FriQuery> = values
-            .iter()
-            .enumerate()
-            .take(4)
-            .map(|(index, value)| FriQuery {
-                index: (index + rng.gen::<usize>()) % values.len().max(1),
-                value: value.clone(),
-            })
-            .collect();
-        FriProof {
-            commitment,
-            queries,
-        }
-    }
+        let mut channel = Blake2sChannel::default();
+        let stwo_prover = StwoFriProver::<CpuBackend, Blake2sMerkleChannel>::commit(
+            &mut channel,
+            inputs.config,
+            &inputs.columns,
+            &inputs.twiddles,
+        );
+        let (proof, query_positions) = stwo_prover.decommit(&mut channel);
+        let query_values = inputs.collect_query_values(&query_positions);
+        let FriInputs {
+            config,
+            column_log_degree_bounds,
+            ..
+        } = inputs;
 
-    pub fn verify(values: &[FieldElement], proof: &FriProof) -> bool {
-        let expected_commitment = Self::commit(values);
-        if expected_commitment != proof.commitment {
-            return false;
-        }
-        proof.queries.iter().all(|query| {
-            values
-                .get(query.index % values.len().max(1))
-                .map(|v| v == &query.value)
-                .unwrap_or(false)
+        Ok(FriProof {
+            config,
+            column_log_degree_bounds,
+            proof,
+            query_values,
         })
+    }
+
+    pub fn verify(
+        values: &[FieldElement],
+        proof: &FriProof,
+        config: &StwoConfig,
+    ) -> Result<(), FriWrapperError> {
+        let inputs = FriInputs::new(values, config)?;
+        if inputs.column_log_degree_bounds != proof.column_log_degree_bounds {
+            return Err(FriWrapperError::ColumnBoundsMismatch);
+        }
+
+        if inputs.config.log_blowup_factor != proof.config.log_blowup_factor
+            || inputs.config.log_last_layer_degree_bound != proof.config.log_last_layer_degree_bound
+            || inputs.config.n_queries != proof.config.n_queries
+        {
+            return Err(FriWrapperError::ConfigMismatch);
+        }
+
+        let mut channel = Blake2sChannel::default();
+        let column_bounds = proof
+            .column_log_degree_bounds
+            .iter()
+            .map(|&log_degree| CirclePolyDegreeBound::new(log_degree))
+            .collect();
+
+        let mut verifier = FriVerifier::<Blake2sMerkleChannel>::commit(
+            &mut channel,
+            proof.config,
+            proof.proof.clone(),
+            column_bounds,
+        )?;
+
+        let query_positions = verifier.sample_query_positions(&mut channel);
+        let expected_query_values = inputs.collect_query_values(&query_positions);
+        if expected_query_values != proof.query_values {
+            return Err(FriWrapperError::QueryMismatch);
+        }
+
+        verifier.decommit(proof.query_values.clone())?;
+        Ok(())
     }
 }
 
 pub fn compress_proof(proof: &FriProof) -> [u8; 32] {
     let encoded = serde_json::to_vec(proof).expect("fri proof is serialisable");
     Blake2sHasher::hash(&encoded).0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_values() -> Vec<FieldElement> {
+        vec![1u128.into(), 2u128.into(), 3u128.into(), 4u128.into()]
+    }
+
+    #[test]
+    fn roundtrip_prove_verify() {
+        let config = StwoConfig::default();
+        let values = sample_values();
+        let proof = FriProver::prove(&values, &config).expect("prove");
+        FriProver::verify(&values, &proof, &config).expect("verify");
+    }
+
+    #[test]
+    fn verification_detects_tampering() {
+        let config = StwoConfig::default();
+        let values = sample_values();
+        let mut proof = FriProver::prove(&values, &config).expect("prove");
+        proof.query_values[0][0] = SecureField::from(999u32);
+        let err = FriProver::verify(&values, &proof, &config).expect_err("verification fails");
+        assert!(matches!(err, FriWrapperError::QueryMismatch));
+    }
 }

--- a/rpp/zk/stwo/src/verifier.rs
+++ b/rpp/zk/stwo/src/verifier.rs
@@ -34,7 +34,7 @@ fn verify_witness(
         return false;
     }
     let fri_inputs = fri_inputs_from_trace(&witness_trace);
-    FriProver::verify(&fri_inputs, &proof.fri_proof)
+    FriProver::verify(&fri_inputs, &proof.fri_proof, &proof.config).is_ok()
 }
 
 pub fn verify_tx(tx: &Transaction, proof: &Proof) -> bool {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2025-07-14"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
## Summary
- add the official `stwo` prover crate and nightly toolchain metadata so the workspace can build against the upstream APIs
- replace the mock FRI code with wrappers around `stwo` that generate and verify proofs, updating the prover/verifier glue code accordingly
- expose the new types, extend helper utilities, and add regression tests for the wrapped FRI flow

## Testing
- `cargo test --manifest-path rpp/zk/stwo/Cargo.toml -- --test-threads=1`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68d9010253248326b68e082a9c217042