### PR TITLE
Document GlobalProof VK registry and migration

### DIFF
--- a/docs/architecture/global_proof_vk_registry.md
+++ b/docs/architecture/global_proof_vk_registry.md
@@ -1,0 +1,81 @@
+# Verifikationsschlüssel-Registry und Versionierung für `GlobalProof`
+
+Dieses Dokument beschreibt, wie Verifikationsschlüssel (VKs) für `GlobalProof`-Beweise
+verwaltet werden, wie `ProofVersion`-Labels auf konkrete VK-IDs abgebildet werden und
+welche Migrationsschritte Nodes befolgen müssen.
+
+## Zentrale Registry für VKs
+
+* **Quell-Of-Truth:** Eine kanonische `vk_registry.json` im Repository (unter
+  `docs/interfaces/runtime/`) enthält alle aktiven und historischen VK-IDs
+  einschließlich Metadaten (`version`, `curve`, `backend`, `activated_at`,
+  `superseded_by`).
+* **Distribution:** Nodes laden die Registry über denselben Release-/Config-Pfad wie
+  andere runtime-spezifische Artefakte (z. B. via packaged assets oder gesicherte
+  HTTP-Bundles). Die Datei wird mit einer Checksumme (z. B. SHA-256) ausgeliefert,
+  die gegen die Release-Metadaten geprüft wird.
+* **Lookup-API:** Loader-Funktionen reichen die Registry als Mapping
+  `vk_id -> {version, metadata}` in die Verifier-Schicht weiter. Die Registry dient
+  als einzige Quelle, aus der `GlobalProofHandle::vk_id` aufgelöst wird; Hardcoding
+  in Codepfaden ist zu vermeiden.
+
+## Versionierungsregeln
+
+* **Eindeutige Zuordnung:** Jedes `ProofVersion`-Label mappt auf genau eine
+  `vk_id`. Beispiel: `ProofVersion::NovaV2 -> "nova-v2-vk"`. Die Zuordnung wird in
+  der Registry gepflegt und in den Runtime-Checks referenziert.
+* **Rückwärtskompatibilität:** Alte Labels bleiben in der Registry bestehen, selbst
+  wenn sie superseded sind, damit historische Blöcke weiterhin verifiziert werden
+  können.
+* **Rotation/Ablauf:**
+  * Eine neue VK-Version wird hinzugefügt, das Vorgänger-VK erhält das Feld
+    `superseded_by` und optional `expires_at_block`.
+  * Validatoren akzeptieren beide Versionen während einer definierten
+    Grace-Periode; danach erzwingt der Cutover-Check, dass das Header-Label auf die
+    neue `vk_id` zeigt.
+  * Die Registry vermerkt den **aktivierten Block** und optional den
+    **abgeschalteten Block**, um Height-basierte Checks zu ermöglichen.
+
+## Migration für Nodes
+
+1. **Registry laden und cachen:**
+   * Beim Start lädt der Node `vk_registry.json`, validiert die Signatur/Checksumme
+     und cached das Mapping im Speichersnapshot (z. B. über `Arc<RwLock<_>>`).
+   * Hot-Reload: Bei neuen Releases kann die Datei im laufenden Betrieb neu geladen
+     werden; die Registry-Version (z. B. SemVer + Hash) verhindert Stale-Caches.
+2. **GlobalProof-Validierung:**
+   * Der Verifier löst `global_proof.handle.vk_id` gegen die Registry auf und
+     prüft, ob das Label im Header (`global_proof_handle.version`) mit dem Registry
+     Eintrag (`ProofVersion` → `vk_id`) übereinstimmt.
+   * Ist eine `expires_at_block` gesetzt, schlägt die Validierung fehl, sobald der
+     Header über dem Ablaufblock liegt.
+   * Proofs werden nur akzeptiert, wenn Commitment, VK und Version konsistent sind
+     **und** die Registry das VK als aktiv markiert.
+3. **Cache-Strategie für VK-Blobs:**
+   * VK-Bytes werden anhand der `vk_id` gecached (z. B. unter
+     `${data_dir}/vk_cache/<vk_id>.bin`). Der Fetch-Pfad nutzt die Registry-URLs
+     oder eingebettete Assets.
+   * Cache-Invalidierung erfolgt, wenn die Registry-Version wechselt oder der
+     Ablaufblock erreicht ist.
+4. **Rollout/Upgrade-Pfade:**
+   * Während der Grace-Periode akzeptiert der Node sowohl den alten als auch den
+     neuen `vk_id`, vergleicht aber das Header-Label gegen den Registry-Eintrag, um
+     Fehlkonfigurationen zu erkennen.
+   * Telemetrie sollte getrennte Counter für „legacy vk accepted“ und
+     „current vk accepted“ erfassen, um den Cutover zu beobachten.
+   * Nach Ende der Grace-Periode wird die Legacy-ID aus der akzeptierten Menge
+     entfernt; historische Blöcke bleiben verifizierbar, weil die Registry den
+     alten Eintrag beibehält.
+
+## Validierungschecks beim Wechsel
+
+* **Header-VK-Check:** `header.global_proof_handle.vk_id` muss exakt der Registry
+  Zuordnung für das Version-Label entsprechen.
+* **Height-Gates:** Wenn die Registry `activated_at`/`expires_at_block` angibt,
+  prüft der Verifier die Header-Höhe gegen diese Grenzen.
+* **Proof-Commitment:** Der Hash aus dem Handle muss mit dem neu heruntergeladenen
+  Proof-Blob übereinstimmen; ansonsten gilt der Beweis als manipuliert und wird
+  verworfen.
+* **Cache-Fallback:** Falls der Cache ein abgelaufenes VK enthält, muss der Loader
+  den Download forcieren und die Registry-Version aktualisieren, bevor erneut
+  validiert wird.

