### PR TITLE
Add Nova folding demo script and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8001,11 +8001,14 @@ dependencies = [
  "blake2",
  "blake3",
  "hex",
+ "once_cell",
+ "opentelemetry 0.30.0",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -10161,6 +10164,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ slashing as described in the Malachite architecture plan.【F:rpp/consensus/src/
   verification steps, consult [docs/wallet_release_status.md](docs/wallet_release_status.md). For upcoming priorities beyond
   Phase 4 (hardware packaging, mobile UI, multisig automation, etc.) see the
   [wallet roadmap](docs/wallet_future_roadmap.md) so contributions line up with
-  the published backlog.【F:docs/wallet_future_roadmap.md†L1-L60】
+  the published backlog.【F:docs/wallet_future_roadmap.md†L1-L60】 The
+  Nova-Folding-Demo [playbook](docs/nova_folding_demo.md) plus
+  [`scripts/demo_nova_folding.sh`](scripts/demo_nova_folding.sh) bootstrap
+  `I_boot`/`π_boot`, falten drei Blöcke mit dem Mock-Backend und validieren die
+  Handles end-to-end, sodass Tester den neuen Flow reproduzieren können.【F:docs/nova_folding_demo.md†L1-L40】【F:scripts/demo_nova_folding.sh†L1-L15】
 
 ### Wallet feature flags and `[wallet.*]` scopes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,10 @@ The project is standardised on the Rust `1.79.0` toolchain. Each release must co
   installation, configuration with `config/node.toml`, rollout feature gates,
   telemetry options, and recovery procedures for VRF mismatches and missing
   snapshots.
+- Dokumentiert die [Nova-Folding-Demo](docs/nova_folding_demo.md) inklusive
+  Repro-Skript [`scripts/demo_nova_folding.sh`](scripts/demo_nova_folding.sh),
+  die `I_boot` + `π_boot` initialisiert, drei Mock-Folds durchläuft und den
+  Handle/Validation-Flow für Tester sichtbar macht.
 - Published the [Wallet Support Policy](docs/wallet_support_policy.md), which
   enumerates long-term wallet configurations, minimum system requirements,
   support tiers (LTS, maintenance, experimental), and explicit deprecation

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ frequently consulted references.
 ## Core guides
 
 - [`rpp-node` operator guide](rpp_node_operator_guide.md)
+- [Nova-Folding-Demo: I_boot/π_boot + Mock-Backend](nova_folding_demo.md)
 - [Wallet integration feature reference](wallet_integration.md)
 - [Configuration guide](configuration.md)
 - [Snapshot streaming protocol](network/snapshots.md)

--- a/docs/nova_folding_demo.md
+++ b/docs/nova_folding_demo.md
@@ -1,0 +1,53 @@
+# Nova-Folding-Demo (I_boot + π_boot)
+
+Dieses Playbook demonstriert den Nova-Folding-Flow mit dem Mock-Backend. Das
+Skript initialisiert eine deterministische Startinstanz (`I_boot` + `π_boot`),
+faltet drei Blöcke nacheinander und prüft nach jedem Schritt den Handle und die
+Verifikation. Alle Artefakte werden lokal erzeugt; es ist kein Backend-Cluster
+oder Snapshot-Download nötig.
+
+## Demo ausführen
+
+```sh
+RUST_LOG=info,folding.pipeline=debug scripts/demo_nova_folding.sh
+```
+
+Die Ausgabe zeigt die Initialisierung und drei Faltungs-Schritte mit Handle und
+Verifikation:
+
+```
+I_boot index=0 commitment=6810c0c1b37c876659ce28f813d55aa76d9a07bf0fd45cf92264ac7b5e379280 (state=73746174652d30, rpp=7270702d30)
+π_boot handle: commitment=a50bb56d71949189eeeac187507b19144ed552ea68f676e1fcef5c0a939e5ad0 vk_id=mock-folding-vk version=AggregatedV1
+2025-12-08T15:15:52.992447Z  INFO prover_backend_interface::folding: folding step completed previous_index=0 next_index=1 witness_block=1 fold_ms=0
+Folded block 1: I_1 commitment=688e3305d912d92cec7ff2a040fd4ed88872ddba4733a5637de8d153154ef3cc / proof=ea55025013d4a30593fca6675fd14691ed21b5a388e68e9bfb3bcb1deec1d5a0 / vk_id=mock-folding-vk / verified=true
+2025-12-08T15:15:52.992980Z  INFO prover_backend_interface::folding: folding step completed previous_index=2 next_index=3 witness_block=3 fold_ms=0
+Folded block 3: I_3 commitment=72ec192d73c1f15f1b0e4dde5eef20d33617d3baf9d14cc3c7027e58b7d83887 / proof=3d07c79bc064a7ee549bbcbe7d1a16afaa5525ab866bc4250823ee5a64ed2719 / vk_id=mock-folding-vk / verified=true
+```
+【5aa476†L1-L22】【5aa476†L23-L28】
+
+## Erwartete Artefakte
+
+- **Initialer Zustand:** `I_boot` entsteht deterministisch aus State- und
+  Pruning-Commitments über `from_state_and_rpp`, sodass Validatoren denselben
+  Combined-Hash berechnen können.【F:rpp/zk/backend-interface/src/folding.rs†L206-L279】
+- **Handle für π_boot:** `GlobalProof::new` erzeugt einen Handle mit
+  Proof-Commitment (Blake2s über die Proof-Bytes), VK-ID und `ProofVersion`.
+  Diese Werte erscheinen im Header und im Demo-Output, der Proof-Blob bleibt
+  lokal.【F:rpp/zk/backend-interface/src/folding.rs†L375-L423】
+- **Faltungs-Schritte:** Jeder `fold_pipeline_step` baut `I_i`/`π_i` mit dem
+  Mock-Backend neu auf; die Commitments und Handles sind deterministisch aus
+  Blocknummer und Witness abgeleitet, sodass die Demo-Ausgabe reproduzierbar
+  bleibt.【F:rpp/zk/backend-interface/src/folding.rs†L783-L827】
+
+## Fehlersuche und Validierung
+
+- `fold_pipeline_step` validiert Monotonie und Payload-Bounds und versieht
+  Ablehnungen mit `FOLD-STEP-*` Codes (`folding.pipeline`-Logs), z. B. bei
+  wiederverwendeten Blocknummern oder leeren Witness-Payloads.【F:rpp/zk/backend-interface/src/folding.rs†L520-L604】
+- Erfolgreiche Schritte protokollieren das neue Commitment, schreiben Telemetrie
+  und (optional) verifizieren den Proof direkt nach dem Fold. Die Demo ruft
+  zusätzlich `verify` des Mock-Backends auf und meldet `verified=true`, damit
+  Tester die vollständige Kette sehen.【F:rpp/zk/backend-interface/src/folding.rs†L608-L639】【F:rpp/zk/backend-interface/src/folding.rs†L822-L826】
+- Schlägt ein Schritt fehl, liefert der Prozess einen non-zero Exit-Code. Mit
+  `RUST_LOG=warn,folding.pipeline=debug` erscheinen die Fehlermeldungen inkl.
+  Reject-Code im Terminal, sodass Operatoren die Ursache sofort erkennen.

--- a/rpp/zk/backend-interface/Cargo.toml
+++ b/rpp/zk/backend-interface/Cargo.toml
@@ -20,7 +20,7 @@ bincode = "=1.3.3"
 blake2 = "=0.10.6"
 blake3 = "=1.8.2"
 hex = "=0.4.3"
-once_cell = "=1.19.0"
+once_cell = "=1.21.3"
 opentelemetry = { workspace = true }
 serde = { version = "=1.0.225", features = ["derive"] }
 serde_json = { workspace = true }
@@ -30,3 +30,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 serde = { version = "=1.0.225", features = ["derive"] }
 tempfile = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/rpp/zk/backend-interface/examples/nova_folding_demo.rs
+++ b/rpp/zk/backend-interface/examples/nova_folding_demo.rs
@@ -1,0 +1,56 @@
+use prover_backend_interface::folding::{
+    fold_pipeline_step, BlockWitness, FoldingBackend, GlobalInstance, GlobalProof,
+    MockFoldingBackend,
+};
+use prover_backend_interface::{BackendResult, ProofVersion};
+
+fn main() -> BackendResult<()> {
+    init_tracing();
+
+    let mut instance = GlobalInstance::from_state_and_rpp(0, b"state-0", b"rpp-0");
+    let mut proof = GlobalProof::new(
+        instance.commitment.clone(),
+        b"proof-0",
+        b"mock-folding-vk",
+        ProofVersion::AggregatedV1,
+    )?;
+
+    println!(
+        "I_boot index={} commitment={} (state={}, rpp={})",
+        instance.index,
+        hex::encode(&instance.commitment),
+        hex::encode(&instance.state_commitment),
+        hex::encode(&instance.rpp_commitment),
+    );
+    println!(
+        "π_boot handle: commitment={} vk_id={} version={:?}",
+        hex::encode(proof.handle.proof_commitment),
+        std::str::from_utf8(proof.handle.vk_id.as_slice()).unwrap_or("<utf8-error>"),
+        proof.handle.version,
+    );
+
+    for block in 1..=3 {
+        let witness = BlockWitness::new(block, format!("demo-witness-{block}").into_bytes());
+
+        let (next_instance, next_proof) =
+            fold_pipeline_step(instance, proof, witness, &MockFoldingBackend)?;
+        let verified = MockFoldingBackend.verify(&next_instance, &next_proof)?;
+
+        println!(
+            "Folded block {block}: I_{block} commitment={} / proof={} / vk_id={} / verified={}",
+            hex::encode(&next_instance.commitment),
+            hex::encode(next_proof.handle.proof_commitment),
+            std::str::from_utf8(next_proof.handle.vk_id.as_slice()).unwrap_or("<utf8-error>"),
+            verified,
+        );
+
+        instance = next_instance;
+        proof = next_proof;
+    }
+
+    Ok(())
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt().with_target(true).try_init();
+}

--- a/scripts/demo_nova_folding.sh
+++ b/scripts/demo_nova_folding.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproducible Nova folding demo that bootstraps I_boot/π_boot and folds three blocks
+# using the mock backend. The example prints the instance commitments, proof handle,
+# and verification status for every step so operators can trace the chain end-to-end.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export RUST_LOG="${RUST_LOG:-info,folding=info,folding.pipeline=debug}"
+
+cd "$ROOT_DIR"
+
+cargo run \
+  -p prover-backend-interface \
+  --example nova_folding_demo \
+  --features "prover-mock" \
+  "$@"


### PR DESCRIPTION
## Summary
- add a mock-backed Nova folding example and helper script that bootstraps I_boot/π_boot and folds three blocks
- document the demo flow, expected commitments/handles, and error signaling, linking it from the docs index and README/release notes
- align backend-interface dependencies for the example (tracing subscriber support and once_cell pin)

## Testing
- scripts/demo_nova_folding.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ea6af2b88326bae41b1d966b0816)