### PR TITLE
feat(stwo): strengthen proof digest hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,6 +4124,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "stwo"
 version = "1.0.0"
 dependencies = [
+ "bincode",
  "blake2",
  "hex",
  "rand 0.8.5",

--- a/rpp/zk/stwo/Cargo.toml
+++ b/rpp/zk/stwo/Cargo.toml
@@ -14,6 +14,7 @@ fri = ["prover"]
 scaffold = []
 
 [dependencies]
+bincode = "1.3"
 blake2 = "0.10"
 rand = { version = "0.8", features = ["std_rng"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- hash proofs by serializing them with bincode before feeding into Poseidon and include a length prefix for unambiguous encoding
- extend the commitment pipeline to absorb trace commitments alongside public inputs
- add regression tests covering trace commitment usage and witness differences with shared prefixes/suffixes
- add the bincode dependency to the stwo crate

## Testing
- cargo test -p stwo commitment_includes_trace_commitments -- --nocapture
- cargo test -p stwo digest_distinguishes_payloads_with_shared_boundaries -- --nocapture
- cargo test -p stwo digest_distinguishes_long_witness_inputs -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d97d5e2eec832689ee825784ad1330