--- a/docs/architecture/ztate_state_folding_interaction.md
+++ b/docs/architecture/ztate_state_folding_interaction.md
@@ -38,7 +38,7 @@ graph TD
 
 ### Light-Client-Pfad
 - **Header-only Check:** `verify_global_proof(header, global_proof)` prüft Commitment, Handle (Commitment + VK-ID) und Versionslabel allein anhand von Header und Proof-Payload. Es werden keine Ledger-Daten oder vorherige Blöcke benötigt.
-- **Serialisierung:** `global_instance_commitment` und `global_proof_handle` werden als lowercase Hex-Strings transportiert; der Handle enthält Commitment, `vk_id` und das semantische Label (`aggregated-v1` oder `nova-v2`). Ein End-to-End-Beispiel befindet sich unter `docs/interfaces/runtime/examples/light_client_global_proof.json`.
+- **Serialisierung & VK-Registry:** `global_instance_commitment` und `global_proof_handle` werden als lowercase Hex-Strings transportiert; der Handle enthält Commitment, `vk_id` und das semantische Label (`aggregated-v1` oder `nova-v2`). Das Label wird über eine zentrale VK-Registry auf die konkret gültige `vk_id` gemappt (siehe `docs/architecture/global_proof_vk_registry.md`). Ein End-to-End-Beispiel befindet sich unter `docs/interfaces/runtime/examples/light_client_global_proof.json`.
 
 ## Übergangsphase: alte Aggregations-Beweise vs. GlobalProofs
 - **Akzeptanzmatrix:** Während der Migration akzeptiert der Validator sowohl legacy Aggregations-Proofs (Poseidon-basierte `recursive_commitment`) als auch neue `GlobalProofHandle`/`GlobalProof`-Paare. Ein Feature-Flag (z. B. `folding-verify`) steuert, ob `verify_global_proof` verpflichtend ist oder optional.

--- a/docs/interfaces/runtime/light_client_global_proof.md
+++ b/docs/interfaces/runtime/light_client_global_proof.md
@@ -6,7 +6,10 @@ Gossip- oder RPC-Headern lesen können. `global_instance_commitment` spiegelt de
 Blake2s-Hash (32 Bytes) über `(index || state_commitment || rpp_commitment)`
 wider; `global_proof_handle` enthält den Proof-Commitment-Hash (32 Bytes), die
 hex-kodierte Verifikationsschlüssel-ID (`vk_id`) und ein semantisches
-Versionslabel (`aggregated-v1` oder `nova-v2`).
+Versionslabel (`aggregated-v1` oder `nova-v2`). Das Label wird über eine
+**zentrale VK-Registry** auf konkrete `vk_id`-Einträge gemappt (siehe
+`docs/architecture/global_proof_vk_registry.md`) und erlaubt so, dass Clients
+rotierende Verifikationsschlüssel sicher auflösen.
 
 Ein komplettes Beispiel liegt unter
 `docs/interfaces/runtime/examples/light_client_global_proof.json` und zeigt die
@@ -24,7 +27,8 @@ dekodieren.
 2. Proof-Payload (`GlobalProof`) via Handle/Commitment vom Netz beziehen.
 3. `verify_global_proof(&header, &global_proof)` aufrufen. Der Helfer verifiziert
    Commitment- und VK-Konsistenz, prüft das erwartete Proof-Version-Label basierend
-   auf der Header-Höhe und hasht die Proof-Bytes erneut gegen das Commitment.
+   auf der Header-Höhe gegen die Registry-Abbildung und hasht die Proof-Bytes
+   erneut gegen das Commitment.
 
 ```rust
 use rpp_chain::runtime::types::{BlockHeader, verify_global_proof};


### PR DESCRIPTION
## Summary
- add design doc for a centralized GlobalProof verification-key registry with versioning and rotation rules
- reference the registry from light-client validation docs and spell out registry-based version checks
- tie the folding interaction overview to the registry to show how handles map to active vk_ids

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936caab3c048326aad3802ccd600c8a)