### PR TITLE
Add block witness production step

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8803,6 +8803,7 @@ dependencies = [
  "prover-backend-interface",
  "prover_stwo_backend",
  "rand 0.8.5",
+ "rayon",
  "rcgen 0.12.1",
  "reqwest 0.12.24",
  "rpp-consensus",

--- a/rpp/chain/Cargo.toml
+++ b/rpp/chain/Cargo.toml
@@ -113,6 +113,7 @@ num-traits = "=0.2.19"
 once_cell = "=1.21.3"
 parking_lot = "=0.12.5"
 prover-backend-interface = { path = "../zk/backend-interface" }
+rayon = "=1.11.0"
 prover_stwo_backend = { workspace = true, optional = true }
 reqwest = { version = "=0.12.24", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 rpp-consensus = { path = "../consensus", default-features = false }

--- a/rpp/proofs/stwo/prover/mod.rs
+++ b/rpp/proofs/stwo/prover/mod.rs
@@ -7,7 +7,10 @@ use crate::consensus::ConsensusCertificate;
 use crate::errors::{ChainError, ChainResult};
 use crate::proof_system::ProofProver;
 use crate::reputation::{ReputationWeights, Tier};
-use crate::rpp::{GlobalStateCommitments, ProofSystemKind};
+use crate::rpp::{
+    produce_block_witness, BlockWitness, GlobalStateCommitments, ProofSystemKind, StateView,
+};
+use crate::runtime::types::block::Block;
 use crate::state::merkle::compute_merkle_root;
 use crate::storage::Storage;
 use crate::types::{
@@ -334,6 +337,14 @@ impl<'a> WalletProver<'a> {
             &state_roots,
             block_height,
         )
+    }
+
+    pub fn produce_block_witness(
+        &self,
+        block: Block,
+        state_view: &dyn StateView,
+    ) -> ChainResult<BlockWitness> {
+        produce_block_witness(block, state_view)
     }
 
     pub fn derive_uptime_witness(&self, claim: &UptimeClaim) -> ChainResult<UptimeWitness> {


### PR DESCRIPTION
## Summary
- add a StateView abstraction and parallelized block witness producer in the RPP proof module
- expose the new block witness builder on the STWO wallet prover flow
- pull in rayon to support sharded transaction witness generation

## Testing
- cargo check --manifest-path rpp/chain/Cargo.toml -p rpp-chain --quiet *(fails: upstream libp2p warnings promoted to errors and existing trait bounds in rpp-p2p)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367e66d22c8326ba4e5a00c3264e3e)