### PR TITLE
Document fold_global integration points

### DIFF
--- a/docs/architecture/fold_global_integration.md
+++ b/docs/architecture/fold_global_integration.md
@@ -1,0 +1,21 @@
+# fold_global integration notes
+
+## Legacy aggregation touchpoints
+- **STWO prover batch wiring** (`rpp/proofs/stwo/prover/mod.rs`): `derive_recursive_witness` builds the recursive witness after all batch proofs and pruning metadata are available. The call is currently routed through `RecursiveAggregator::new(...).build_witness(...)` and is tagged with a TODO for swapping in `fold_global` once the folding pipeline owns the batch output.
+- **Plonky3 prover recursion** (`rpp/proofs/plonky3/prover/mod.rs`): `prove_recursive` finalizes the recursive batch via the backend-specific `RecursiveAggregator`. A TODO marks this as the handoff point where `fold_global` should accept the Plonky3 recursion artifact instead of the legacy aggregator path.
+- **STWO verifier commitment check** (`prover/prover_stwo_backend/src/official/verifier/mod.rs`): `compute_recursive_commitment` recomputes the recursive hash inside the verifier. A TODO documents that this should be replaced with a `fold_global` verification hook so the accumulator operates on folded instances.
+
+## Interface deltas to cover
+- Current aggregation expects **hex-encoded commitments and `StateCommitmentSnapshot` structs** plus pruning digests, whereas `fold_global` operates on `GlobalInstance`/`GlobalProof` pairs (`rpp/zk/backend-interface/src/folding.rs`). Parameter conversion from hex strings to the fixed-length byte payloads used by `GlobalInstance::from_state_and_rpp` and `GlobalProof::new` will be required.
+- The existing recursive helpers return **`RecursiveWitness` structs or raw `FieldElement` commitments**; `fold_global` emits **`GlobalProofHandle` metadata** and proof bytes instead, so callers will need to persist the folding handle instead of hex commitments.
+- Aggregator constructors currently rely on **`StarkParameters`/`Plonky3Parameters`** and backend-specific verifiers. `fold_global` expects a **`FoldingBackend`** implementation, so re-exports and trait object wiring in the prover crates must be adjusted to surface that backend to the orchestration layer.
+
+## Verifier/accumulator dependencies
+- The node verifier currently recomputes recursive commitments to validate the proof payload. Moving to `fold_global` means the accumulator needs access to the **`GlobalInstance` commitment chain** and should verify against `GlobalProofHandle::proof_commitment` instead of the Poseidon-based recursive hash.
+- Final ledger checks that depend on `StateCommitmentSnapshot` (e.g., pruning/state roots) will need to pull the same fields from the folded instance headers (`GlobalInstance::to_header_fields`) to avoid duplicating validation logic.
+
+## Open items for the refactor
+- Define the **byte/hex normalization** between existing `TaggedDigestHex` fields and the byte vectors expected by `GlobalInstance`/`GlobalProof` constructors.
+- Confirm **batch size and constraint limits** (`MAX_BATCHED_PROOFS`) remain enforceable once folding subsumes recursive aggregation.
+- Identify how **previous recursive commitments** map to the `GlobalProofHandle` chain so block height/index offsets remain monotonic.
+- Determine whether **telemetry and metrics** that currently record aggregation latency need to be moved to the folding backend interfaces.

--- a/prover/prover_stwo_backend/src/official/verifier/mod.rs
+++ b/prover/prover_stwo_backend/src/official/verifier/mod.rs
@@ -193,6 +193,9 @@ impl NodeVerifier {
         witness: &super::circuit::recursive::RecursiveWitness,
         state_commitments: &StateCommitmentSnapshot,
     ) -> FieldElement {
+        // TODO(fold_global): swap the legacy recursive hash recomputation with
+        // a `fold_global` verification hook so the accumulator checks the folded
+        // global instance rather than the pre-fold commitment chain.
         let aggregator = RecursiveAggregator::new(self.parameters.clone());
         aggregator.aggregate_commitment(
             witness.previous_commitment.as_deref(),

--- a/rpp/proofs/plonky3/prover/mod.rs
+++ b/rpp/proofs/plonky3/prover/mod.rs
@@ -590,6 +590,9 @@ impl ProofProver for Plonky3Prover {
     }
 
     fn prove_recursive(&self, witness: Self::RecursiveWitness) -> ChainResult<ChainProof> {
+        // TODO(fold_global): hand the recursive batch output to `fold_global`
+        // once the folding backend consumes Plonky3 recursion artifacts
+        // directly instead of relying on the legacy aggregator.
         let aggregator = RecursiveAggregator::new(self.params.clone(), self.backend.clone());
         let proof = aggregator.finalize(&witness)?;
         proof.into_value().map(ChainProof::Plonky3)

--- a/rpp/proofs/stwo/prover/mod.rs
+++ b/rpp/proofs/stwo/prover/mod.rs
@@ -324,6 +324,9 @@ impl<'a> WalletProver<'a> {
                 pruning_owned.kind
             )));
         }
+        // TODO(fold_global): route the post-batch recursive aggregation into
+        // `fold_global` so the folding pipeline can consume the same witness
+        // material instead of the legacy `RecursiveAggregator` output.
         let aggregator = RecursiveAggregator::new(self.parameters.clone());
         let state_roots = StateCommitmentSnapshot::from_commitments(state_commitments);
         aggregator.build_witness(


### PR DESCRIPTION
## Summary
- mark recursive aggregation handoff sites for planned `fold_global` integration in both provers and the STWO verifier
- capture interface and dependency differences between legacy aggregation and folding backends in a design note

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693692edb6788326b9a4fdc7da0aa1ae)