### PR TITLE
Pin STWO dependencies and document feature toggles

### DIFF
--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -13,15 +13,28 @@ jobs:
       RPP_SIM_REQUIRE_DETERMINISTIC: "0"
       CARGO_TERM_COLOR: always
       RUSTFLAGS: -D warnings
+      CARGO_HOME: ${{ github.workspace }}/.cargo
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Audit deterministic cargo environment
+        run: |
+          expected="$GITHUB_WORKSPACE/.cargo"
+          if [ "${CARGO_HOME}" != "$expected" ]; then
+            echo "CARGO_HOME mismatch: ${CARGO_HOME} != $expected" >&2
+            exit 1
+          fi
+          if [ "${RUSTFLAGS:-}" != "-D warnings" ]; then
+            echo "RUSTFLAGS mismatch: ${RUSTFLAGS:-<unset>}" >&2
+            exit 1
+          fi
+          mkdir -p "$CARGO_HOME"
       - name: Cache cargo directories
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |

--- a/.github/workflows/sim-smoke.yml
+++ b/.github/workflows/sim-smoke.yml
@@ -3,6 +3,7 @@ name: sim-smoke
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  CARGO_HOME: ${{ github.workspace }}/.cargo
 
 on:
   push:
@@ -18,14 +19,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Audit deterministic cargo environment
+        run: |
+          expected="$GITHUB_WORKSPACE/.cargo"
+          if [ "${CARGO_HOME}" != "$expected" ]; then
+            echo "CARGO_HOME mismatch: ${CARGO_HOME} != $expected" >&2
+            exit 1
+          fi
+          if [ "${RUSTFLAGS:-}" != "-D warnings" ]; then
+            echo "RUSTFLAGS mismatch: ${RUSTFLAGS:-<unset>}" >&2
+            exit 1
+          fi
+          mkdir -p "$CARGO_HOME"
       # Cache Cargo registry and build artifacts; updating Cargo.lock will bust the key.
       # Keep an eye on runtime after enabling the cache and tighten the path list if size grows.
       - name: Cache cargo directories
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
@@ -43,14 +56,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Audit deterministic cargo environment
+        run: |
+          expected="$GITHUB_WORKSPACE/.cargo"
+          if [ "${CARGO_HOME}" != "$expected" ]; then
+            echo "CARGO_HOME mismatch: ${CARGO_HOME} != $expected" >&2
+            exit 1
+          fi
+          if [ "${RUSTFLAGS:-}" != "-D warnings" ]; then
+            echo "RUSTFLAGS mismatch: ${RUSTFLAGS:-<unset>}" >&2
+            exit 1
+          fi
+          mkdir -p "$CARGO_HOME"
       # Share the same cache key so registry downloads and build output can be reused across jobs.
       # If cache misses start to dominate runtime, consider separating cargo registry vs target caches.
       - name: Cache cargo directories
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,12 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,18 +1466,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1896,12 +1879,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown",
  "rayon",
 ]
 
@@ -2231,7 +2214,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.9",
- "thiserror 2.0.16",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
@@ -2522,7 +2505,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2559,7 +2542,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c738d3789301e957a8f7519318fcbb1b92bb95863b28f6938ae5a05be6259f34"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
  "itertools 0.14.0",
  "libm",
  "ryu",
@@ -2780,7 +2763,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.16",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3162,7 +3145,7 @@ dependencies = [
  "blake3",
  "hex",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3188,7 +3171,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stwo-official",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3234,7 +3217,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -3255,7 +3238,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3587,7 +3570,7 @@ dependencies = [
  "serde_json",
  "storage-firewood",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tower",
