### PR TITLE
Add folding CI coverage and perf gating

### DIFF
--- a/.github/workflows/folding.yml
+++ b/.github/workflows/folding.yml
@@ -1,0 +1,39 @@
+name: Folding layer CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  folding-tests:
+    name: Folding unit and migration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: folding-tests
+
+      - name: Run folding unit tests
+        run: |
+          set -euo pipefail
+          cargo test -p rpp-chain global_proof
+          cargo test -p rpp-chain block_witness_flows_into_mock_fold_pipeline
+
+      - name: Validate storage folding integration
+        run: |
+          set -euo pipefail
+          cargo test -p rpp-chain bootstraps_fold_pipeline_from_cut_tip
+
+      - name: Enforce AggregatedV1 -> NovaV2 migration guardrails
+        run: |
+          set -euo pipefail
+          cargo test -p rpp-chain nova_cutover_requires_bootstrap_version_shift

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -169,3 +169,94 @@ jobs:
           path: |
             pruning-${{ matrix.backend }}-bf${{ matrix.branch_factor }}.log
             pruning-metrics-${{ matrix.backend }}-bf${{ matrix.branch_factor }}.json
+
+  folding:
+    name: Global proof benchmarks
+    runs-on: ubuntu-latest
+    env:
+      FOLDING_PERF_OUTPUT: folding-perf.json
+      FOLDING_PERF_CHAIN_LENGTH: 256
+      FOLDING_PERF_PROOF_BYTES: 4096
+      FOLDING_MAX_AGGREGATED_KIB: 12
+      FOLDING_MAX_NOVA_KIB: 16
+      FOLDING_MAX_AGGREGATED_VERIFY_MS: 1.5
+      FOLDING_MAX_NOVA_VERIFY_MS: 2.5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: folding-benchmarks
+
+      - name: Run folding performance sampler
+        run: |
+          set -euo pipefail
+          cargo run -p rpp-chain --bin folding_perf --release \
+            --quiet
+
+      - name: Summarize folding metrics
+        run: |
+          set -euo pipefail
+          jq -r '.runs[] | ["version=" + .version, "avg_bytes=" + (.avg_proof_bytes|tostring), "max_bytes=" + (.max_proof_bytes|tostring), "verify_ms=" + (.verify_per_proof_ms|tostring)] | join("\t")' "${FOLDING_PERF_OUTPUT}" > folding-perf-summary.tsv
+
+      - name: Enforce folding thresholds
+        run: |
+          set -euo pipefail
+
+          agg_limit_bytes=$((FOLDING_MAX_AGGREGATED_KIB * 1024))
+          nova_limit_bytes=$((FOLDING_MAX_NOVA_KIB * 1024))
+
+          agg_bytes=$(jq '.runs[] | select(.version=="AggregatedV1") | .max_proof_bytes' "${FOLDING_PERF_OUTPUT}")
+          nova_bytes=$(jq '.runs[] | select(.version=="NovaV2") | .max_proof_bytes' "${FOLDING_PERF_OUTPUT}")
+          agg_verify=$(jq '.runs[] | select(.version=="AggregatedV1") | .verify_per_proof_ms' "${FOLDING_PERF_OUTPUT}")
+          nova_verify=$(jq '.runs[] | select(.version=="NovaV2") | .verify_per_proof_ms' "${FOLDING_PERF_OUTPUT}")
+
+          if (( $(printf '%.0f' "$agg_bytes") > agg_limit_bytes )); then
+            echo "::error::AggregatedV1 proof size ${agg_bytes}B exceeds limit ${agg_limit_bytes}B"
+            exit 1
+          fi
+          if (( $(printf '%.0f' "$nova_bytes") > nova_limit_bytes )); then
+            echo "::error::NovaV2 proof size ${nova_bytes}B exceeds limit ${nova_limit_bytes}B"
+            exit 1
+          fi
+
+          python - <<'PY'
+import os, sys, json
+payload = json.load(open(os.environ['FOLDING_PERF_OUTPUT']))
+agg = next(run for run in payload['runs'] if run['version'] == 'AggregatedV1')
+limit = float(os.environ['FOLDING_MAX_AGGREGATED_VERIFY_MS'])
+sys.exit(0 if agg['verify_per_proof_ms'] <= limit else 1)
+PY
+          agg_verify_status=$?
+
+          if (( agg_verify_status != 0 )); then
+            echo "::error::AggregatedV1 verify time exceeds ${FOLDING_MAX_AGGREGATED_VERIFY_MS}ms"
+            exit 1
+          fi
+
+          python - <<'PY'
+import os, sys, json
+payload = json.load(open(os.environ['FOLDING_PERF_OUTPUT']))
+nova = next(run for run in payload['runs'] if run['version'] == 'NovaV2')
+limit = float(os.environ['FOLDING_MAX_NOVA_VERIFY_MS'])
+sys.exit(0 if nova['verify_per_proof_ms'] <= limit else 1)
+PY
+          nova_verify_status=$?
+
+          if (( nova_verify_status != 0 )); then
+            echo "::error::NovaV2 verify time exceeds ${FOLDING_MAX_NOVA_VERIFY_MS}ms"
+            exit 1
+          fi
+
+      - name: Upload folding artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: folding-benchmarks
+          path: |
+            ${FOLDING_PERF_OUTPUT}
+            folding-perf-summary.tsv

