### PR TITLE
Refactor prover backend configuration and interface usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["backend-stwo"]
-backend-stwo = ["dep:stwo", "stwo/prover"]
+default = ["prover-stwo"]
+prover-stwo = [
+    "dep:stwo",
+    "prover-backend-interface/prover-stwo",
+    "stwo/prover-stwo",
+]
+prover-mock = [
+    "dep:prover_mock_backend",
+    "prover-backend-interface/prover-mock",
+    "prover_mock_backend/prover-mock",
+]
 backend-plonky3 = []
-backend-mock = ["dep:prover_mock_backend"]
 
 [dependencies]
 anyhow = "1.0"

--- a/docs/architecture/prover-backends.md
+++ b/docs/architecture/prover-backends.md
@@ -6,7 +6,7 @@ workspace and the contracts that tie them together.
 ## Workspace entry points
 
 The root crate `rpp-chain` exposes prover functionality behind feature flags.
-`backend-stwo` enables the nightly STWO integration, while `backend-mock`
+`prover-stwo` enables the nightly STWO integration, while `prover-mock`
 selects the stable mock implementation.  Both use the shared
 `prover-backend-interface` dependency, and the STWO backend is wired in via the
 `stwo` alias so existing modules can keep their imports.【F:Cargo.toml†L6-L33】

--- a/rpp/consensus/node.rs
+++ b/rpp/consensus/node.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use malachite::Natural;
 use malachite::base::num::arithmetic::traits::DivRem;
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::crypto::{
     VrfPublicKey, VrfSecretKey, address_from_public_key, public_key_from_hex, signature_from_hex,

--- a/rpp/consensus/src/lib.rs
+++ b/rpp/consensus/src/lib.rs
@@ -1,5 +1,10 @@
 use std::fmt;
 
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
+pub use prover_backend_interface as proof_backend;
+
 pub mod bft_loop;
 pub mod evidence;
 pub mod leader;

--- a/rpp/crypto/mod.rs
+++ b/rpp/crypto/mod.rs
@@ -9,7 +9,7 @@ use schnorrkel::keys::{
     ExpansionMode, Keypair as VrfKeypairInner, MiniSecretKey, PublicKey as SrPublicKey,
 };
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::errors::{ChainError, ChainResult};
 

--- a/rpp/crypto/vrf/mod.rs
+++ b/rpp/crypto/vrf/mod.rs
@@ -18,7 +18,7 @@ use malachite::base::num::arithmetic::traits::DivRem;
 use schnorrkel::signing_context;
 use schnorrkel::vrf::{VRFPreOut, VRFProof};
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 use thiserror::Error;
 
 /// Poseidon domain separator used for deriving VRF inputs.

--- a/rpp/node/Cargo.toml
+++ b/rpp/node/Cargo.toml
@@ -3,9 +3,15 @@ name = "rpp-node"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["prover-stwo"]
+prover-stwo = ["prover-backend-interface/prover-stwo"]
+prover-mock = ["prover-backend-interface/prover-mock"]
+
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "signal", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+prover-backend-interface = { path = "../zk/backend-interface" }

--- a/rpp/node/src/lib.rs
+++ b/rpp/node/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
+pub use prover_backend_interface as proof_backend;

--- a/rpp/proofs/rpp.rs
+++ b/rpp/proofs/rpp.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use blake2::{Blake2s256, Digest};
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::errors::{ChainError, ChainResult};
 use crate::proof_backend::{

--- a/rpp/proofs/stwo/circuit/identity.rs
+++ b/rpp/proofs/stwo/circuit/identity.rs
@@ -53,7 +53,7 @@ impl IdentityCircuit {
             ChainError::Transaction(format!("invalid wallet public key encoding: {err}"))
         })?;
         Ok(hex::encode::<[u8; 32]>(
-            stwo::core::vcs::blake2_hash::Blake2sHasher::hash(&pk_bytes).into(),
+            crate::proof_backend::Blake2sHasher::hash(&pk_bytes).into(),
         ))
     }
 

