### PR TITLE
Document nightly build requirements and stable migration guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
 # Contributing
 
-- Use the repository's pinned `nightly-2024-06-20` toolchain. `rustup` automatically selects it via `rust-toolchain.toml`, so avoid overriding the channel in local configuration.
-- Install required nightly components (rustfmt and clippy) through `rustup component add --toolchain nightly-2024-06-20` to keep formatting and linting aligned with CI.
-- Run formatting, linting, and test scripts before submitting changes to ensure parity with automation.
+## Toolchains & Local Workflows
+
+- **Nightly-first path (current default)**
+  - Ensure the repository's pinned `nightly-2024-06-20` toolchain is active. `rustup` selects it automatically via `rust-toolchain.toml`.
+  - Install the matching components with `rustup component add --toolchain nightly-2024-06-20 rustfmt clippy`.
+  - Use the helper scripts for consistency:
+    - `scripts/build.sh [--release|--feature-set ...]` to compile.
+    - `scripts/test.sh [flags]` to execute unit, integration, and doc tests.
+  - Run `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings` before opening a PR.
+- **Stable validation path (migration prep)**
+  - Install the target stable release (currently `1.79`) with `rustup toolchain install 1.79.0`.
+  - Mirror the nightly commands by prefixing with `RUSTUP_TOOLCHAIN=1.79.0` (or using `rustup run 1.79.0 ...`) to detect nightly-only dependencies.
+  - Capture differences in output, formatting, or warnings and file migration issues in the tracking board referenced in `MIGRATION.md`.
+
+## Backend Implementation Conventions
+
+- New proving/storage backends must live under dedicated feature flags (e.g. `backend-plonky3`) and default to disabled unless production-ready.
+- Implement backend-specific configuration in `config/` and document required keys in the README backend section.
+- Provide integration tests or simulations under `tests/` or `rpp/sim/` that exercise the backend in isolation.
+- Update CI matrices to include opt-in coverage for the new backend and describe the workflow in the PR summary.
+
+## Troubleshooting
+
+- **Toolchain mismatch errors**
+  - `error: toolchain 'nightly-2024-06-20' is not installed`: run `rustup toolchain install nightly-2024-06-20`.
+  - `error: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is unavailable`: install via `rustup component add --toolchain nightly-2024-06-20 rustfmt`.
+  - `error: toolchain '1.79.0' is not installed` when testing the stable path: run `rustup toolchain install 1.79.0` and retry with `RUSTUP_TOOLCHAIN=1.79.0`.
+- If builds succeed on nightly but fail on stable, cross-reference the checklist in `MIGRATION.md` and flag blocking nightly-only features.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,7 +2,23 @@
 
 ## Switching from Nightly to Stable
 
-1. Run the full validation suite on the existing nightly toolchain, including formatting (`cargo fmt --check`), linting (`cargo clippy --all-targets --all-features -- -D warnings`), and the project's test scripts, to capture any regressions ahead of the migration.
-2. Update dependencies or code as needed to resolve nightly-only features identified by the validation passes.
-3. Once the codebase is stable-friendly, edit `rust-toolchain.toml` to point to the desired stable release channel. If the project no longer requires a pinned toolchain, remove the file entirely so that contributors fall back to their default Rust installation.
-4. Communicate the change to the team, including any newly required components or workflows, and confirm CI is running against the stable channel before merging the migration.
+Use the following checklist to track the stable readiness work:
+
+- [ ] **Toolchain**
+  - [ ] Run the full validation suite on `nightly-2024-06-20` to capture baseline behaviour.
+  - [ ] Verify the codebase compiles with the target stable (`1.79`) locally and in CI sandboxes.
+  - [ ] Update `rust-toolchain.toml` to reference the stable channel, or remove it if default `rustup` overrides are acceptable.
+- [ ] **Feature flags & crates**
+  - [ ] Audit `Cargo.toml` and workspace members for `#![feature(...)]` attributes or nightly-only dependencies.
+  - [ ] Gate unstable functionality behind cfg flags or replace it with stable equivalents.
+  - [ ] Refresh documentation snippets and examples to avoid nightly-only syntax.
+- [ ] **CI configuration**
+  - [ ] Switch CI jobs (build, test, lint, docs) to the stable toolchain matrix.
+  - [ ] Ensure formatting and linting steps pull `rustfmt`/`clippy` from the stable channel.
+  - [ ] Update cached toolchain layers or containers to include the stable version.
+- [ ] **Benchmarks & performance tracking**
+  - [ ] Re-run benchmark suites under both nightly and stable toolchains to compare regressions.
+  - [ ] Update baseline metrics stored in `bench/` artefacts or observability dashboards.
+  - [ ] Communicate any performance deltas to stakeholders and capture follow-up tasks.
+
+Once every item is checked, announce the migration timeline, merge the toolchain update, and monitor post-merge CI for regressions.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ It integrates:
 
 This workspace is pinned to `nightly-2024-06-20` via `rust-toolchain.toml`. Install the matching toolchain along with the bundled `rustfmt` and `clippy` components before building locally to ensure consistent formatting and lint coverage.
 
+## Build Matrix
+
+| Channel | Status | Notes |
+| --- | --- | --- |
+| Nightly (`nightly-2024-06-20`) | ✅ Required today | CI, dev tooling, and docs expect this toolchain until the stable transition lands. |
+| Stable (target `1.79`) | 🚧 Target for tomorrow | Migration checklists and experiments should validate readiness for switching the workspace default. |
+
+> ℹ️ Keep running validation passes against both channels so that the nightly dependency can be safely removed when the stable target is promoted.
+
 ## Getting Started
 
 ### Prerequisites

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,26 @@
+# Release Notes
+
+## Nightly Dependency & Update Process
+
+The project currently depends on the `nightly-2024-06-20` Rust toolchain. Releases must confirm that this nightly pin still compiles, formats, and lints cleanly before the artefact is tagged. The migration plan targets Rust `1.79` as the next stable baseline; consult `MIGRATION.md` for the readiness checklist.
+
+### Risks
+
+- Nightly regressions can break the workspace with little notice. Mitigate by caching toolchains and mirroring CI jobs onto the prospective stable channel.
+- Nightly-only features may be deprecated or altered, requiring rapid code changes. Track the upstream release notes and stabilisation proposals.
+- Contributors running default stable toolchains may encounter build failures until the stable switch is complete.
+
+### Update Process
+
+1. Run the full validation suite (`scripts/build.sh`, `scripts/test.sh`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`).
+2. Execute the stable validation path with `RUSTUP_TOOLCHAIN=1.79.0` to compare results.
+3. Update documentation (README, CONTRIBUTING, MIGRATION) if toolchain requirements change.
+4. Announce the outcome in the release communication channel and update the tracking issues.
+
+### Manual Checks per Release
+
+- [ ] Confirm `rust-toolchain.toml` points to the intended release channel.
+- [ ] Verify CI pipelines completed against both nightly and stable targets.
+- [ ] Review benchmarking dashboards for regressions versus the previous release.
+- [ ] Ensure new backend feature flags are documented and gated appropriately.
+- [ ] Validate release artefacts (binaries, Docker images, manifests) were built with the pinned toolchain.


### PR DESCRIPTION
## Summary
- document the build matrix with the current nightly requirement and the planned stable target
- expand the migration checklist, contributor guidance, and troubleshooting notes for the nightly-to-stable switch
- add release notes outlining nightly dependency risks, update workflow, and mandatory manual checks per release

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dadf0985fc8326a85c90718d23d21f