--- a/docs/testing/folding_ci_gates.md
+++ b/docs/testing/folding_ci_gates.md
@@ -1,0 +1,24 @@
+# Folding-CI und Performance-Grenzwerte
+
+Die Folding-spezifischen Pipelines bestehen aus zwei Bausteinen:
+
+1. **CI-Tests** (`.github/workflows/folding.yml`)
+   - Führt `cargo test -p rpp-chain global_proof` und die Mock-Pipeline (`block_witness_flows_into_mock_fold_pipeline`) aus.
+   - Prüft die Storage-Sequenzen rund um `GlobalProof` (`cargo test -p rpp-chain bootstraps_fold_pipeline_from_cut_tip`).
+   - Erzwingt die Migration `AggregatedV1 → NovaV2` über den Test `nova_cutover_requires_bootstrap_version_shift`.
+2. **Performance-Gates** (`folding`-Job in `.github/workflows/perf.yml`)
+   - Nutzt `cargo run -p rpp-chain --bin folding_perf --release`, um eine Kette synthetischer GlobalProofs aufzubauen und `verify_global_proof` in Serie zu messen.
+   - Schreibt die Messwerte nach `folding-perf.json` und fasst sie in `folding-perf-summary.tsv` zusammen (Artefakte des Jobs).
+
+## Schwellenwerte
+
+Die Failure-Gates im Perf-Job schlagen fehl, wenn eine der folgenden Bedingungen verletzt wird:
+
+- **AggregatedV1**
+  - Maximale Proof-Größe: `FOLDING_MAX_AGGREGATED_KIB = 12` KiB
+  - Verifikationszeit pro Proof: `FOLDING_MAX_AGGREGATED_VERIFY_MS = 1.5` ms
+- **NovaV2**
+  - Maximale Proof-Größe: `FOLDING_MAX_NOVA_KIB = 16` KiB
+  - Verifikationszeit pro Proof: `FOLDING_MAX_NOVA_VERIFY_MS = 2.5` ms
+
+Die Kettenlänge (`FOLDING_PERF_CHAIN_LENGTH`, Standard `256`) und die synthetische Payload-Größe (`FOLDING_PERF_PROOF_BYTES`, Standard `4096`) können im Workflow überschrieben werden. Die Benchmarks laufen mit stabilem Toolchain-Stand und werden bei täglichen Perf-Runs als Artefakte veröffentlicht.