--- a/rpp/proofs/stwo/circuit/state.rs
+++ b/rpp/proofs/stwo/circuit/state.rs
@@ -48,7 +48,7 @@ impl StateCircuit {
             .iter()
             .map(|account| {
                 let bytes = serde_json::to_vec(account).expect("serialize account");
-                <[u8; 32]>::from(stwo::core::vcs::blake2_hash::Blake2sHasher::hash(
+                <[u8; 32]>::from(crate::proof_backend::Blake2sHasher::hash(
                     bytes.as_slice(),
                 ))
             })

--- a/rpp/proofs/stwo/official_adapter.rs
+++ b/rpp/proofs/stwo/official_adapter.rs
@@ -8,7 +8,7 @@
 //! subsequent trait implementations to bridge the lightweight blueprint models
 //! with the official prover APIs.
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 
@@ -22,7 +22,7 @@ use super::{
 };
 use stwo::stwo_official::core::fields::m31::BaseField;
 use stwo::stwo_official::core::fields::qm31::{SECURE_EXTENSION_DEGREE, SecureField};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::{
     air::accumulation::PointEvaluationAccumulator,
     circle::CirclePoint,
@@ -33,29 +33,29 @@ use stwo::stwo_official::core::{
 /// so that downstream modules can rely on them without repetitive imports.
 pub use stwo::stwo_official::core::{ColumnVec, air::Component, pcs::TreeVec};
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use num_traits::{One, Zero};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::channel::MerkleChannel;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::fields::FieldExpOps;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::poly::circle::{CanonicCoset, CircleDomain};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::utils::{
     bit_reverse_index, offset_bit_reversed_circle_domain_index,
 };
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 pub use stwo::stwo_official::prover::poly::circle::CircleEvaluation;
 /// Re-export prover-side structures when the upstream dependency exposes them.
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 pub use stwo::stwo_official::prover::{
     CommitmentSchemeProver, CommitmentTreeProver, ComponentProver, ComponentProvers,
     DomainEvaluationAccumulator, Trace, TreeBuilder, backend::cpu::CpuBackend,
 };
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::{backend::BackendForChannel, poly::circle::PolyOps};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::{
     backend::cpu::{CpuCircleEvaluation, CpuCirclePoly},
     poly::twiddles::TwiddleTree,
@@ -98,14 +98,14 @@ pub struct SegmentDescriptor<'a> {
     pub column_indices: HashMap<&'a str, usize>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 #[derive(Debug, Default)]
 struct ColumnMask {
     offsets: Vec<isize>,
     positions: HashMap<isize, usize>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl ColumnMask {
     fn new(offsets: Vec<isize>) -> Self {
         let mut unique = offsets;
@@ -147,7 +147,7 @@ pub struct BlueprintComponent<'a> {
     pub segments: Vec<SegmentDescriptor<'a>>,
     /// Quick lookup from segment name to descriptor index.
     pub segment_lookup: HashMap<&'a str, usize>,
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     column_masks: Vec<Vec<ColumnMask>>,
 }
 
@@ -167,7 +167,7 @@ impl<'a> BlueprintComponent<'a> {
             segments.push(build_descriptor(segment)?);
         }
 
-        #[cfg(feature = "backend-stwo")]
+        #[cfg(feature = "prover-stwo")]
         let column_masks = build_column_masks(air, &segments, &segment_lookup);
 
         Ok(Self {
@@ -176,7 +176,7 @@ impl<'a> BlueprintComponent<'a> {
             parameters,
             segments,
             segment_lookup,
-            #[cfg(feature = "backend-stwo")]
+            #[cfg(feature = "prover-stwo")]
             column_masks,
         })
     }
@@ -188,7 +188,7 @@ impl<'a> BlueprintComponent<'a> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn build_column_masks<'a>(
     air: &'a AirDefinition,
     segments: &[SegmentDescriptor<'a>],
@@ -219,7 +219,7 @@ fn build_column_masks<'a>(
         .collect()
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn collect_expression_offsets<'a>(
     expression: &AirExpression,
     segments: &[SegmentDescriptor<'a>],
@@ -261,12 +261,12 @@ where
     column_to_base(column)
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn segment_tree_index(segment_index: usize) -> usize {
     segment_index + 1
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn secure_to_field(parameters: &StarkParameters, value: &SecureField) -> FieldElement {
     let limbs = value.to_m31_array();
     let mut bytes = [0u8; 4 * SECURE_EXTENSION_DEGREE];
@@ -278,14 +278,14 @@ fn secure_to_field(parameters: &StarkParameters, value: &SecureField) -> FieldEl
     parameters.element_from_bytes(&bytes)
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 struct MaskTraceView<'a, 'm> {
     component: &'a BlueprintComponent<'a>,
     parameters: &'a StarkParameters,
     mask: &'m TreeVec<ColumnVec<Vec<SecureField>>>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a, 'm> MaskTraceView<'a, 'm> {
     fn new(
         component: &'a BlueprintComponent<'a>,
@@ -300,7 +300,7 @@ impl<'a, 'm> MaskTraceView<'a, 'm> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a, 'm> TraceEvaluator for MaskTraceView<'a, 'm> {
     fn value(
         &self,
@@ -336,13 +336,13 @@ impl<'a, 'm> TraceEvaluator for MaskTraceView<'a, 'm> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 enum ColumnDomainValues<'a> {
     Borrowed(&'a [BaseField]),
     Owned(Vec<BaseField>),
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a> ColumnDomainValues<'a> {
     fn len(&self) -> usize {
         match self {
@@ -359,14 +359,14 @@ impl<'a> ColumnDomainValues<'a> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 struct SegmentDomainValues<'a, 't> {
     descriptor: &'a SegmentDescriptor<'a>,
     log_size: u32,
     columns: Vec<ColumnDomainValues<'t>>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 struct DomainTraceView<'a, 't> {
     component: &'a BlueprintComponent<'a>,
     parameters: &'a StarkParameters,
@@ -374,7 +374,7 @@ struct DomainTraceView<'a, 't> {
     segments: Vec<SegmentDomainValues<'a, 't>>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a, 't> DomainTraceView<'a, 't> {
     fn new(
         component: &'a BlueprintComponent<'a>,
@@ -423,7 +423,7 @@ impl<'a, 't> DomainTraceView<'a, 't> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a, 't> TraceEvaluator for DomainTraceView<'a, 't> {
     fn value(
         &self,
@@ -460,7 +460,7 @@ impl<'a, 't> TraceEvaluator for DomainTraceView<'a, 't> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn map_domain_index(
     row: usize,
     offset: isize,
@@ -486,7 +486,7 @@ fn map_domain_index(
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn domain_vanishing(
     descriptor: &SegmentDescriptor<'_>,
     domain: &ConstraintDomain,
@@ -565,7 +565,7 @@ fn ceil_log2(value: usize) -> u32 {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn segment_to_circle_evals(
     segment: &TraceSegment,
     descriptor: &SegmentDescriptor<'_>,
@@ -584,14 +584,14 @@ fn segment_to_circle_evals(
         .collect()
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 #[derive(Debug)]
 pub struct TraceCommitmentViews<'a> {
     pub polynomials: TreeVec<ColumnVec<&'a CpuCirclePoly>>,
     pub evaluations: TreeVec<ColumnVec<&'a CpuCircleEvaluation<BaseField, BitReversedOrder>>>,
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a> BlueprintComponent<'a> {
     pub fn build_commitment_views<'b, 'c, MC: MerkleChannel>(
         &self,
@@ -618,7 +618,7 @@ impl<'a> BlueprintComponent<'a> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn prepend_preprocessed_tree<T>(views: TreeVec<ColumnVec<T>>) -> TreeVec<ColumnVec<T>> {
     let mut trees = Vec::with_capacity(views.len() + 1);
     trees.push(Vec::new());
@@ -626,7 +626,7 @@ fn prepend_preprocessed_tree<T>(views: TreeVec<ColumnVec<T>>) -> TreeVec<ColumnV
     TreeVec(trees)
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a> Component for BlueprintComponent<'a> {
     fn n_constraints(&self) -> usize {
         self.air.constraints().len()
@@ -722,7 +722,7 @@ impl<'a> Component for BlueprintComponent<'a> {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 impl<'a> ComponentProver<CpuBackend> for BlueprintComponent<'a> {
     fn evaluate_constraint_quotients_on_domain(
         &self,
@@ -816,11 +816,11 @@ mod tests {
     };
     use crate::stwo::circuit::TraceSegment;
     use crate::stwo::conversions::column_to_secure;
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     use stwo::stwo_official::core::fields::m31::BaseField;
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     use stwo::stwo_official::core::fields::qm31::SecureField;
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     use stwo::stwo_official::prover::{DomainEvaluationAccumulator, Trace};
 
     fn sample_segment(name: &str, columns: usize, rows: usize) -> TraceSegment {
@@ -846,7 +846,7 @@ mod tests {
         assert_eq!(secure_values.len(), 3);
     }
 
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     #[test]
     fn segment_evaluations_pad_to_power_of_two() {
         use num_traits::Zero;
@@ -864,7 +864,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     #[test]
     fn component_handles_single_row_segments() {
         let params = StarkParameters::blueprint_default();

--- a/rpp/proofs/stwo/tests/adapter.rs
+++ b/rpp/proofs/stwo/tests/adapter.rs
@@ -2,35 +2,35 @@ use crate::stwo::air::{AirColumn, AirConstraint, AirDefinition, AirExpression, C
 use crate::stwo::circuit::{ExecutionTrace, TraceSegment};
 use crate::stwo::conversions::{field_to_base, field_to_secure};
 use crate::stwo::official_adapter::{BlueprintComponent, ColumnVec, TreeVec};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use crate::stwo::official_adapter::{Component, ComponentProver};
 use crate::stwo::params::{FieldElement, StarkParameters};
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use num_traits::{One, Zero};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::air::accumulation::PointEvaluationAccumulator;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::circle::CirclePoint;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::constraints::point_vanishing;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::fields::FieldExpOps;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::fields::m31::BaseField;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::fields::qm31::SecureField;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::core::poly::circle::CanonicCoset;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::DomainEvaluationAccumulator;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::Trace;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::backend::cpu::{CpuBackend, CpuCircleEvaluation, CpuCirclePoly};
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::poly::circle::PolyOps;
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 use stwo::stwo_official::prover::poly::{BitReversedOrder, NaturalOrder};
 
 fn constant_segment(
@@ -55,7 +55,7 @@ fn constant_segment(
     TraceSegment::new(name, columns, rows).expect("valid segment")
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 fn build_mask_values(
     trace: &ExecutionTrace,
     component: &BlueprintComponent,
@@ -82,7 +82,7 @@ fn build_mask_values(
     TreeVec(trees)
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 #[test]
 fn point_quotients_match_blueprint_evaluations() {
     let parameters = StarkParameters::blueprint_default();
@@ -132,7 +132,7 @@ fn point_quotients_match_blueprint_evaluations() {
     }
 }
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 #[test]
 fn domain_quotients_align_with_blueprint_trace() {
     let parameters = StarkParameters::blueprint_default();

--- a/rpp/proofs/stwo/tests/mod.rs
+++ b/rpp/proofs/stwo/tests/mod.rs
@@ -1,7 +1,7 @@
 mod adapter;
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 mod official_integration;
 
-#[cfg(feature = "backend-stwo")]
+#[cfg(feature = "prover-stwo")]
 mod valid_proof;

--- a/rpp/proofs/stwo/tests/official_integration.rs
+++ b/rpp/proofs/stwo/tests/official_integration.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "backend-stwo")]
+#![cfg(feature = "prover-stwo")]
 
 #[allow(unused_imports)]
 use super::*;

--- a/rpp/proofs/stwo/tests/valid_proof.rs
+++ b/rpp/proofs/stwo/tests/valid_proof.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "backend-stwo")]
+#![cfg(feature = "prover-stwo")]
 
 use crate::stwo::air::AirDefinition;
 use crate::stwo::circuit::{ExecutionTrace, StarkCircuit};

--- a/rpp/reputation/mod.rs
+++ b/rpp/reputation/mod.rs
@@ -8,7 +8,7 @@ use crate::types::Address;
 use hex;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 use thiserror::Error;
 
 /// Configuration weights used to evaluate the reputation score. The values

--- a/rpp/runtime/node.rs
+++ b/rpp/runtime/node.rs
@@ -67,7 +67,7 @@ use crate::vrf::{
     self, PoseidonVrfInput, VrfEpochManager, VrfProof, VrfSubmission, VrfSubmissionPool,
 };
 use rpp_p2p::{HandshakePayload, NodeIdentity, TierLevel, VRF_HANDSHAKE_CONTEXT};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 const BASE_BLOCK_REWARD: u64 = 5;
 const LEADER_BONUS_PERCENT: u8 = 20;
@@ -551,7 +551,7 @@ mod tests {
     use crate::vrf::{self, PoseidonVrfInput, VrfProof, VrfSubmission, VrfSubmissionPool};
     use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signer};
     use malachite::Natural;
-    use stwo::core::vcs::blake2_hash::Blake2sHasher;
+    use crate::proof_backend::Blake2sHasher;
     use tempfile::tempdir;
     use tracing_test::traced_test;
 

--- a/rpp/runtime/types/account.rs
+++ b/rpp/runtime/types/account.rs
@@ -12,7 +12,7 @@ use hex;
 
 use super::Address;
 
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct IdentityBinding {

--- a/rpp/runtime/types/block.rs
+++ b/rpp/runtime/types/block.rs
@@ -8,7 +8,7 @@ use hex;
 use ed25519_dalek::{PublicKey, Signature};
 use malachite::Natural;
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::consensus::{BftVoteKind, ConsensusCertificate, SignedBftVote, verify_vrf};
 use crate::crypto::{
@@ -478,7 +478,7 @@ impl RecursiveProof {
         Ok(())
     }
 
-    #[cfg(feature = "backend-stwo")]
+    #[cfg(feature = "prover-stwo")]
     fn verify_stwo(
         &self,
         header: &BlockHeader,
@@ -577,7 +577,7 @@ impl RecursiveProof {
         Ok(())
     }
 
-    #[cfg(not(feature = "backend-stwo"))]
+    #[cfg(not(feature = "prover-stwo"))]
     fn verify_stwo(
         &self,
         _header: &BlockHeader,
@@ -1340,7 +1340,7 @@ mod tests {
     };
     use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer};
     use rand::rngs::OsRng;
-    use stwo::core::vcs::blake2_hash::Blake2sHasher;
+    use crate::proof_backend::Blake2sHasher;
 
     fn seeded_keypair(seed: u8) -> Keypair {
         let secret = SecretKey::from_bytes(&[seed; 32]).expect("secret");

--- a/rpp/runtime/types/identity.rs
+++ b/rpp/runtime/types/identity.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::consensus::{BftVoteKind, SignedBftVote};
 use crate::crypto::{VrfPublicKey, vrf_public_key_from_hex};

--- a/rpp/runtime/types/transaction.rs
+++ b/rpp/runtime/types/transaction.rs
@@ -2,7 +2,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use ed25519_dalek::{PublicKey, Signature};
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 use uuid::Uuid;
 
 use crate::crypto::{

--- a/rpp/runtime/types/uptime.rs
+++ b/rpp/runtime/types/uptime.rs
@@ -1,6 +1,6 @@
 use hex;
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::errors::{ChainError, ChainResult};
 

--- a/rpp/storage/identity_tree.rs
+++ b/rpp/storage/identity_tree.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::errors::{ChainError, ChainResult};
 use hex;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 /// Depth of the sparse identity commitment tree.
 pub const IDENTITY_TREE_DEPTH: usize = 32;

--- a/rpp/storage/ledger.rs
+++ b/rpp/storage/ledger.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet, hash_map::Entry};
 use std::mem;
 
 use parking_lot::RwLock;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::consensus::ValidatorProfile as ConsensusValidatorProfile;
 use crate::crypto::public_key_from_hex;
@@ -1199,7 +1199,7 @@ mod tests {
     use crate::vrf::{VrfProof, VrfSelectionRecord};
     use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signer};
     use std::collections::{BTreeMap, HashMap, HashSet};
-    use stwo::core::vcs::blake2_hash::Blake2sHasher;
+    use crate::proof_backend::Blake2sHasher;
 
     fn seeded_keypair(seed: u8) -> Keypair {
         let secret = SecretKey::from_bytes(&[seed; 32]).expect("secret");

--- a/rpp/storage/state/global.rs
+++ b/rpp/storage/state/global.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::state::merkle::compute_merkle_root;
 use crate::types::{Account, Address, Stake};

--- a/rpp/storage/state/merkle.rs
+++ b/rpp/storage/state/merkle.rs
@@ -1,4 +1,4 @@
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 /// Compute a binary merkle root over the provided leaves.
 ///

--- a/rpp/storage/state/proof_registry.rs
+++ b/rpp/storage/state/proof_registry.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use parking_lot::RwLock;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::rpp::ProofArtifact;
 use crate::state::merkle::compute_merkle_root;

--- a/rpp/storage/state/reputation.rs
+++ b/rpp/storage/state/reputation.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use parking_lot::RwLock;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::reputation::Tier;
 use crate::rpp::{ReputationRecord, TierDescriptor};

--- a/rpp/storage/state/timetoke.rs
+++ b/rpp/storage/state/timetoke.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use parking_lot::RwLock;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::rpp::TimetokeRecord;
 use crate::state::merkle::compute_merkle_root;

--- a/rpp/storage/state/utxo.rs
+++ b/rpp/storage/state/utxo.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 use tokio::sync::RwLock;
 
 use crate::rpp::{AssetType, UtxoOutpoint, UtxoRecord};

--- a/rpp/storage/state/zsi.rs
+++ b/rpp/storage/state/zsi.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use parking_lot::RwLock;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::rpp::ZsiRecord;
 use crate::state::merkle::compute_merkle_root;

--- a/rpp/wallet/Cargo.toml
+++ b/rpp/wallet/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpp-consensus"
+name = "rpp-wallet"
 version = "0.1.0"
 edition = "2021"
 
@@ -9,9 +9,4 @@ prover-stwo = ["prover-backend-interface/prover-stwo"]
 prover-mock = ["prover-backend-interface/prover-mock"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1", features = ["sync", "time", "rt", "macros"] }
-blake3 = "1.5"
-libp2p = { version = "0.54", default-features = false }
 prover-backend-interface = { path = "../zk/backend-interface" }

--- a/rpp/wallet/src/lib.rs
+++ b/rpp/wallet/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
+pub use prover_backend_interface as proof_backend;

--- a/rpp/wallet/ui/proofs.rs
+++ b/rpp/wallet/ui/proofs.rs
@@ -1,7 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::types::{Address, SignedTransaction, UptimeProof};
 

--- a/rpp/wallet/ui/wallet.rs
+++ b/rpp/wallet/ui/wallet.rs
@@ -6,7 +6,7 @@ use ed25519_dalek::Keypair;
 use malachite::Natural;
 use parking_lot::RwLock;
 use serde::{Serialize, de::DeserializeOwned};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 use tokio::sync::Mutex;
 
 use crate::config::NodeConfig;

--- a/rpp/wallet/ui/workflows.rs
+++ b/rpp/wallet/ui/workflows.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
-use stwo::core::vcs::blake2_hash::Blake2sHasher;
+use crate::proof_backend::Blake2sHasher;
 
 use crate::errors::{ChainError, ChainResult};
 use crate::ledger::Ledger;

--- a/rpp/zk/backend-interface/Cargo.toml
+++ b/rpp/zk/backend-interface/Cargo.toml
@@ -5,8 +5,14 @@ edition = "2021"
 description = "Common prover backend interface shared across RPP components"
 license = "MIT"
 
+[features]
+default = []
+prover-stwo = []
+prover-mock = []
+
 [dependencies]
 bincode = "1.3"
+blake2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 

--- a/rpp/zk/backend-interface/src/lib.rs
+++ b/rpp/zk/backend-interface/src/lib.rs
@@ -1,5 +1,35 @@
 use std::fmt;
 
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
+pub mod blake2s {
+    use blake2::{Blake2s256, Digest};
+
+    /// Simple Blake2s hasher mirroring the upstream STWO API.
+    #[derive(Debug, Default, Clone, Copy)]
+    pub struct Blake2sHasher;
+
+    /// Wrapper returned by [`Blake2sHasher::hash`] to ease conversions.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Blake2sHash(pub [u8; 32]);
+
+    impl Blake2sHasher {
+        /// Hash an arbitrary byte slice using Blake2s-256.
+        pub fn hash(input: &[u8]) -> Blake2sHash {
+            Blake2sHash(Blake2s256::digest(input).into())
+        }
+    }
+
+    impl From<Blake2sHash> for [u8; 32] {
+        fn from(value: Blake2sHash) -> Self {
+            value.0
+        }
+    }
+}
+
+pub use blake2s::{Blake2sHash, Blake2sHasher};
+
 use bincode::Options;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/rpp/zk/prover_mock_backend/Cargo.toml
+++ b/rpp/zk/prover_mock_backend/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "Mock prover backend for stable toolchains"
 license = "MIT"
 
+[features]
+default = []
+prover-stwo = []
+prover-mock = []
+
 [dependencies]
 bincode = "1.3"
 prover-backend-interface = { path = "../backend-interface" }

--- a/rpp/zk/prover_mock_backend/src/lib.rs
+++ b/rpp/zk/prover_mock_backend/src/lib.rs
@@ -4,6 +4,9 @@ use prover_backend_interface::{
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
 /// Lightweight mock backend that records inputs and produces deterministic
 /// placeholder artifacts for development and testing on stable toolchains.
 #[derive(Default)]

--- a/rpp/zk/prover_stwo_backend/Cargo.toml
+++ b/rpp/zk/prover_stwo_backend/Cargo.toml
@@ -12,6 +12,8 @@ official = ["dep:stwo-official"]
 prover = ["official", "stwo-official/prover"]
 fri = ["prover"]
 scaffold = []
+prover-stwo = []
+prover-mock = []
 
 [dependencies]
 bincode = "1.3"

--- a/rpp/zk/prover_stwo_backend/src/lib.rs
+++ b/rpp/zk/prover_stwo_backend/src/lib.rs
@@ -6,6 +6,9 @@
 //! offers simple, pure-Rust stand-ins for the original StarkWare components so
 //! that tests and local development can run without external dependencies.
 
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
+
 pub mod backend;
 #[cfg(any(test, feature = "scaffold"))]
 pub mod circuits;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -153,7 +153,7 @@ case "$BACKEND" in
     BACKEND_ARGS=()
     ;;
   stwo)
-    BACKEND_ARGS=("--no-default-features" "--features" "backend-stwo")
+    BACKEND_ARGS=("--no-default-features" "--features" "prover-stwo")
     ;;
   plonky3)
     BACKEND_ARGS=("--features" "backend-plonky3")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,7 +37,7 @@ Build options:
 
 Backends:
   default   Use the workspace default backend configuration
-  stwo      Force the `backend-stwo` feature only
+  stwo      Force the `prover-stwo` feature only
   plonky3   Force the `backend-plonky3` feature only
 USAGE
 }
@@ -194,7 +194,7 @@ run_suite() {
       backend_args=()
       ;;
     stwo)
-      backend_args=("--no-default-features" "--features" "backend-stwo")
+      backend_args=("--no-default-features" "--features" "prover-stwo")
       ;;
     plonky3)
       backend_args=("--features" "backend-plonky3")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@
 //! Applications typically depend on [`config::NodeConfig`] to bootstrap a node,
 //! [`node::Node`] and [`node::NodeHandle`] to operate it, and the supporting modules for consensus,
 //! networking, proofs, and state synchronization.
+
+#[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
+compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
 #[path = "../rpp/rpc/api.rs"]
 pub mod api;
 #[path = "../rpp/proofs/blueprint/mod.rs"]

--- a/tests/zsi_renewal.rs
+++ b/tests/zsi_renewal.rs
@@ -42,9 +42,8 @@ fn sample_identity_declaration(ledger: &Ledger) -> IdentityDeclaration {
     ledger.sync_epoch_for_height(1);
     let pk_bytes = vec![1u8; 32];
     let pk_hex = hex::encode(&pk_bytes);
-    let wallet_addr = hex::encode::<[u8; 32]>(
-        stwo::core::vcs::blake2_hash::Blake2sHasher::hash(&pk_bytes).into(),
-    );
+    let wallet_addr =
+        hex::encode::<[u8; 32]>(rpp_chain::proof_backend::Blake2sHasher::hash(&pk_bytes).into());
     let vrf_keypair = generate_vrf_keypair().expect("generate vrf keypair");
     let vrf = rpp_chain::consensus::evaluate_vrf(
         &ledger.current_epoch_nonce(),


### PR DESCRIPTION
## Summary
- add mutually exclusive `prover-stwo` and `prover-mock` feature flags at the workspace and backend crate level
- re-export the shared prover backend interface from the chain, consensus, node, and wallet crates
- switch runtime, storage, and wallet modules to use the interface-provided Blake2s hasher instead of importing the STWO crate directly, and update helper scripts

## Testing
- `cargo check -p prover-backend-interface` *(fails: manifest requires unstable `edition2024` feature)*

------
https://chatgpt.com/codex/tasks/task_e_68dacc57c68c8326b0754646a54a7c18