### PR TITLE
Document STWO fixture regeneration and gate tests

### DIFF
--- a/rpp/proofs/stwo/tests/official_integration.rs
+++ b/rpp/proofs/stwo/tests/official_integration.rs
@@ -153,6 +153,11 @@ fn recorded_transaction_proof_generation_succeeds() {
     }
 }
 
+/// Rerun [`recorded_transaction_proof_generation_succeeds`] with
+/// `STWO_DUMP_VALID_PROOF=1` to regenerate
+/// `rpp/proofs/stwo/tests/vectors/valid_proof.json`. The helper constructs a
+/// deterministic prover environment so the refreshed fixture remains
+/// reproducible.
 fn dump_valid_proof_fixture(proof: &StarkProof) {
     const ENV_FLAG: &str = "STWO_DUMP_VALID_PROOF";
     if std::env::var_os(ENV_FLAG).is_none() {

--- a/rpp/proofs/stwo/tests/valid_proof.rs
+++ b/rpp/proofs/stwo/tests/valid_proof.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "backend-stwo")]
+
 use crate::stwo::air::AirDefinition;
 use crate::stwo::circuit::{ExecutionTrace, StarkCircuit};
 use crate::stwo::circuit::transaction::TransactionCircuit;


### PR DESCRIPTION
## Summary
- gate the STWO valid proof fixture tests behind the backend-stwo feature at the module level
- document how to regenerate the deterministic valid_proof.json fixture from the official integration helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9cb38c1883268e44e4e6d4a3ba84