--- a/rpp/chain/src/bin/folding_perf.rs
+++ b/rpp/chain/src/bin/folding_perf.rs
@@ -1,0 +1,166 @@
+use std::env;
+use std::fs;
+use std::time::Instant;
+
+use rpp_chain::proof_backend::folding::{GlobalInstance, GlobalProof};
+use rpp_chain::proof_backend::ProofVersion;
+use rpp_chain::runtime::types::{verify_global_proof, Address, BlockHeader};
+use serde::Serialize;
+
+const DEFAULT_CHAIN_LENGTH: usize = 256;
+const DEFAULT_PROOF_BYTES: usize = 4096;
+const DEFAULT_OUTPUT: &str = "folding-perf.json";
+
+#[derive(Serialize)]
+struct FoldingRun {
+    version: String,
+    chain_length: usize,
+    avg_proof_bytes: f64,
+    max_proof_bytes: usize,
+    verify_total_ms: f64,
+    verify_per_proof_ms: f64,
+    success_rate: f64,
+}
+
+#[derive(Serialize)]
+struct FoldingReport {
+    chain_length: usize,
+    runs: Vec<FoldingRun>,
+}
+
+struct CutoverGuard(u64, u64);
+
+impl Drop for CutoverGuard {
+    fn drop(&mut self) {
+        ProofVersion::configure_cutover(self.0, self.1);
+    }
+}
+
+fn base_header(height: u64) -> BlockHeader {
+    let hex_pad = || "00".repeat(32);
+    BlockHeader::new(
+        height,
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        hex_pad(),
+        Address::from(hex_pad()),
+        "tier-0".into(),
+        0,
+    )
+}
+
+fn build_chain(
+    version: ProofVersion,
+    chain_length: usize,
+    proof_bytes: usize,
+) -> Result<Vec<(BlockHeader, GlobalProof)>, Box<dyn std::error::Error>> {
+    let vk_id = match version {
+        ProofVersion::AggregatedV1 => b"vk-aggregated".to_vec(),
+        ProofVersion::NovaV2 => b"vk-nova".to_vec(),
+    };
+
+    let mut chain = Vec::with_capacity(chain_length);
+
+    for height in 0..chain_length {
+        let state_commitment = vec![0x11; 32];
+        let pruning_commitment = vec![0x22; 32];
+        let instance =
+            GlobalInstance::from_state_and_rpp(height as u64, state_commitment, pruning_commitment);
+
+        let mut proof_payload = vec![0u8; proof_bytes + (height % 32)];
+        for (idx, byte) in proof_payload.iter_mut().enumerate() {
+            *byte = (idx % 251) as u8;
+        }
+
+        let proof = GlobalProof::new(instance.commitment.clone(), proof_payload, &vk_id, version)?;
+
+        let header =
+            base_header(height as u64).with_global_instance(&instance, Some(&proof.handle));
+        chain.push((header, proof));
+    }
+
+    Ok(chain)
+}
+
+fn measure_chain(
+    version: ProofVersion,
+    chain_length: usize,
+    proof_bytes: usize,
+) -> Result<FoldingRun, Box<dyn std::error::Error>> {
+    let (guard_height, guard_epoch) = ProofVersion::current_cutover();
+    let _guard = CutoverGuard(guard_height, guard_epoch);
+
+    match version {
+        ProofVersion::AggregatedV1 => ProofVersion::configure_cutover(u64::MAX - 1, u64::MAX - 1),
+        ProofVersion::NovaV2 => ProofVersion::configure_cutover(0, 0),
+    }
+
+    let chain = build_chain(version, chain_length, proof_bytes)?;
+
+    let start = Instant::now();
+    let mut successes = 0usize;
+    for (header, proof) in &chain {
+        if verify_global_proof(header, proof) {
+            successes += 1;
+        }
+    }
+    let elapsed = start.elapsed();
+
+    let total_proof_bytes: usize = chain.iter().map(|(_, proof)| proof.proof_bytes.len()).sum();
+    let max_proof_bytes = chain
+        .iter()
+        .map(|(_, proof)| proof.proof_bytes.len())
+        .max()
+        .unwrap_or(0);
+
+    let avg_proof_bytes = total_proof_bytes as f64 / chain.len() as f64;
+    let verify_total_ms = elapsed.as_secs_f64() * 1000.0;
+    let verify_per_proof_ms = verify_total_ms / chain.len() as f64;
+    let success_rate = successes as f64 / chain.len() as f64;
+
+    Ok(FoldingRun {
+        version: format!("{:?}", version),
+        chain_length: chain.len(),
+        avg_proof_bytes,
+        max_proof_bytes,
+        verify_total_ms,
+        verify_per_proof_ms,
+        success_rate,
+    })
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let chain_length = env::var("FOLDING_PERF_CHAIN_LENGTH")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CHAIN_LENGTH);
+    let proof_bytes = env::var("FOLDING_PERF_PROOF_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_PROOF_BYTES);
+    let output_path =
+        env::var("FOLDING_PERF_OUTPUT").unwrap_or_else(|_| DEFAULT_OUTPUT.to_string());
+
+    let aggregated = measure_chain(ProofVersion::AggregatedV1, chain_length, proof_bytes)?;
+    let nova = measure_chain(ProofVersion::NovaV2, chain_length, proof_bytes)?;
+
+    let report = FoldingReport {
+        chain_length,
+        runs: vec![aggregated, nova],
+    };
+
+    let json = serde_json::to_string_pretty(&report)?;
+    fs::write(&output_path, &json)?;
+    println!("Saved folding metrics to {output_path}\n{json}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a dedicated folding CI workflow that runs global proof unit tests, storage bootstrap checks, and the Nova migration guardrail
- extend the perf workflow with a folding benchmark job that enforces proof size and verification-time thresholds and uploads artifacts
- add a folding performance sampler binary and document the CI/perf gates and thresholds

## Testing
- cargo test -p prover-backend-interface proof_version -- --nocapture


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d31748c48326bffdaa0b3fe97856)