### PR TITLE
Implement Merkle-based FRI proofs and serialize full circuit traces

### DIFF
--- a/rpp/zk/stwo/src/circuits/identity.rs
+++ b/rpp/zk/stwo/src/circuits/identity.rs
@@ -59,6 +59,12 @@ impl IdentityWitness {
         trace_bytes.extend(self.vote_signature.as_bytes());
         let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
 
-        CircuitTrace::new(trace_commitment, constraint_commitment)
+        let trace_data = serde_json::json!({
+            "genesis": self.genesis.clone(),
+            "wallet_public_key": self.wallet_public_key.clone(),
+            "vote_signature": self.vote_signature.clone(),
+        });
+
+        CircuitTrace::new(trace_commitment, constraint_commitment, trace_data)
     }
 }

--- a/rpp/zk/stwo/src/circuits/mod.rs
+++ b/rpp/zk/stwo/src/circuits/mod.rs
@@ -11,6 +11,7 @@ pub mod reputation;
 pub mod transaction;
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Marker trait implemented by all circuit witnesses.
 pub trait CircuitWitness: Serialize + for<'de> Deserialize<'de> {
@@ -30,13 +31,20 @@ pub struct CircuitTrace {
     pub trace_commitment: [u8; 32],
     /// Additional domain specific commitment, typically Poseidon based.
     pub constraint_commitment: [u8; 32],
+    /// Full trace data used during proving for deterministic verification.
+    pub trace_data: Value,
 }
 
 impl CircuitTrace {
-    pub fn new(trace_commitment: [u8; 32], constraint_commitment: [u8; 32]) -> Self {
+    pub fn new(
+        trace_commitment: [u8; 32],
+        constraint_commitment: [u8; 32],
+        trace_data: Value,
+    ) -> Self {
         Self {
             trace_commitment,
             constraint_commitment,
+            trace_data,
         }
     }
 }

--- a/rpp/zk/stwo/src/circuits/pruning.rs
+++ b/rpp/zk/stwo/src/circuits/pruning.rs
@@ -55,6 +55,17 @@ impl PruningWitness {
         trace_bytes.extend(merkle_root);
         let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
 
-        CircuitTrace::new(trace_commitment, constraint_commitment)
+        let trace_data = serde_json::json!({
+            "inputs": self.inputs.clone(),
+            "previous_digest": hex::encode(self.inputs.previous_proof_digest),
+            "leaf_hashes": self
+                .leaf_hashes
+                .iter()
+                .map(|leaf| hex::encode(leaf))
+                .collect::<Vec<_>>(),
+            "merkle_root": hex::encode(merkle_root),
+        });
+
+        CircuitTrace::new(trace_commitment, constraint_commitment, trace_data)
     }
 }

--- a/rpp/zk/stwo/src/circuits/reputation.rs
+++ b/rpp/zk/stwo/src/circuits/reputation.rs
@@ -62,6 +62,12 @@ impl ReputationWitness {
         trace_bytes.extend(self.adjustment.to_be_bytes());
         let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
 
-        CircuitTrace::new(trace_commitment, constraint_commitment)
+        let trace_data = serde_json::json!({
+            "state": self.state.clone(),
+            "timetoken": self.timetoken,
+            "adjustment": self.adjustment,
+        });
+
+        CircuitTrace::new(trace_commitment, constraint_commitment, trace_data)
     }
 }

--- a/rpp/zk/stwo/src/circuits/transaction.rs
+++ b/rpp/zk/stwo/src/circuits/transaction.rs
@@ -79,6 +79,15 @@ impl TransactionWitness {
         trace_bytes.extend(self.ownership_seal.as_bytes());
         let trace_commitment = Blake2sHasher::hash(&trace_bytes).0;
 
-        CircuitTrace::new(trace_commitment, constraint_commitment)
+        let trace_data = serde_json::json!({
+            "transaction": self.tx.clone(),
+            "utxo_state": self.state.clone(),
+            "inputs": self.tx.inputs.clone(),
+            "outputs": self.tx.outputs.clone(),
+            "balance_sum": self.balance_sum,
+            "ownership_seal": self.ownership_seal.clone(),
+        });
+
+        CircuitTrace::new(trace_commitment, constraint_commitment, trace_data)
     }
 }


### PR DESCRIPTION
## Summary
- replace the deterministic placeholder FRI implementation with a Merkle-based proof that samples random queries and verifies Merkle openings
- store full execution trace data in circuit traces so verifiers can compare the complete witness rather than just commitments
- extend verifier unit tests to cover tampering of trace payloads and FRI proofs

## Testing
- `cargo test -p stwo`


------
https://chatgpt.com/codex/tasks/task_e_68d9770cda808326b8db7f98a2707505