### PR TITLE
Refactor STWO wallet proof generation pipeline

### DIFF
--- a/rpp/proofs/stwo/mod.rs
+++ b/rpp/proofs/stwo/mod.rs
@@ -2,11 +2,10 @@
 
 pub mod aggregation;
 pub mod ffi;
+pub mod proof;
 pub mod prover;
 
-pub use stwo::official::{
-    air, circuit, conversions, fri, official_adapter, params, proof, verifier,
-};
+pub use stwo::official::{air, circuit, conversions, fri, official_adapter, params, verifier};
 
 #[cfg(test)]
 mod tests;

--- a/rpp/proofs/stwo/proof.rs
+++ b/rpp/proofs/stwo/proof.rs
@@ -1,0 +1,32 @@
+use super::air::AirDefinition;
+use super::circuit::ExecutionTrace;
+use super::fri::FriProver;
+use super::params::{FieldElement, StarkParameters};
+
+pub use stwo::official::proof::{
+    CommitmentSchemeProofData, FriProof, ProofKind, ProofPayload, StarkProof,
+};
+
+/// Construct a proof artifact by committing to the supplied trace and public inputs.
+pub fn placeholder_proof(
+    parameters: &StarkParameters,
+    kind: ProofKind,
+    payload: ProofPayload,
+    public_inputs: Vec<FieldElement>,
+    trace: ExecutionTrace,
+    air: AirDefinition,
+) -> StarkProof {
+    let fri_prover = FriProver::new(parameters);
+    let fri_output = fri_prover.prove(&air, &trace, &public_inputs);
+    let hasher = parameters.poseidon_hasher();
+
+    StarkProof::new(
+        kind,
+        payload,
+        public_inputs,
+        trace,
+        fri_output.commitment_proof,
+        fri_output.fri_proof,
+        &hasher,
+    )
+}

--- a/rpp/proofs/stwo/prover/mod.rs
+++ b/rpp/proofs/stwo/prover/mod.rs
@@ -26,9 +26,8 @@ use crate::stwo::circuit::{
     uptime::{UptimeCircuit, UptimeWitness},
     CircuitError, StarkCircuit,
 };
-use crate::stwo::fri::FriProver;
 use crate::stwo::params::{FieldElement, StarkParameters};
-use crate::stwo::proof::{ProofKind, ProofPayload, StarkProof};
+use crate::stwo::proof::{placeholder_proof, ProofKind, ProofPayload, StarkProof};
 
 fn map_circuit_error(err: CircuitError) -> ChainError {
     ChainError::Crypto(err.to_string())
@@ -471,17 +470,13 @@ impl<'a> WalletProver<'a> {
             self.parameters.element_from_u64(tx.fee as u64),
             self.parameters.element_from_u64(tx.nonce),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Transaction,
             ProofPayload::Transaction(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -503,17 +498,13 @@ impl<'a> WalletProver<'a> {
             string_to_field(&self.parameters, &witness.identity_root),
             string_to_field(&self.parameters, &witness.state_root),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Identity,
             ProofPayload::Identity(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -535,17 +526,13 @@ impl<'a> WalletProver<'a> {
             self.parameters
                 .element_from_u64(witness.transactions.len() as u64),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::State,
             ProofPayload::State(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -567,17 +554,13 @@ impl<'a> WalletProver<'a> {
             self.parameters
                 .element_from_u64(witness.removed_transactions.len() as u64),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Pruning,
             ProofPayload::Pruning(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -600,17 +583,13 @@ impl<'a> WalletProver<'a> {
             self.parameters
                 .element_from_u64(witness.tx_commitments.len() as u64),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Recursive,
             ProofPayload::Recursive(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -635,17 +614,13 @@ impl<'a> WalletProver<'a> {
             self.parameters.element_from_u64(witness.window_end),
             string_to_field(&self.parameters, &witness.commitment),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Uptime,
             ProofPayload::Uptime(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 
@@ -667,17 +642,13 @@ impl<'a> WalletProver<'a> {
             string_to_field(&self.parameters, &witness.leader_proposal),
             self.parameters.element_from_u64(witness.quorum_threshold),
         ];
-        let hasher = self.hasher();
-        let fri_prover = FriProver::new(&self.parameters);
-        let fri_output = fri_prover.prove(&air, &trace, &inputs);
-        Ok(StarkProof::new(
+        Ok(placeholder_proof(
+            &self.parameters,
             ProofKind::Consensus,
             ProofPayload::Consensus(witness),
             inputs,
             trace,
-            fri_output.commitment_proof,
-            fri_output.fri_proof,
-            &hasher,
+            air,
         ))
     }
 }


### PR DESCRIPTION
## Summary
- add a local `proof` module that re-exports the official proof types and wraps the deterministic prover pipeline
- update the wallet prover helpers to call the shared `placeholder_proof` routine instead of instantiating the FRI prover inline

## Testing
- `cargo fmt -- rpp/proofs/stwo/mod.rs rpp/proofs/stwo/prover/mod.rs rpp/proofs/stwo/proof.rs`
- `cargo test -p rpp-chain recorded_transaction_proof_generation_succeeds -- --nocapture` *(fails: required Cargo `edition2024` feature unavailable in bundled nightly)*

------
https://chatgpt.com/codex/tasks/task_e_68dae57ffed88326a8ff79ce5293da6f