### PR TITLE
Integrate official STWO prover plumbing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [features]
 default = ["backend-stwo"]
-backend-stwo = ["dep:stwo", "stwo/official"]
+backend-stwo = ["dep:stwo", "stwo/prover"]
 backend-plonky3 = []
 
 [dependencies]

--- a/rpp/proofs/stwo/aggregation/mod.rs
+++ b/rpp/proofs/stwo/aggregation/mod.rs
@@ -265,7 +265,9 @@ mod tests {
     use crate::stwo::circuit::transaction::TransactionWitness;
     use crate::stwo::circuit::uptime::UptimeWitness;
     use crate::stwo::circuit::{ExecutionTrace, TraceSegment};
-    use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+    use crate::stwo::proof::{
+        CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+    };
     use crate::types::{Account, SignedTransaction, Stake, Transaction};
     use uuid::Uuid;
 
@@ -277,7 +279,7 @@ mod tests {
     }
 
     fn dummy_fri_proof() -> FriProof {
-        FriProof::empty()
+        FriProof::default()
     }
 
     fn make_proof(
@@ -292,6 +294,7 @@ mod tests {
             public_inputs: Vec::new(),
             payload,
             trace: dummy_trace(parameters),
+            commitment_proof: CommitmentSchemeProofData::default(),
             fri_proof: dummy_fri_proof(),
         }
     }

--- a/rpp/proofs/stwo/air/mod.rs
+++ b/rpp/proofs/stwo/air/mod.rs
@@ -94,6 +94,18 @@ pub struct ColumnReference {
     offset: isize,
 }
 
+impl ColumnReference {
+    /// Returns the column referenced by the expression.
+    pub fn column(&self) -> &AirColumn {
+        &self.column
+    }
+
+    /// Returns the relative row offset associated with the reference.
+    pub fn offset(&self) -> isize {
+        self.offset
+    }
+}
+
 /// Trait abstracting sources that can provide column values with row offsets.
 pub trait TraceEvaluator {
     fn value(
@@ -135,7 +147,7 @@ impl AirExpression {
         Self::Sub(Box::new(lhs), Box::new(rhs))
     }
 
-    fn evaluate<E: TraceEvaluator>(
+    pub(crate) fn evaluate<E: TraceEvaluator>(
         &self,
         view: &E,
         row: usize,
@@ -191,7 +203,7 @@ pub enum ConstraintDomain {
 }
 
 impl ConstraintDomain {
-    fn rows(&self, length: usize) -> Vec<usize> {
+    pub(crate) fn rows(&self, length: usize) -> Vec<usize> {
         match self {
             ConstraintDomain::AllRows => (0..length).collect(),
             ConstraintDomain::FirstRow => {

--- a/rpp/proofs/stwo/fri.rs
+++ b/rpp/proofs/stwo/fri.rs
@@ -1,20 +1,25 @@
-//! Deterministic FRI-style polynomial commitment scaffolding.
-//!
-//! This module provides a lightweight polynomial commitment builder that
-//! emulates the structure of a FRI prover. While it does not implement the
-//! full low-level cryptographic primitives of a production STARK backend, the
-//! scaffolding produces deterministic field-element transcripts that can be
-//! wrapped into the official STWO FRI proof structures. The resulting artifacts
-//! are embedded in [`StarkProof`](crate::stwo::proof::StarkProof) instances.
+//! Deterministic FRI proof generation backed by the official STWO prover.
 
+use crate::stwo::air::AirDefinition;
 use crate::stwo::circuit::ExecutionTrace;
-use crate::stwo::params::{FieldElement, PoseidonHasher, StarkParameters};
-use crate::stwo::proof::FriProof;
+use crate::stwo::conversions::field_to_secure;
+use crate::stwo::official_adapter::BlueprintComponent;
+use crate::stwo::params::{FieldElement, StarkParameters};
+use crate::stwo::proof::{CommitmentSchemeProofData, FriProof};
+
+use stwo::stwo_official::core::channel::{Blake2sChannel, Channel};
+use stwo::stwo_official::core::pcs::PcsConfig;
+use stwo::stwo_official::core::poly::circle::CanonicCoset;
+use stwo::stwo_official::core::vcs::blake2_merkle::Blake2sMerkleChannel;
+use stwo::stwo_official::prover::ComponentProver;
+use stwo::stwo_official::prover::backend::cpu::CpuBackend;
+use stwo::stwo_official::prover::poly::circle::PolyOps;
+use stwo::stwo_official::prover::{CommitmentSchemeProver, prove};
 
 /// Helper encapsulating the deterministic FRI-style commitment process.
 pub struct FriProver<'a> {
     parameters: &'a StarkParameters,
-    hasher: PoseidonHasher,
+    pcs_config: PcsConfig,
 }
 
 impl<'a> FriProver<'a> {
@@ -22,54 +27,60 @@ impl<'a> FriProver<'a> {
     pub fn new(parameters: &'a StarkParameters) -> Self {
         Self {
             parameters,
-            hasher: parameters.poseidon_hasher(),
+            pcs_config: PcsConfig::default(),
         }
     }
 
     /// Generate a deterministic FRI-style commitment proof for the supplied
     /// execution trace and public inputs.
-    pub fn prove(&self, trace: &ExecutionTrace, public_inputs: &[FieldElement]) -> FriProof {
-        let mut elements = Vec::new();
-        elements.extend_from_slice(public_inputs);
-
-        let challenges = self.derive_challenges(trace, public_inputs);
-        elements.extend(challenges.iter().cloned());
-
-        for segment in &trace.segments {
-            let name_element =
-                FieldElement::from_bytes(segment.name.as_bytes(), self.parameters.modulus());
-            elements.push(name_element);
-            for column in &segment.columns {
-                let column_element =
-                    FieldElement::from_bytes(column.as_bytes(), self.parameters.modulus());
-                elements.push(column_element);
-            }
-            for row in &segment.rows {
-                elements.extend(row.iter().cloned());
-            }
-        }
-
-        FriProof::from_elements(&elements)
-    }
-
-    fn derive_challenges(
+    pub fn prove(
         &self,
+        air: &AirDefinition,
         trace: &ExecutionTrace,
         public_inputs: &[FieldElement],
-    ) -> Vec<FieldElement> {
-        let mut sponge = self.hasher.sponge();
-        sponge.absorb_elements(public_inputs);
-        for segment in &trace.segments {
-            let name_element =
-                FieldElement::from_bytes(segment.name.as_bytes(), self.hasher.modulus());
-            sponge.absorb_elements(&[name_element]);
-            for column in &segment.columns {
-                let column_element =
-                    FieldElement::from_bytes(column.as_bytes(), self.hasher.modulus());
-                sponge.absorb_elements(&[column_element]);
-            }
+    ) -> FriProverOutput {
+        let component = BlueprintComponent::new(air, trace, self.parameters)
+            .expect("component adapter initialises");
+
+        let mut channel = Blake2sChannel::default();
+        let secure_inputs = public_inputs
+            .iter()
+            .map(field_to_secure)
+            .collect::<Vec<_>>();
+        channel.mix_felts(&secure_inputs);
+        self.pcs_config.mix_into(&mut channel);
+
+        let max_log = component
+            .segments
+            .iter()
+            .map(|segment| segment.log_size.max(1))
+            .max()
+            .unwrap_or(0);
+        let evaluation_log = max_log + self.pcs_config.fri_config.log_blowup_factor + 1;
+        let domain = CanonicCoset::new(evaluation_log).circle_domain();
+        let twiddles = CpuBackend::precompute_twiddles(domain.half_coset);
+
+        let mut commitment_scheme =
+            CommitmentSchemeProver::<_, Blake2sMerkleChannel>::new(self.pcs_config, &twiddles);
+        component.build_commitment_views(&mut commitment_scheme, &mut channel);
+
+        let component_refs: [&dyn ComponentProver<CpuBackend>; 1] = [&component];
+        let stark_proof = prove(&component_refs, &mut channel, commitment_scheme)
+            .expect("official prover succeeds");
+
+        let commitment_proof = CommitmentSchemeProofData::from_official(&stark_proof.0);
+        let fri_proof = FriProof::from_official(&stark_proof.0.fri_proof);
+
+        FriProverOutput {
+            commitment_proof,
+            fri_proof,
         }
-        sponge.finish_absorbing();
-        sponge.squeeze_many(2)
     }
+}
+
+/// Prover output bundling the commitment scheme and FRI proofs.
+#[derive(Clone, Debug)]
+pub struct FriProverOutput {
+    pub commitment_proof: CommitmentSchemeProofData,
+    pub fri_proof: FriProof,
 }

--- a/rpp/proofs/stwo/prover/mod.rs
+++ b/rpp/proofs/stwo/prover/mod.rs
@@ -460,6 +460,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let tx = &witness.signed_tx.payload;
         let inputs = vec![
             string_to_field(&self.parameters, &tx.from),
@@ -470,13 +473,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Transaction,
             ProofPayload::Transaction(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -490,6 +494,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let inputs = vec![
             string_to_field(&self.parameters, &witness.wallet_addr),
             string_to_field(&self.parameters, &witness.vrf_tag),
@@ -498,13 +505,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Identity,
             ProofPayload::Identity(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -518,6 +526,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let inputs = vec![
             string_to_field(&self.parameters, &witness.prev_state_root),
             string_to_field(&self.parameters, &witness.new_state_root),
@@ -526,13 +537,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::State,
             ProofPayload::State(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -546,6 +558,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let inputs = vec![
             string_to_field(&self.parameters, &witness.previous_tx_root),
             string_to_field(&self.parameters, &witness.pruned_tx_root),
@@ -554,13 +569,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Pruning,
             ProofPayload::Pruning(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -574,6 +590,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let prev = witness.previous_commitment.clone().unwrap_or_default();
         let inputs = vec![
             string_to_field(&self.parameters, &prev),
@@ -583,13 +602,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Recursive,
             ProofPayload::Recursive(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -603,6 +623,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let inputs = vec![
             string_to_field(&self.parameters, &witness.wallet_address),
             self.parameters.element_from_u64(witness.node_clock),
@@ -614,13 +637,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Uptime,
             ProofPayload::Uptime(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }
@@ -634,6 +658,9 @@ impl<'a> WalletProver<'a> {
         circuit
             .verify_air(&self.parameters, &trace)
             .map_err(map_circuit_error)?;
+        let air = circuit
+            .define_air(&self.parameters, &trace)
+            .map_err(map_circuit_error)?;
         let inputs = vec![
             string_to_field(&self.parameters, &witness.block_hash),
             self.parameters.element_from_u64(witness.round),
@@ -642,13 +669,14 @@ impl<'a> WalletProver<'a> {
         ];
         let hasher = self.hasher();
         let fri_prover = FriProver::new(&self.parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         Ok(StarkProof::new(
             ProofKind::Consensus,
             ProofPayload::Consensus(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         ))
     }

--- a/rpp/proofs/stwo/tests/adapter.rs
+++ b/rpp/proofs/stwo/tests/adapter.rs
@@ -2,29 +2,35 @@ use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, C
 use crate::stwo::circuit::{ExecutionTrace, TraceSegment};
 use crate::stwo::conversions::{field_to_base, field_to_secure};
 use crate::stwo::official_adapter::{BlueprintComponent, ColumnVec, TreeVec};
+#[cfg(feature = "backend-stwo")]
+use crate::stwo::official_adapter::{Component, ComponentProver};
 use crate::stwo::params::{FieldElement, StarkParameters};
 
-#[cfg(feature = "stwo/prover")]
-use num_traits::Zero;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
+use num_traits::{One, Zero};
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::air::accumulation::PointEvaluationAccumulator;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::circle::CirclePoint;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::constraints::point_vanishing;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::fields::m31::BaseField;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::fields::qm31::SecureField;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
+use stwo::stwo_official::core::fields::FieldExpOps;
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::core::poly::circle::CanonicCoset;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::prover::DomainEvaluationAccumulator;
-#[cfg(feature = "stwo/prover")]
-use stwo::stwo_official::prover::air::component_prover::Trace;
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
+use stwo::stwo_official::prover::Trace;
+#[cfg(feature = "backend-stwo")]
+use stwo::stwo_official::prover::poly::circle::PolyOps;
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::prover::backend::cpu::{CpuBackend, CpuCircleEvaluation, CpuCirclePoly};
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 use stwo::stwo_official::prover::poly::{BitReversedOrder, NaturalOrder};
 
 fn constant_segment(
@@ -49,7 +55,7 @@ fn constant_segment(
     TraceSegment::new(name, columns, rows).expect("valid segment")
 }
 
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 fn build_mask_values(
     trace: &ExecutionTrace,
     component: &BlueprintComponent,
@@ -76,7 +82,7 @@ fn build_mask_values(
     TreeVec(trees)
 }
 
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 #[test]
 fn point_quotients_match_blueprint_evaluations() {
     let parameters = StarkParameters::blueprint_default();
@@ -126,7 +132,7 @@ fn point_quotients_match_blueprint_evaluations() {
     }
 }
 
-#[cfg(feature = "stwo/prover")]
+#[cfg(feature = "backend-stwo")]
 #[test]
 fn domain_quotients_align_with_blueprint_trace() {
     let parameters = StarkParameters::blueprint_default();
@@ -198,7 +204,7 @@ fn domain_quotients_align_with_blueprint_trace() {
     let eval_domain = CanonicCoset::new(composition.log_size()).circle_domain();
     let twiddles = CpuBackend::precompute_twiddles(eval_domain.half_coset);
     let aggregated = composition.evaluate_with_twiddles(eval_domain, &twiddles);
-    for value in aggregated.values.to_vec() {
+    for value in aggregated.values.to_cpu().to_vec() {
         assert_eq!(value, secure_zero);
     }
 

--- a/rpp/proofs/stwo/verifier/mod.rs
+++ b/rpp/proofs/stwo/verifier/mod.rs
@@ -70,11 +70,16 @@ impl NodeVerifier {
         proof: &StarkProof,
         public_inputs: &[FieldElement],
         trace: &ExecutionTrace,
+        air: &super::air::AirDefinition,
     ) -> ChainResult<()> {
         let fri_prover = FriProver::new(&self.parameters);
-        let expected = fri_prover.prove(trace, public_inputs);
-        if proof.fri_proof != expected {
-            return Err(ChainError::Crypto("fri proof mismatch".into()));
+        let expected = fri_prover.prove(air, trace, public_inputs);
+        if proof.fri_proof != expected.fri_proof
+            || proof.commitment_proof != expected.commitment_proof
+        {
+            return Err(ChainError::Crypto(
+                "fri or commitment proof mismatch".into(),
+            ));
         }
         Ok(())
     }
@@ -118,8 +123,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto(
                 "transaction proof payload mismatch".into(),
@@ -139,8 +147,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto("identity proof payload mismatch".into()))
         }
@@ -158,8 +169,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto("state proof payload mismatch".into()))
         }
@@ -177,8 +191,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto("pruning proof payload mismatch".into()))
         }
@@ -196,8 +213,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto(
                 "recursive proof payload mismatch".into(),
@@ -217,8 +237,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto("uptime proof payload mismatch".into()))
         }
@@ -236,8 +259,11 @@ impl NodeVerifier {
             circuit
                 .verify_air(&self.parameters, &trace)
                 .map_err(map_circuit_error)?;
+            let air = circuit
+                .define_air(&self.parameters, &trace)
+                .map_err(map_circuit_error)?;
             self.check_trace(trace.clone(), proof)?;
-            self.check_fri(proof, &public_inputs, &trace)
+            self.check_fri(proof, &public_inputs, &trace, &air)
         } else {
             Err(ChainError::Crypto(
                 "consensus proof payload mismatch".into(),

--- a/rpp/runtime/sync.rs
+++ b/rpp/runtime/sync.rs
@@ -478,7 +478,9 @@ mod tests {
     use crate::stwo::circuit::{
         pruning::PruningWitness, recursive::RecursiveWitness, state::StateWitness,
     };
-    use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+    use crate::stwo::proof::{
+        CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+    };
     use crate::types::{Account, BlockHeader, PruningProof, RecursiveProof, Stake};
     use ed25519_dalek::{Keypair, Signer};
     use rand::rngs::OsRng;
@@ -533,7 +535,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 
@@ -551,7 +554,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 
@@ -586,7 +590,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 

--- a/rpp/runtime/types/proofs.rs
+++ b/rpp/runtime/types/proofs.rs
@@ -99,7 +99,9 @@ mod tests {
         use super::super::ChainProof;
         use crate::stwo::circuit::ExecutionTrace;
         use crate::stwo::circuit::recursive::RecursiveWitness;
-        use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+        use crate::stwo::proof::{
+            CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+        };
 
         fn sample_stwo_proof() -> StarkProof {
             let witness = RecursiveWitness {
@@ -127,7 +129,8 @@ mod tests {
                 trace: ExecutionTrace {
                     segments: Vec::new(),
                 },
-                fri_proof: FriProof::empty(),
+                commitment_proof: CommitmentSchemeProofData::default(),
+                fri_proof: FriProof::default(),
             }
         }
 

--- a/rpp/storage/ledger.rs
+++ b/rpp/storage/ledger.rs
@@ -1302,13 +1302,17 @@ mod tests {
         ];
         let hasher = parameters.poseidon_hasher();
         let fri_prover = FriProver::new(&parameters);
-        let fri_proof = fri_prover.prove(&trace, &inputs);
+        let air = circuit
+            .define_air(&parameters, &trace)
+            .expect("air definition");
+        let fri_output = fri_prover.prove(&air, &trace, &inputs);
         let proof = StarkProof::new(
             ProofKind::Identity,
             ProofPayload::Identity(witness),
             inputs,
             trace,
-            fri_proof,
+            fri_output.commitment_proof,
+            fri_output.fri_proof,
             &hasher,
         );
         IdentityDeclaration {

--- a/rpp/storage/migration.rs
+++ b/rpp/storage/migration.rs
@@ -259,7 +259,9 @@ mod tests {
         state::StateWitness,
         uptime::UptimeWitness,
     };
-    use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+    use crate::stwo::proof::{
+        CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+    };
     use crate::types::ChainProof;
     use ed25519_dalek::Signer;
     use tempfile::tempdir;
@@ -294,7 +296,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         })
     }
 
@@ -380,7 +383,8 @@ mod tests {
                 TraceSegment::new("dummy", vec!["column".to_string()], Vec::new()).unwrap(),
             )
             .unwrap(),
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 

--- a/rpp/storage/mod.rs
+++ b/rpp/storage/mod.rs
@@ -485,7 +485,9 @@ mod tests {
     use crate::stwo::circuit::{
         ExecutionTrace, pruning::PruningWitness, recursive::RecursiveWitness, state::StateWitness,
     };
-    use crate::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+    use crate::stwo::proof::{
+        CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+    };
     use crate::types::{
         Block, BlockHeader, BlockMetadata, BlockProofBundle, ChainProof, PruningProof,
         RecursiveProof,
@@ -512,7 +514,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 
@@ -530,7 +533,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 
@@ -565,7 +569,8 @@ mod tests {
             trace: ExecutionTrace {
                 segments: Vec::new(),
             },
-            fri_proof: FriProof::empty(),
+            commitment_proof: CommitmentSchemeProofData::default(),
+            fri_proof: FriProof::default(),
         }
     }
 

--- a/rpp/zk/stwo/vendor/stwo-dev/crates/stwo/src/prover/backend/simd/circle.rs
+++ b/rpp/zk/stwo/vendor/stwo-dev/crates/stwo/src/prover/backend/simd/circle.rs
@@ -182,29 +182,28 @@ impl PolyOps for SimdBackend {
         // of the current index. For every 2^n aligned chunk of 2^n elements, the twiddle
         // array is the same, denoted twiddle_low. Use this to compute sums of (coeff *
         // twiddle_high) mod 2^n, then multiply by twiddle_low, and sum to get the final result.
-        let compute_chunk_sum = |coeff_chunk: &[PackedBaseField],
-                                 twiddle_mids: PackedSecureField,
-                                 offset: usize| {
-            let mut sum = PackedSecureField::zeroed();
-            let mut twiddle_high = Self::twiddle_at(&mappings, offset * N_LANES);
-            for (i, coeff_chunk) in coeff_chunk.array_chunks::<N_LANES>().enumerate() {
-                // For every chunk of 2 ^ 4 * 2 ^ 4 = 2 ^ 8 elements, the twiddle high is the same.
-                // Multiply it by every mid twiddle factor to get the factors for the current chunk.
-                let high_twiddle_factors =
-                    (PackedSecureField::broadcast(twiddle_high) * twiddle_mids).to_array();
+        let compute_chunk_sum =
+            |coeff_chunk: &[PackedBaseField], twiddle_mids: PackedSecureField, offset: usize| {
+                let mut sum = PackedSecureField::zeroed();
+                let mut twiddle_high = Self::twiddle_at(&mappings, offset * N_LANES);
+                for (i, coeff_chunk) in coeff_chunk.array_chunks::<N_LANES>().enumerate() {
+                    // For every chunk of 2 ^ 4 * 2 ^ 4 = 2 ^ 8 elements, the twiddle high is the same.
+                    // Multiply it by every mid twiddle factor to get the factors for the current chunk.
+                    let high_twiddle_factors =
+                        (PackedSecureField::broadcast(twiddle_high) * twiddle_mids).to_array();
 
-                // Sum the coefficients multiplied by each corrseponsing twiddle. Result is
-                // effectively an array[16] where the value at index 'i' is the sum
-                // of all coefficients at indices that are i mod 16.
-                for (&packed_coeffs, mid_twiddle) in zip(coeff_chunk, high_twiddle_factors) {
-                    sum += PackedSecureField::broadcast(mid_twiddle) * packed_coeffs;
+                    // Sum the coefficients multiplied by each corrseponsing twiddle. Result is
+                    // effectively an array[16] where the value at index 'i' is the sum
+                    // of all coefficients at indices that are i mod 16.
+                    for (&packed_coeffs, mid_twiddle) in zip(coeff_chunk, high_twiddle_factors) {
+                        sum += PackedSecureField::broadcast(mid_twiddle) * packed_coeffs;
+                    }
+
+                    // Advance twiddle high.
+                    twiddle_high = Self::advance_twiddle(twiddle_high, &twiddle_steps, offset + i);
                 }
-
-                // Advance twiddle high.
-                twiddle_high = Self::advance_twiddle(twiddle_high, &twiddle_steps, offset + i);
-            }
-            sum
-        };
+                sum
+            };
 
         #[cfg(not(feature = "parallel"))]
         let sum = compute_chunk_sum(&poly.coeffs.data, twiddle_mids, 0);

--- a/tests/end_to_end_rpc.rs
+++ b/tests/end_to_end_rpc.rs
@@ -15,7 +15,9 @@ use rpp_chain::reputation::{ReputationWeights, Tier};
 use rpp_chain::runtime::RuntimeMode;
 use rpp_chain::stwo::circuit::ExecutionTrace;
 use rpp_chain::stwo::circuit::transaction::TransactionWitness;
-use rpp_chain::stwo::proof::{FriProof, ProofKind, ProofPayload, StarkProof};
+use rpp_chain::stwo::proof::{
+    CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+};
 use rpp_chain::types::{
     Account, ChainProof, SignedTransaction, Stake, Transaction, TransactionProofBundle,
 };
@@ -160,7 +162,8 @@ fn sample_transaction_bundle(to: &str) -> TransactionProofBundle {
         trace: ExecutionTrace {
             segments: Vec::new(),
         },
-        fri_proof: FriProof::empty(),
+        commitment_proof: CommitmentSchemeProofData::default(),
+        fri_proof: FriProof::default(),
     };
 
     TransactionProofBundle::new(signed_tx, ChainProof::Stwo(proof))

--- a/tests/zsi_renewal.rs
+++ b/tests/zsi_renewal.rs
@@ -98,13 +98,17 @@ fn sample_identity_declaration(ledger: &Ledger) -> IdentityDeclaration {
     ];
     let hasher = parameters.poseidon_hasher();
     let prover = FriProver::new(&parameters);
-    let proof = prover.prove(&trace, &inputs);
+    let air = circuit
+        .define_air(&parameters, &trace)
+        .expect("air definition");
+    let proof = prover.prove(&air, &trace, &inputs);
     let stark = StarkProof::new(
         ProofKind::Identity,
         ProofPayload::Identity(witness),
         inputs,
         trace,
-        proof,
+        proof.commitment_proof,
+        proof.fri_proof,
         &hasher,
     );
     IdentityDeclaration {


### PR DESCRIPTION
## Summary
- store the official prover's commitment scheme proof alongside real FRI data in `StarkProof`
- adapt the STWO blueprint adapter to drive `CommitmentSchemeProver`/`prove` using only the public prover APIs
- update runtime, storage, and tests to serialize the new proof payloads and drop the fake helpers

## Testing
- RUSTC_BOOTSTRAP=1 cargo check
- RUSTC_BOOTSTRAP=1 cargo test *(partially executed; aborted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68da4ad773808326af40eeb4035c7318