@@ -3639,7 +3622,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",
@@ -4174,7 +4157,7 @@ dependencies = [
  "criterion",
  "educe",
  "fnv",
- "hashbrown 0.16.0",
+ "hashbrown",
  "hex",
  "indexmap",
  "itertools 0.12.1",
@@ -4186,7 +4169,7 @@ dependencies = [
  "starknet-ff",
  "std-shims",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen-test",
@@ -4307,11 +4290,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4327,9 +4310,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ prover-stwo = [
     "prover-backend-interface/prover-stwo",
     "stwo/prover-stwo",
 ]
+prover-stwo-simd = [
+    "prover-stwo",
+    "prover-backend-interface/prover-stwo-simd",
+    "stwo/simd",
+]
 prover-mock = [
     "dep:prover_mock_backend",
     "prover-backend-interface/prover-mock",
@@ -21,7 +26,7 @@ backend-plonky3 = []
 [dependencies]
 anyhow = "1.0"
 axum = { version = "0.8", features = ["macros"] }
-bincode = "1.3"
+bincode = "=1.3.3"
 clap = { version = "4.5", features = ["derive"] }
 ed25519-dalek = { version = "1.0", features = ["serde"] }
 merlin = "3.0"
@@ -32,22 +37,22 @@ rpp-consensus = { path = "rpp/consensus" }
 rpp-p2p = { path = "rpp/p2p" }
 parking_lot = "0.12"
 rand = "0.7"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "=1.0.225", features = ["derive"] }
+serde_json = "=1.0.145"
 storage-firewood = { path = "storage-firewood" }
 prover-backend-interface = { path = "rpp/zk/backend-interface" }
 prover_mock_backend = { path = "rpp/zk/prover_mock_backend", optional = true }
 stwo = { package = "prover_stwo_backend", path = "rpp/zk/prover_stwo_backend", optional = true }
-thiserror = "1.0"
+thiserror = "=2.0.12"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal", "sync", "time", "net"] }
 toml = "0.8"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+tracing = "=0.1.41"
+tracing-subscriber = { version = "=0.3.20", features = ["fmt", "env-filter"] }
 uuid = { version = "1.7", features = ["v4", "serde"] }
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
-blake2 = "0.10"
-blake3 = "1.5"
+blake2 = "=0.10.6"
+blake3 = "=1.8.2"
 once_cell = "1.19"
 base64 = "0.22"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -79,3 +84,4 @@ hex-literal = "0.4"
 hyper = "1.2"
 tracing-test = "0.2"
 tower = "0.5"
+

--- a/docs/development/dependency-policy.md
+++ b/docs/development/dependency-policy.md
@@ -1,0 +1,37 @@
+# Dependency update policy
+
+This policy applies to all Rust crates in the repository and complements the
+toolchain pinning we already enforce via `rust-toolchain.toml`.
+
+## Step-by-step update checklist
+
+1. **Prepare an update window.**
+   - Coordinate with the maintainers of the affected crates and schedule a
+     review window where no other dependency bumps are merged.
+   - Capture the motivation for the change (security advisory, performance fix,
+     etc.) in the pull request description.
+2. **Stage the changes behind review gates.**
+   - Open a dedicated pull request per dependency family (e.g. STWO, hashing,
+     field arithmetic) so that reviewers can focus on one risk domain at a time.
+   - Run the full CI suite and attach logs for any manual verification that was
+     required (integration networks, prover benchmarks, …).
+3. **Define a rollback plan before merging.**
+   - Document the minimum supported version after the bump and confirm that the
+     previous lockfile still builds from a clean checkout.
+   - Note who owns the release of the downstream crates in case the update needs
+     to be reverted quickly.
+4. **Review and commit the lockfile.**
+   - Inspect `Cargo.lock` for new transitive dependencies or extra feature flags
+     introduced by the update.
+   - Reject the change if the lockfile contains unreviewed build scripts or
+     network access in new dependencies.
+   - Commit the regenerated lockfile together with the manifest changes so the
+     repository remains reproducible.
+5. **Communicate the rollout.**
+   - Announce the update, the expected impact and the rollback contact in the
+     weekly engineering sync and in the `#release` Slack channel.
+   - Track the deployment on the rollout board and confirm completion once the
+     change runs in production and on the nightly simulator.
+
+Following this process keeps dependency bumps reviewable, reversible and fully
+traceable.

--- a/rpp/consensus/Cargo.toml
+++ b/rpp/consensus/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2021"
 [features]
 default = ["prover-stwo"]
 prover-stwo = ["prover-backend-interface/prover-stwo"]
+prover-stwo-simd = ["prover-stwo", "prover-backend-interface/prover-stwo-simd"]
 prover-mock = ["prover-backend-interface/prover-mock"]
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "=1.0.225", features = ["derive"] }
+serde_json = "=1.0.145"
 tokio = { version = "1", features = ["sync", "time", "rt", "macros"] }
-blake3 = "1.5"
+blake3 = "=1.8.2"
 libp2p = { version = "0.54", default-features = false }
 prover-backend-interface = { path = "../zk/backend-interface" }

--- a/rpp/consensus/src/lib.rs
+++ b/rpp/consensus/src/lib.rs
@@ -1,3 +1,16 @@
+//! Consensus engine coordinating the validator set and proof backends.
+//!
+//! # STWO feature toggles
+//! * `prover-stwo` enables the STWO backend for real proof verification.
+//! * `prover-stwo-simd` layers on `prover-stwo` and allows the STWO fork to use
+//!   its SIMD optimisations. Enable it when the runtime environment guarantees
+//!   the necessary vector extensions; omit it to rely on the portable scalar
+//!   implementation.
+//! * `prover-mock` replaces the prover with a mock implementation for
+//!   simulation-heavy workflows.
+//!
+//! Toggling these options only requires adjusting Cargo feature flags; no code
+//! snippets or manual wiring is needed.
 use std::fmt;
 
 #[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]

--- a/rpp/node/Cargo.toml
+++ b/rpp/node/Cargo.toml
@@ -6,12 +6,13 @@ edition = "2021"
 [features]
 default = ["prover-stwo"]
 prover-stwo = ["prover-backend-interface/prover-stwo"]
+prover-stwo-simd = ["prover-stwo", "prover-backend-interface/prover-stwo-simd"]
 prover-mock = ["prover-backend-interface/prover-mock"]
 
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 tokio = { version = "1.37", features = ["macros", "rt", "signal", "time"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing = "=0.1.41"
+tracing-subscriber = { version = "=0.3.20", features = ["fmt"] }
 prover-backend-interface = { path = "../zk/backend-interface" }

--- a/rpp/node/src/lib.rs
+++ b/rpp/node/src/lib.rs
@@ -1,3 +1,16 @@
+//! Node entry point that wires the prover backends into the networking stack.
+//!
+//! # STWO feature toggles
+//! * `prover-stwo` enables the STWO backend (default).
+//! * `prover-stwo-simd` extends `prover-stwo` and turns on the optional SIMD
+//!   acceleration exposed by the STWO fork. Activate it when the target
+//!   architecture supports the vector instructions; leave it disabled to stay on
+//!   the portable scalar implementation.
+//! * `prover-mock` swaps in the mock backend for tests and environments without
+//!   a prover.
+//!
+//! Switching between these options is handled entirely through Cargo features;
+//! no code changes or configuration files are required.
 #[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
 compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
 

--- a/rpp/p2p/Cargo.toml
+++ b/rpp/p2p/Cargo.toml
@@ -5,21 +5,21 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-base64 = "0.21"
+base64 = "=0.21.7"
 async-trait = "0.1"
 futures = "0.3"
-hex = "0.4"
+hex = "=0.4.3"
 libp2p = { version = "0.54", features = ["macros", "noise", "request-response", "identify", "ping", "gossipsub", "tcp", "tokio", "yamux"] }
 parking_lot = "0.12"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+serde = { version = "=1.0.225", features = ["derive"] }
+serde_json = "=1.0.145"
+thiserror = "=2.0.12"
 tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time"] }
 toml = "0.8"
-tracing = "0.1"
-blake3 = "1.5"
-blake2 = "0.10"
-rand = { version = "0.8", features = ["std"] }
+tracing = "=0.1.41"
+blake3 = "=1.8.2"
+blake2 = "=0.10.6"
+rand = { version = "=0.8.5", features = ["std"] }
 schnorrkel = "0.11"
 
 [dev-dependencies]

--- a/rpp/wallet/Cargo.toml
+++ b/rpp/wallet/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = ["prover-stwo"]
 prover-stwo = ["prover-backend-interface/prover-stwo"]
+prover-stwo-simd = ["prover-stwo", "prover-backend-interface/prover-stwo-simd"]
 prover-mock = ["prover-backend-interface/prover-mock"]
 
 [dependencies]

--- a/rpp/wallet/src/lib.rs
+++ b/rpp/wallet/src/lib.rs
@@ -1,3 +1,15 @@
+//! Wallet facade that interacts with the prover backend for signing flows.
+//!
+//! # STWO feature toggles
+//! * `prover-stwo` activates the STWO backend with the scalar execution path.
+//! * `prover-stwo-simd` builds on top of `prover-stwo` and enables the optional
+//!   SIMD acceleration in the STWO fork. Use it on hosts with supported
+//!   instruction sets and keep it disabled otherwise for maximum portability.
+//! * `prover-mock` routes wallet operations through the mock backend for pure
+//!   testing environments.
+//!
+//! Switching among these features happens via Cargo's feature flags; no code
+//! samples or configuration edits are necessary.
 #[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
 compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");
 

--- a/rpp/zk/backend-interface/Cargo.toml
+++ b/rpp/zk/backend-interface/Cargo.toml
@@ -8,15 +8,16 @@ license = "MIT"
 [features]
 default = []
 prover-stwo = []
+prover-stwo-simd = ["prover-stwo"]
 prover-mock = []
 
 [dependencies]
-bincode = "1.3"
-blake2 = "0.10"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+bincode = "=1.3.3"
+blake2 = "=0.10.6"
+serde = { version = "=1.0.225", features = ["derive"] }
+thiserror = "=2.0.12"
 
 [dev-dependencies]
-blake3 = "1.5"
-hex = "0.4"
-serde = { version = "1.0", features = ["derive"] }
+blake3 = "=1.8.2"
+hex = "=0.4.3"
+serde = { version = "=1.0.225", features = ["derive"] }

--- a/rpp/zk/backend-interface/src/lib.rs
+++ b/rpp/zk/backend-interface/src/lib.rs
@@ -1,3 +1,14 @@
+//! Shared prover backend interface consumed across the workspace.
+//!
+//! # STWO feature toggles
+//! * `prover-stwo` exposes the STWO backend types.
+//! * `prover-stwo-simd` builds on the STWO backend and signals that the
+//!   accelerator-friendly SIMD pathway is allowed. Downstream crates forward
+//!   this flag to the STWO fork which enables the `parallel` implementation.
+//! * `prover-mock` exposes the lightweight mock backend for deterministic tests.
+//!
+//! Consumers opt in or out exclusively through Cargo features; no sample code is
+//! required to change the active backend.
 use std::fmt;
 
 #[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]

--- a/rpp/zk/prover_stwo_backend/Cargo.toml
+++ b/rpp/zk/prover_stwo_backend/Cargo.toml
@@ -13,17 +13,18 @@ prover = ["official", "stwo-official/prover"]
 fri = ["prover"]
 scaffold = []
 prover-stwo = ["official"]
+simd = ["prover", "stwo-official/parallel"]
 prover-mock = []
 
 [dependencies]
-bincode = "1.3"
-blake2 = "0.10"
-hex = "0.4"
-num-bigint = { version = "0.4", features = ["serde"] }
-num-traits = "0.2"
+bincode = "=1.3.3"
+blake2 = "=0.10.6"
+hex = "=0.4.3"
+num-bigint = { version = "=0.4.6", features = ["serde"] }
+num-traits = "=0.2.19"
 prover-backend-interface = { path = "../backend-interface" }
-rand = { version = "0.8", features = ["std_rng"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+rand = { version = "=0.8.5", features = ["std_rng"] }
+serde = { version = "=1.0.225", features = ["derive"] }
+serde_json = "=1.0.145"
+thiserror = "=2.0.12"
 stwo-official = { package = "stwo-official", path = "vendor/stwo-dev/crates/stwo", optional = true }

--- a/rpp/zk/prover_stwo_backend/src/lib.rs
+++ b/rpp/zk/prover_stwo_backend/src/lib.rs
@@ -5,6 +5,19 @@
 //! determinism and debuggability rather than cryptographic performance.  It
 //! offers simple, pure-Rust stand-ins for the original StarkWare components so
 //! that tests and local development can run without external dependencies.
+//!
+//! # Feature flags
+//! * `prover-stwo` pulls in the official STWO implementation bundled with this
+//!   repository.
+//! * `simd` builds on top of `prover-stwo` and enables the upstream
+//!   `parallel` feature, allowing the SIMD-accelerated execution path when the
+//!   host CPU supports it.
+//! * `prover-mock` remains available for parity with the rest of the workspace
+//!   but does not affect this crate directly.
+//!
+//! Switching between the scalar and SIMD implementations only involves toggling
+//! these Cargo features; no code snippets or environment configuration are
+//! necessary.
 
 #[cfg(all(feature = "prover-stwo", feature = "prover-mock"))]
 compile_error!("features `prover-stwo` and `prover-mock` are mutually exclusive");

--- a/rpp/zk/prover_stwo_backend/vendor/stwo-dev/Cargo.toml
+++ b/rpp/zk/prover_stwo_backend/vendor/stwo-dev/Cargo.toml
@@ -15,22 +15,22 @@ version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]
-itertools = { version = "0.12", default-features = false, features = [
+itertools = { version = "=0.12.1", default-features = false, features = [
     "use_alloc",
 ] }
-blake2 = { version = "0.10.6", default-features = false }
-blake3 = { version = "1.5.0", default-features = false }
-educe = "0.5.0"
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-num-traits = { version = "0.2.19", default-features = false }
-thiserror = { version = "2.0.12", default-features = false }
-bytemuck = { version = "1.14.3", default-features = false }
-tracing = { version = "0.1.40", default-features = false }
-tracing-subscriber = { version = "0.3.18", default-features = false }
-rayon = { version = "1.10.0", optional = false }
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-hashbrown = ">=0.15.2"
+blake2 = { version = "=0.10.6", default-features = false }
+blake3 = { version = "=1.8.2", default-features = false }
+educe = "=0.5.11"
+hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
+num-traits = { version = "=0.2.19", default-features = false }
+thiserror = { version = "=2.0.12", default-features = false }
+bytemuck = { version = "=1.23.2", default-features = false }
+tracing = { version = "=0.1.41", default-features = false }
+tracing-subscriber = { version = "=0.3.20", default-features = false }
+rayon = { version = "=1.11.0", optional = false }
+rand = { version = "=0.8.5", default-features = false, features = ["small_rng"] }
+serde = { version = "=1.0.225", default-features = false, features = ["derive"] }
+hashbrown = "=0.15.5"
 std-shims = { path = "crates/std-shims", default-features = false }
 
 [profile.bench]

--- a/rpp/zk/prover_stwo_backend/vendor/stwo-dev/crates/stwo/Cargo.toml
+++ b/rpp/zk/prover_stwo_backend/vendor/stwo-dev/crates/stwo/Cargo.toml
@@ -26,30 +26,30 @@ tracing = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2 = { version = "0.10.6", default-features = false }
-blake3 = { version = "1.5.0", default-features = false }
-bytemuck = { version = "1.14.3", default-features = false, features = ["derive", "extern_crate_alloc"] }
+blake2 = { version = "=0.10.6", default-features = false }
+blake3 = { version = "=1.8.2", default-features = false }
+bytemuck = { version = "=1.23.2", default-features = false, features = ["derive", "extern_crate_alloc"] }
 cfg-if = "1.0.0"
-educe = "0.5.0"
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-indexmap = { version = "2.10.0", default-features = false }
+educe = "=0.5.11"
+hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
+indexmap = { version = "=2.10.0", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
-itertools = { version = "0.12", default-features = false, features = ["use_alloc"] }
-num-traits = { version = "0.2.19", default-features = false }
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-starknet-crypto = { version = "0.6.2", default-features = false, features = [
+itertools = { version = "=0.12.1", default-features = false, features = ["use_alloc"] }
+num-traits = { version = "=0.2.19", default-features = false }
+rand = { version = "=0.8.5", default-features = false, features = ["small_rng"] }
+starknet-crypto = { version = "=0.6.2", default-features = false, features = [
     "alloc",
 ] }
-starknet-ff = { version = "0.3.7", default-features = false, features = [
+starknet-ff = { version = "=0.3.7", default-features = false, features = [
     "alloc",
     "serde",
 ] }
-thiserror = { version = "2.0.12", default-features = false }
-tracing = { version = "0.1.40", default-features = false }
-rayon = { version = "1.10.0", optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-tracing-subscriber = { version = "0.3.18", default-features = false }
-hashbrown = ">=0.15.2"
+thiserror = { version = "=2.0.12", default-features = false }
+tracing = { version = "=0.1.41", default-features = false }
+rayon = { version = "=1.11.0", optional = true }
+serde = { version = "=1.0.225", default-features = false, features = ["derive"] }
+tracing-subscriber = { version = "=0.3.20", default-features = false }
+hashbrown = "=0.15.5"
 std-shims = { path = "../std-shims", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- pin STWO backend crates and dependent hashing/field libraries to exact versions across workspace and vendor manifests
- expose a `prover-stwo-simd` feature across the backend crates, document the available toggles, and add a dependency update runbook
- audit the CI workflows to ensure deterministic Cargo environment variables

## Testing
- `cargo check --workspace` *(fails: base64ct v1.8.0 requires edition2024 support in the pinned nightly toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68dad9ee56488326a4ef45b76a358b53