### PR TITLE
Add prover CI matrices and document STWO migration path

### DIFF
--- a/.github/workflows/prover-ci.yml
+++ b/.github/workflows/prover-ci.yml
@@ -1,0 +1,79 @@
+name: prover-ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  nightly-prover-stwo:
+    name: nightly-prover-stwo
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: nightly-prover-stwo
+            toolchain: nightly
+            features: prover-stwo
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            cargo/registry
+            target
+          key: ${{ runner.os }}-nightly-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nightly-
+      - name: Build release artifacts
+        run: cargo build --release --workspace --features ${{ matrix.features }}
+      - name: Run tests
+        run: cargo test --workspace --features ${{ matrix.features }}
+      - name: Run benchmarks (scheduled only)
+        if: ${{ github.event_name == 'schedule' }}
+        run: cargo bench --workspace --features ${{ matrix.features }}
+
+  stable-prover-mock:
+    name: stable-prover-mock
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: stable-prover-mock
+            toolchain: stable
+            features: prover-mock
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo directories
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            cargo/registry
+            target
+          key: ${{ runner.os }}-stable-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-stable-
+      - name: Smoke build
+        run: cargo build --workspace --features ${{ matrix.features }}
+      - name: Run tests
+        run: cargo test --workspace --features ${{ matrix.features }}
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --features ${{ matrix.features }} -- -D warnings
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,3 +6,11 @@
 2. Update dependencies or code as needed to resolve nightly-only features identified by the validation passes.
 3. Once the codebase is stable-friendly, edit `rust-toolchain.toml` to point to the desired stable release channel. If the project no longer requires a pinned toolchain, remove the file entirely so that contributors fall back to their default Rust installation.
 4. Communicate the change to the team, including any newly required components or workflows, and confirm CI is running against the stable channel before merging the migration.
+
+## Promoting STWO to Stable
+
+Once the STWO prover feature is ready for general availability:
+
+1. Update the stable CI job to pass `--features prover-stwo` to its build, test, and lint steps so that the default release flow exercises the new prover implementation.
+2. Remove or disable the nightly `prover-stwo` job if it is no longer needed for feature-gating or benchmarking, or keep it scheduled only for extended performance checks.
+3. Clean up any documentation that still references the mock prover for stable releases to avoid confusion for downstream consumers.


### PR DESCRIPTION
## Summary
- add a dedicated CI workflow with nightly and stable matrices for prover builds
- cover nightly release builds, tests, and scheduled benchmarks for the STWO feature set
- ensure the stable pipeline validates the mock prover with build, test, clippy, and fmt checks, and document the future switch in MIGRATION.md

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad877b870832690f893a66641a918