### PR TITLE
Pin nightly Rust toolchain and document requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+- Use the repository's pinned `nightly-2024-06-20` toolchain. `rustup` automatically selects it via `rust-toolchain.toml`, so avoid overriding the channel in local configuration.
+- Install required nightly components (rustfmt and clippy) through `rustup component add --toolchain nightly-2024-06-20` to keep formatting and linting aligned with CI.
+- Run formatting, linting, and test scripts before submitting changes to ensure parity with automation.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration Guide
+
+## Switching from Nightly to Stable
+
+1. Run the full validation suite on the existing nightly toolchain, including formatting (`cargo fmt --check`), linting (`cargo clippy --all-targets --all-features -- -D warnings`), and the project's test scripts, to capture any regressions ahead of the migration.
+2. Update dependencies or code as needed to resolve nightly-only features identified by the validation passes.
+3. Once the codebase is stable-friendly, edit `rust-toolchain.toml` to point to the desired stable release channel. If the project no longer requires a pinned toolchain, remove the file entirely so that contributors fall back to their default Rust installation.
+4. Communicate the change to the team, including any newly required components or workflows, and confirm CI is running against the stable channel before merging the migration.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It integrates:
 - Configurable block cadence, mempool sizing, and genesis allocation via TOML configuration.
 - Iterative rollout controls with feature gates and telemetry sampling for staged deployments.
 
+## Build Requirements
+
+This workspace is pinned to `nightly-2024-06-20` via `rust-toolchain.toml`. Install the matching toolchain along with the bundled `rustfmt` and `clippy` components before building locally to ensure consistent formatting and lint coverage.
+
 ## Getting Started
 
 ### Prerequisites

--- a/docs/development/tooling.md
+++ b/docs/development/tooling.md
@@ -1,0 +1,6 @@
+# Tooling
+
+The pinned Rust toolchain requires the following components to be installed:
+
+- rustfmt
+- clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-06-20"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- pin the workspace to nightly-2024-06-20 with rustfmt and clippy components
- document the pinned toolchain requirements across contributor and migration guides
- describe required tooling components for developers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dacb991968832680260f0cb15b0151