### PR TITLE
Add official integration test module scaffolding

### DIFF
--- a/rpp/proofs/stwo/tests/mod.rs
+++ b/rpp/proofs/stwo/tests/mod.rs
@@ -1,1 +1,4 @@
 mod adapter;
+
+#[cfg(feature = "backend-stwo")]
+mod official_integration;

--- a/rpp/proofs/stwo/tests/official_integration.rs
+++ b/rpp/proofs/stwo/tests/official_integration.rs
@@ -1,0 +1,15 @@
+#![cfg(feature = "backend-stwo")]
+
+#[allow(unused_imports)]
+use super::*;
+
+#[allow(unused_imports)]
+use crate::stwo::air::{AirDefinition, AirExpression, ConstraintDomain};
+#[allow(unused_imports)]
+use crate::stwo::circuit::ExecutionTrace;
+#[allow(unused_imports)]
+use crate::stwo::fri::FriProver;
+#[allow(unused_imports)]
+use crate::stwo::official_adapter::{BlueprintComponent, Component, ComponentProver};
+#[allow(unused_imports)]
+use crate::stwo::params::{FieldElement, StarkParameters};


### PR DESCRIPTION
## Summary
- gate the new official integration tests module behind the `backend-stwo` feature
- add scaffolded imports for upcoming official integration tests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7d2ca1c483269e26153dad0ff0bc