### PR TITLE
Add folding pipeline helper with validation and tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8005,6 +8005,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/rpp/zk/backend-interface/Cargo.toml
+++ b/rpp/zk/backend-interface/Cargo.toml
@@ -13,6 +13,7 @@ backend-plonky3-gpu = ["backend-plonky3"]
 prover-stwo = []
 prover-stwo-simd = ["prover-stwo"]
 prover-mock = []
+folding-verify = []
 
 [dependencies]
 bincode = "=1.3.3"
@@ -22,6 +23,7 @@ hex = "=0.4.3"
 serde = { version = "=1.0.225", features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = "=2.0.12"
+tracing = { workspace = true }
 
 [dev-dependencies]
 serde = { version = "=1.0.225", features = ["derive"] }


### PR DESCRIPTION
## Summary
- add a folding pipeline helper that validates inputs, derives missing commitments, and times backend folds
- emit tracing for folding steps with optional verification behind the new `folding-verify` feature flag
- cover the pipeline helper with unit tests and add tracing as a dependency

## Testing
- cargo test -p prover-backend-interface


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69368330649c83269be38c6870bf2a9f)