### PR TITLE
Add nightly toolchain guard for prover-stwo builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let prover_stwo_enabled = env::var("CARGO_FEATURE_PROVER_STWO").is_ok();
+    if !prover_stwo_enabled {
+        return;
+    }
+
+    if is_nightly_toolchain() {
+        return;
+    }
+
+    panic!(concat!(
+        "The `prover-stwo` feature requires the Rust nightly toolchain.\n",
+        "Please switch to a nightly toolchain (e.g. `rustup override set nightly`) ",
+        "or set `RUSTC_BOOTSTRAP=1` before building."
+    ));
+}
+
+fn is_nightly_toolchain() -> bool {
+    if env::var("RUSTC_BOOTSTRAP")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_owned());
+    match Command::new(rustc).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout.contains("nightly")
+        }
+        _ => false,
+    }
+}

--- a/docs/development/tooling.md
+++ b/docs/development/tooling.md
@@ -4,3 +4,11 @@ The pinned Rust toolchain requires the following components to be installed:
 
 - rustfmt
 - clippy
+
+## Fehlersuche
+
+| Fehlermeldung | Ursache | Lösung |
+| --- | --- | --- |
+| `error: component 'rustfmt' is not installed for toolchain` | Die benötigten Komponenten der fixierten Toolchain wurden noch nicht installiert. | Installiere die fehlenden Komponenten mit `rustup component add rustfmt clippy --toolchain <toolchain>` oder nutze `rustup component add rustfmt clippy --toolchain nightly`. |
+| `error: toolchain 'nightly' is not installed` | Die Nightly-Toolchain ist lokal nicht vorhanden. | Installiere die Toolchain mit `rustup toolchain install nightly` oder passe die `rust-toolchain.toml`-Konfiguration an. |
+| `error: The 'prover-stwo' feature requires the Rust nightly toolchain.` | Das Feature `prover-stwo` wurde aktiviert, aber der Build läuft nicht mit einer Nightly-Toolchain oder ohne `RUSTC_BOOTSTRAP`. | Wechsle auf eine Nightly-Toolchain (`rustup override set nightly`) oder setze vor dem Build `RUSTC_BOOTSTRAP=1`. |


### PR DESCRIPTION
## Summary
- add a build script guard that checks the active toolchain when the `prover-stwo` feature is enabled
- document common build-time errors and their remediations in the tooling guide

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad6ca13b08326abb1fc1534aa288e